### PR TITLE
feat: search filters, caching, profile page, bulk import UX

### DIFF
--- a/src/components/bulk-import/index.tsx
+++ b/src/components/bulk-import/index.tsx
@@ -212,6 +212,21 @@ async function downloadTemplate(type: ImportTab) {
     fgColor: { argb: 'FFE0E0E0' },
   };
 
+  // Add example data row with light yellow background
+  if (type === 'plots') {
+    sheet.addRow(['A-001', '1期', 3.6, 'サンプルデータ（この行は削除してください）']);
+  } else {
+    sheet.addRow(['山田太郎', 'taro@example.com', 'operator']);
+  }
+
+  const exampleRow = sheet.getRow(2);
+  exampleRow.fill = {
+    type: 'pattern',
+    pattern: 'solid',
+    fgColor: { argb: 'FFFFF9C4' },
+  };
+  exampleRow.font = { color: { argb: 'FF999999' } };
+
   const buffer = await workbook.xlsx.writeBuffer();
   saveAs(
     new Blob([buffer]),
@@ -251,6 +266,7 @@ export default function BulkImportPage() {
 // ===== タブごとのパネル =====
 
 function BulkImportPanel({ type }: { type: ImportTab }) {
+  const [showFormatInfo, setShowFormatInfo] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [plotRows, setPlotRows] = useState<PlotRow[]>([]);
   const [staffRows, setStaffRows] = useState<StaffRow[]>([]);
@@ -430,6 +446,122 @@ function BulkImportPanel({ type }: { type: ImportTab }) {
         </CardContent>
       </Card>
 
+      {/* フォーマット仕様 */}
+      <Card>
+        <CardContent className="pt-6">
+          <button
+            type="button"
+            onClick={() => setShowFormatInfo((prev) => !prev)}
+            className="flex items-center gap-2 text-sm font-medium text-matsu hover:text-matsu/80 transition-colors"
+          >
+            <svg
+              className={`w-4 h-4 transition-transform ${showFormatInfo ? 'rotate-90' : ''}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+            {showFormatInfo ? 'フォーマット仕様を非表示' : 'フォーマット仕様を表示'}
+          </button>
+
+          {showFormatInfo && (
+            <div className="mt-4 space-y-4">
+              {type === 'plots' ? (
+                <>
+                  <div className="overflow-x-auto border border-gin rounded-lg">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="bg-kinari border-b border-gin">
+                          <th className="px-4 py-2 text-left font-semibold text-sumi">フィールド</th>
+                          <th className="px-4 py-2 text-center font-semibold text-sumi">必須</th>
+                          <th className="px-4 py-2 text-left font-semibold text-sumi">説明</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr className="border-b border-gin">
+                          <td className="px-4 py-2 font-medium">区画番号</td>
+                          <td className="px-4 py-2 text-center text-beni">○</td>
+                          <td className="px-4 py-2 text-hai">最大50文字。バッチ内・既存データと重複不可</td>
+                        </tr>
+                        <tr className="border-b border-gin">
+                          <td className="px-4 py-2 font-medium">区域名</td>
+                          <td className="px-4 py-2 text-center text-beni">○</td>
+                          <td className="px-4 py-2 text-hai">最大100文字</td>
+                        </tr>
+                        <tr className="border-b border-gin">
+                          <td className="px-4 py-2 font-medium">面積(㎡)</td>
+                          <td className="px-4 py-2 text-center text-hai">-</td>
+                          <td className="px-4 py-2 text-hai">正の数値。未入力時は3.6㎡がデフォルト</td>
+                        </tr>
+                        <tr>
+                          <td className="px-4 py-2 font-medium">備考</td>
+                          <td className="px-4 py-2 text-center text-hai">-</td>
+                          <td className="px-4 py-2 text-hai">最大1000文字</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                  <div className="text-sm text-hai space-y-1">
+                    <p className="font-medium text-sumi">注意事項:</p>
+                    <ul className="list-disc list-inside space-y-0.5 ml-1">
+                      <li>1回の登録で最大500件まで対応</li>
+                      <li>対応ファイル形式: .xlsx / .csv</li>
+                      <li>1行目はヘッダー行として自動スキップされます</li>
+                      <li>区画番号が既存データと重複する場合、その行はエラーになります</li>
+                      <li>1件でもエラーがあると全件登録されません（全件ロールバック）</li>
+                      <li>空行は自動的にスキップされます</li>
+                    </ul>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="overflow-x-auto border border-gin rounded-lg">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="bg-kinari border-b border-gin">
+                          <th className="px-4 py-2 text-left font-semibold text-sumi">フィールド</th>
+                          <th className="px-4 py-2 text-center font-semibold text-sumi">必須</th>
+                          <th className="px-4 py-2 text-left font-semibold text-sumi">説明</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr className="border-b border-gin">
+                          <td className="px-4 py-2 font-medium">名前</td>
+                          <td className="px-4 py-2 text-center text-beni">○</td>
+                          <td className="px-4 py-2 text-hai">スタッフ名</td>
+                        </tr>
+                        <tr className="border-b border-gin">
+                          <td className="px-4 py-2 font-medium">メールアドレス</td>
+                          <td className="px-4 py-2 text-center text-beni">○</td>
+                          <td className="px-4 py-2 text-hai">有効なメールアドレス形式</td>
+                        </tr>
+                        <tr>
+                          <td className="px-4 py-2 font-medium">ロール</td>
+                          <td className="px-4 py-2 text-center text-beni">○</td>
+                          <td className="px-4 py-2 text-hai">viewer / operator / manager / admin のいずれか</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                  <div className="text-sm text-hai space-y-1">
+                    <p className="font-medium text-sumi">注意事項:</p>
+                    <ul className="list-disc list-inside space-y-0.5 ml-1">
+                      <li>1回の登録で最大100件まで対応</li>
+                      <li>対応ファイル形式: .xlsx / .csv</li>
+                      <li>1行目はヘッダー行として自動スキップされます</li>
+                      <li>1件でもエラーがあると全件登録されません（全件ロールバック）</li>
+                      <li>空行は自動的にスキップされます</li>
+                    </ul>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       {/* ファイルアップロード */}
       {!submitResult && (
         <Card>
@@ -490,6 +622,9 @@ function BulkImportPanel({ type }: { type: ImportTab }) {
                 </div>
               )}
             </div>
+            <p className="mt-3 text-xs text-hai text-center">
+              最大{type === 'plots' ? '500' : '100'}件まで一括登録可能
+            </p>
           </CardContent>
         </Card>
       )}

--- a/src/components/plot-management.tsx
+++ b/src/components/plot-management.tsx
@@ -17,6 +17,7 @@ import StaffManagement from '@/components/staff-management';
 import MastersManagement from '@/components/masters-management';
 import { DocumentManagement } from '@/components/document-management';
 import BulkImportPage from '@/components/bulk-import';
+import ProfilePage from '@/components/profile-page';
 import { usePlotDetail } from '@/hooks/usePlots';
 
 import {
@@ -147,7 +148,7 @@ export default function PlotManagement({ initialView = 'registry' }: PlotManagem
 
     setCurrentView(view);
     // メインメニュー項目の場合は選択をクリア
-    if (['registry', 'collective-burial', 'plot-availability', 'documents', 'staff-management', 'masters', 'bulk-import'].includes(view)) {
+    if (['registry', 'collective-burial', 'plot-availability', 'documents', 'staff-management', 'masters', 'bulk-import', 'profile'].includes(view)) {
       setSelectedPlotId(null);
       setSelectedPlotName('');
       setSelectedPlotCode('');
@@ -245,6 +246,8 @@ export default function PlotManagement({ initialView = 'registry' }: PlotManagem
           <div className="flex-1 overflow-auto">
             <BulkImportPage />
           </div>
+        ) : currentView === 'profile' ? (
+          <ProfilePage onBack={() => setCurrentView('registry')} />
         ) : null}
 
         {/* 書類履歴（区画コンテキスト） */}

--- a/src/components/plot-registry.tsx
+++ b/src/components/plot-registry.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { PlotListItem, PaymentStatus } from '@komine/types';
+import { PlotListItem, PaymentStatus, PhysicalPlotStatus } from '@komine/types';
 import {
   getPlots,
   getPlotDisplayStatus,
@@ -75,6 +75,12 @@ const PAYMENT_STATUS_LABELS: Record<PaymentStatus, string> = {
   [PaymentStatus.Cancelled]: 'キャンセル',
 };
 
+const PLOT_STATUS_LABELS: Record<PhysicalPlotStatus, string> = {
+  [PhysicalPlotStatus.Available]: '利用可能',
+  [PhysicalPlotStatus.PartiallySold]: '一部販売済',
+  [PhysicalPlotStatus.SoldOut]: '完売',
+};
+
 // ===== ヘルパー =====
 
 function formatContractDate(dateStr: string | null | undefined): string {
@@ -111,6 +117,11 @@ export default function PlotRegistry({
   const [sortKey, setSortKey] = useState<SortKey>('plotNumber');
   const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
 
+  // フィルタ
+  const [filterStatus, setFilterStatus] = useState<PhysicalPlotStatus | undefined>(undefined);
+  const [filterPaymentStatus, setFilterPaymentStatus] = useState<PaymentStatus | undefined>(undefined);
+  const [filterAreaName, setFilterAreaName] = useState('');
+
   // サーバーサイドページネーション
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(50);
@@ -137,6 +148,17 @@ export default function PlotRegistry({
         params.nameKanaPrefix = tabDef.kataKey;
       }
 
+      // フィルタ
+      if (filterStatus) {
+        params.status = filterStatus;
+      }
+      if (filterPaymentStatus) {
+        params.paymentStatus = filterPaymentStatus;
+      }
+      if (filterAreaName.trim()) {
+        params.areaName = filterAreaName.trim();
+      }
+
       // サーバー対応ソートキーのみ送信
       const serverSortKey = SERVER_SORT_MAP[sortKey];
       if (serverSortKey) {
@@ -157,7 +179,7 @@ export default function PlotRegistry({
     } finally {
       setIsLoading(false);
     }
-  }, [currentPage, itemsPerPage, searchQuery, activeTab, sortKey, sortOrder]);
+  }, [currentPage, itemsPerPage, searchQuery, activeTab, sortKey, sortOrder, filterStatus, filterPaymentStatus, filterAreaName]);
 
   useEffect(() => {
     fetchPlots();
@@ -190,6 +212,31 @@ export default function PlotRegistry({
 
   const handleTabChange = (tabKey: string) => {
     setActiveTab(tabKey);
+    setCurrentPage(1);
+  };
+
+  // フィルタ変更ハンドラ
+  const hasActiveFilters = filterStatus !== undefined || filterPaymentStatus !== undefined || filterAreaName.trim() !== '';
+
+  const handleFilterStatusChange = (value: string) => {
+    setFilterStatus(value === 'all' ? undefined : value as PhysicalPlotStatus);
+    setCurrentPage(1);
+  };
+
+  const handleFilterPaymentStatusChange = (value: string) => {
+    setFilterPaymentStatus(value === 'all' ? undefined : value as PaymentStatus);
+    setCurrentPage(1);
+  };
+
+  const handleFilterAreaNameChange = (value: string) => {
+    setFilterAreaName(value);
+    setCurrentPage(1);
+  };
+
+  const handleClearFilters = () => {
+    setFilterStatus(undefined);
+    setFilterPaymentStatus(undefined);
+    setFilterAreaName('');
     setCurrentPage(1);
   };
 
@@ -267,7 +314,7 @@ export default function PlotRegistry({
         <div className="flex-1 max-w-md">
           <Input
             type="text"
-            placeholder="氏名・フリガナ・区画番号・電話番号で検索..."
+            placeholder="氏名・フリガナ・区画番号・電話番号・住所で検索..."
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             onKeyPress={handleKeyPress}
@@ -304,6 +351,58 @@ export default function PlotRegistry({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
             </svg>
             新規登録
+          </Button>
+        )}
+      </div>
+
+      {/* フィルタ行 */}
+      <div className="mb-4 flex items-center gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-hai whitespace-nowrap">区画ステータス:</span>
+          <Select value={filterStatus || 'all'} onValueChange={handleFilterStatusChange}>
+            <SelectTrigger className="w-32 h-9 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全て</SelectItem>
+              {Object.entries(PLOT_STATUS_LABELS).map(([value, label]) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-hai whitespace-nowrap">入金ステータス:</span>
+          <Select value={filterPaymentStatus || 'all'} onValueChange={handleFilterPaymentStatusChange}>
+            <SelectTrigger className="w-32 h-9 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全て</SelectItem>
+              {Object.entries(PAYMENT_STATUS_LABELS).map(([value, label]) => (
+                <SelectItem key={value} value={value}>{label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-hai whitespace-nowrap">エリア:</span>
+          <Input
+            type="text"
+            placeholder="エリア名"
+            value={filterAreaName}
+            onChange={(e) => handleFilterAreaNameChange(e.target.value)}
+            className="w-28 h-9 text-sm"
+          />
+        </div>
+        {hasActiveFilters && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleClearFilters}
+            className="h-9 text-sm text-beni border-beni hover:bg-beni-50"
+          >
+            フィルタクリア
           </Button>
         )}
       </div>

--- a/src/components/profile-page.tsx
+++ b/src/components/profile-page.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useAuth } from '@/contexts/auth-context';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const ROLE_LABELS: Record<string, string> = {
+  viewer: '閲覧者',
+  operator: 'オペレーター',
+  manager: 'マネージャー',
+  admin: '管理者',
+};
+
+interface ProfilePageProps {
+  onBack: () => void;
+}
+
+export default function ProfilePage({ onBack }: ProfilePageProps) {
+  const { user, changePassword, isLoading } = useAuth();
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setValidationError(null);
+
+    if (!currentPassword) {
+      setValidationError('現在のパスワードを入力してください');
+      return;
+    }
+
+    if (!newPassword) {
+      setValidationError('新しいパスワードを入力してください');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setValidationError('新しいパスワードは8文字以上で入力してください');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setValidationError('新しいパスワードが一致しません');
+      return;
+    }
+
+    const result = await changePassword({ currentPassword, newPassword });
+
+    if (result.success) {
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    }
+  };
+
+  return (
+    <div className="flex-1 p-6 overflow-auto">
+      <div className="max-w-2xl mx-auto space-y-6">
+        {/* 戻るボタン */}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onBack}
+          className="mb-2"
+        >
+          <svg className="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          戻る
+        </Button>
+
+        <h1 className="text-2xl font-semibold text-sumi">アカウント設定</h1>
+
+        {/* プロフィール情報 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">プロフィール情報</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <Label className="text-hai text-sm">名前</Label>
+                <p className="mt-1 text-sumi font-medium">{user?.name || '-'}</p>
+              </div>
+              <div>
+                <Label className="text-hai text-sm">メールアドレス</Label>
+                <p className="mt-1 text-sumi font-medium">{user?.email || '-'}</p>
+              </div>
+              <div>
+                <Label className="text-hai text-sm">権限</Label>
+                <p className="mt-1">
+                  <span className="inline-block px-2 py-0.5 text-sm rounded bg-matsu-50 text-matsu-dark border border-matsu-100">
+                    {user?.role ? ROLE_LABELS[user.role] || user.role : '-'}
+                  </span>
+                </p>
+              </div>
+              <div>
+                <Label className="text-hai text-sm">アカウント状態</Label>
+                <p className="mt-1">
+                  {user?.isActive !== undefined ? (
+                    <span
+                      className={`inline-block px-2 py-0.5 text-sm rounded border ${user.isActive
+                          ? 'bg-green-50 text-green-700 border-green-200'
+                          : 'bg-red-50 text-red-700 border-red-200'
+                        }`}
+                    >
+                      {user.isActive ? '有効' : '無効'}
+                    </span>
+                  ) : (
+                    '-'
+                  )}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* パスワード変更 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">パスワード変更</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <Label htmlFor="current-password">現在のパスワード</Label>
+                <Input
+                  id="current-password"
+                  type="password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  className="mt-1"
+                  autoComplete="current-password"
+                />
+              </div>
+              <div>
+                <Label htmlFor="new-password">新しいパスワード</Label>
+                <Input
+                  id="new-password"
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  className="mt-1"
+                  autoComplete="new-password"
+                />
+                <p className="text-xs text-hai mt-1">8文字以上で入力してください</p>
+              </div>
+              <div>
+                <Label htmlFor="confirm-password">新しいパスワード（確認）</Label>
+                <Input
+                  id="confirm-password"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  className="mt-1"
+                  autoComplete="new-password"
+                />
+              </div>
+
+              {validationError && (
+                <p className="text-sm text-red-600">{validationError}</p>
+              )}
+
+              <Button type="submit" disabled={isLoading} className="mt-2">
+                {isLoading ? 'パスワードを変更中...' : 'パスワードを変更'}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/usePlots.ts
+++ b/src/hooks/usePlots.ts
@@ -219,6 +219,33 @@ export function usePlots(options: UsePlotsOptions = {}): UsePlotsReturn {
   };
 }
 
+// ===== 詳細キャッシュ =====
+
+const DETAIL_CACHE_TTL = 2 * 60 * 1000; // 2分
+const detailCache = new Map<string, { data: PlotDetailResponse; timestamp: number }>();
+
+function getCachedDetail(id: string): PlotDetailResponse | null {
+  const cached = detailCache.get(id);
+  if (!cached) return null;
+  if (Date.now() - cached.timestamp > DETAIL_CACHE_TTL) {
+    detailCache.delete(id);
+    return null;
+  }
+  return cached.data;
+}
+
+function saveCachedDetail(id: string, data: PlotDetailResponse): void {
+  detailCache.set(id, { data, timestamp: Date.now() });
+}
+
+export function clearDetailCache(id?: string): void {
+  if (id) {
+    detailCache.delete(id);
+  } else {
+    detailCache.clear();
+  }
+}
+
 // ===== usePlotDetail: 区画詳細フック =====
 
 interface UsePlotDetailReturn {
@@ -229,9 +256,12 @@ interface UsePlotDetailReturn {
 }
 
 export function usePlotDetail(id: string | null): UsePlotDetailReturn {
-  const [plot, setPlot] = useState<PlotDetailResponse | null>(null);
+  // キャッシュから初期値を取得（stale-while-revalidate）
+  const cachedData = id ? getCachedDetail(id) : null;
+  const [plot, setPlot] = useState<PlotDetailResponse | null>(cachedData);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const restoredFromDetailCache = useRef(cachedData !== null);
 
   const fetchPlot = useCallback(async () => {
     if (!id) {
@@ -239,7 +269,11 @@ export function usePlotDetail(id: string | null): UsePlotDetailReturn {
       return;
     }
 
-    setIsLoading(true);
+    // キャッシュから復元済みならローディング非表示（バックグラウンド更新）
+    if (!restoredFromDetailCache.current) {
+      setIsLoading(true);
+    }
+    restoredFromDetailCache.current = false;
     setError(null);
 
     try {
@@ -247,6 +281,7 @@ export function usePlotDetail(id: string | null): UsePlotDetailReturn {
 
       if (response.success) {
         setPlot(response.data);
+        saveCachedDetail(id, response.data);
       } else {
         setError(response.error.message);
         setPlot(null);
@@ -256,6 +291,21 @@ export function usePlotDetail(id: string | null): UsePlotDetailReturn {
       setPlot(null);
     } finally {
       setIsLoading(false);
+    }
+  }, [id]);
+
+  // IDが変わったらキャッシュから即座に表示
+  useEffect(() => {
+    if (id) {
+      const cached = getCachedDetail(id);
+      if (cached) {
+        setPlot(cached);
+        restoredFromDetailCache.current = true;
+      } else {
+        restoredFromDetailCache.current = false;
+      }
+    } else {
+      setPlot(null);
     }
   }, [id]);
 
@@ -293,6 +343,8 @@ export function usePlotMutations(): UsePlotMutationsReturn {
       const response = await createPlot(request);
 
       if (response.success) {
+        // リストキャッシュをクリア（新規追加で一覧が変わるため）
+        sessionStorage.removeItem(CACHE_KEY);
         return response.data;
       } else {
         setError(response.error.message);
@@ -314,6 +366,9 @@ export function usePlotMutations(): UsePlotMutationsReturn {
       const response = await updatePlot(id, request);
 
       if (response.success) {
+        // 詳細キャッシュとリストキャッシュをクリア
+        clearDetailCache(id);
+        sessionStorage.removeItem(CACHE_KEY);
         return response.data;
       } else {
         setError(response.error.message);
@@ -335,6 +390,9 @@ export function usePlotMutations(): UsePlotMutationsReturn {
       const response = await deletePlot(id);
 
       if (response.success) {
+        // 詳細キャッシュとリストキャッシュをクリア
+        clearDetailCache(id);
+        sessionStorage.removeItem(CACHE_KEY);
         return true;
       } else {
         setError(response.error.message);

--- a/src/lib/api/plots.ts
+++ b/src/lib/api/plots.ts
@@ -369,7 +369,7 @@ export async function getPlots(
     page: params.page,
     limit: params.limit,
     search: params.search,
-    areaName: params.areaName,
+    cemeteryType: params.areaName,
     status: params.status,
     paymentStatus: params.paymentStatus,
     contractStatus: params.contractStatus,

--- a/src/types/plot-detail.ts
+++ b/src/types/plot-detail.ts
@@ -11,7 +11,8 @@ export type ViewType =
   | 'documents'
   | 'document-select'
   | 'document-history'
-  | 'bulk-import';
+  | 'bulk-import'
+  | 'profile';
 
 // 対応履歴の型定義
 export interface HistoryEntry {
@@ -49,6 +50,7 @@ export const MENU_ITEMS: MenuItemConfig[] = [
   { label: 'スタッフ管理', view: 'staff-management', requiredRoles: ['manager', 'admin'] },
   { label: 'マスタ管理', view: 'masters', requiredRoles: ['admin'] },
   { label: '一括登録', view: 'bulk-import', requiredRoles: ['manager', 'admin'] },
+  { label: 'アカウント設定', view: 'profile', requiredRoles: ['viewer', 'operator', 'manager', 'admin'] },
 ];
 
 export type MenuItem = string;


### PR DESCRIPTION
## Summary
- **#18 検索フィルタ**: 区画ステータス・入金ステータス・エリアのドロップダウンフィルタ追加、`areaName`→`cemeteryType`パラメータ名修正、検索プレースホルダーに「住所」追加
- **#19 キャッシュ改善**: `usePlotDetail`にインメモリキャッシュ（2分TTL、stale-while-revalidate）追加、ミューテーション後のキャッシュ自動クリア
- **#20 一括登録UX**: 折りたたみ式フォーマット仕様テーブル、テンプレートにサンプルデータ行追加、最大件数表示
- **#23 プロフィール画面**: アカウント設定ページ新規作成（プロフィール表示＋パスワード変更フォーム）

## Test plan
- [x] TypeScriptエラーなし（変更ファイルのみ）
- [ ] 検索フィルタ動作確認（ステータス・入金・エリア絞り込み）
- [ ] キャッシュ動作確認（区画詳細の再表示でAPI呼び出し削減）
- [ ] 一括登録画面のフォーマット仕様表示・テンプレートダウンロード確認
- [ ] プロフィール画面表示・パスワード変更動作確認

Closes #18, Closes #19, Closes #23
Partially addresses #20 (format info improvement only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)