### PR TITLE
fix: 開発用バッジ削除・サイドバータイトル統一

### DIFF
--- a/src/components/collective-burial/ListView.tsx
+++ b/src/components/collective-burial/ListView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * 合祀一覧コンポーネント（API連携版）
+ * 合祀一覧コンポーネント
  * Prisma CollectiveBurialモデルに準拠
  */
 
@@ -121,9 +121,6 @@ export default function CollectiveBurialListView({
             </div>
             <div>
               <h2 className="font-mincho text-2xl font-semibold text-sumi tracking-wide">合祀管理</h2>
-              <span className="text-sm text-cha bg-cha-100 px-3 py-0.5 rounded-full mt-1 inline-block">
-                API連携版
-              </span>
             </div>
           </div>
           <div className="flex items-center space-x-3">

--- a/src/components/plot-detail-sidebar/PlotDetailSidebar.tsx
+++ b/src/components/plot-detail-sidebar/PlotDetailSidebar.tsx
@@ -37,29 +37,7 @@ export default function PlotDetailSidebar({
     };
     return roleLabels[role] || role;
   };
-  const getSidebarTitle = () => {
-    switch (currentView) {
-      case 'plot-details':
-      case 'edit':
-      case 'document-select':
-      case 'document-history':
-        return '区画詳細';
-      case 'collective-burial':
-        return '合祀管理メニュー';
-      case 'plot-availability':
-        return '区画残数管理メニュー';
-      case 'documents':
-        return '書類管理メニュー';
-      case 'staff-management':
-        return 'スタッフ管理メニュー';
-      case 'masters':
-        return 'マスタ管理メニュー';
-      case 'bulk-import':
-        return '一括登録メニュー';
-      default:
-        return '小峰霊園CRM';
-    }
-  };
+  const getSidebarTitle = () => '小峰霊園CRM';
 
   const isPlotContextView =
     (currentView === 'plot-details' || currentView === 'edit' || currentView === 'document-select' || currentView === 'document-history') &&


### PR DESCRIPTION
## Summary
- 合祀管理画面ヘッダーの「API連携版」バッジを削除（開発用表示の残留）
- サイドバー左上タイトルを全画面で「小峰霊園CRM」に統一（ビューごとの切替を廃止）

## Changes
- `src/components/collective-burial/ListView.tsx`: バッジspan要素を削除、コメントから「（API連携版）」を削除
- `src/components/plot-detail-sidebar/PlotDetailSidebar.tsx`: `getSidebarTitle()` のswitch文をワンライナーに簡略化

## Test plan
- [ ] 合祀管理画面を開き、ヘッダーに「API連携版」バッジが表示されないことを確認
- [ ] 各画面（台帳、合祀、区画残数、書類、スタッフ、マスタ、一括登録）に遷移し、サイドバータイトルが「小峰霊園CRM」であることを確認

Closes #17, Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)