### PR TITLE
fix: 区画編集フォームのバリデーション・UX改善

### DIFF
--- a/src/components/plot-form/BurialInfoTab.tsx
+++ b/src/components/plot-form/BurialInfoTab.tsx
@@ -359,7 +359,7 @@ export function BurialInfoTab({
                 min={1}
                 max={100}
                 placeholder="例: 10"
-                {...register('collectiveBurial.burialCapacity')}
+                {...register('collectiveBurial.burialCapacity', { valueAsNumber: true })}
                 className={errors.collectiveBurial?.burialCapacity ? 'border-beni' : ''}
               />
               <p className="text-xs text-hai mt-1">この区画に埋葬できる最大人数</p>
@@ -380,7 +380,7 @@ export function BurialInfoTab({
                 min={1}
                 max={100}
                 placeholder="例: 33"
-                {...register('collectiveBurial.validityPeriodYears')}
+                {...register('collectiveBurial.validityPeriodYears', { valueAsNumber: true })}
                 className={errors.collectiveBurial?.validityPeriodYears ? 'border-beni' : ''}
               />
               <p className="text-xs text-hai mt-1">埋葬上限到達後の合祀管理期間</p>
@@ -398,7 +398,7 @@ export function BurialInfoTab({
                 type="number"
                 min={0}
                 placeholder="例: 50000"
-                {...register('collectiveBurial.billingAmount')}
+                {...register('collectiveBurial.billingAmount', { valueAsNumber: true })}
                 className={errors.collectiveBurial?.billingAmount ? 'border-beni' : ''}
               />
               {errors.collectiveBurial?.billingAmount && (

--- a/src/components/plot-form/index.tsx
+++ b/src/components/plot-form/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useForm, useFieldArray, Resolver } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
@@ -12,6 +12,7 @@ import type { PlotFormData } from '@/lib/validations/plot-form';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useMasters } from '@/hooks';
+import { showWarning } from '@/lib/toast';
 
 import type { PlotFormProps, MasterData } from './types';
 import { BasicInfoTab } from './BasicInfoTab';
@@ -46,12 +47,20 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     setValue,
     watch,
     control,
+    reset,
   } = useForm<PlotFormData>({
     resolver: zodResolver(plotFormSchema) as Resolver<PlotFormData>,
     defaultValues: plotDetail
       ? plotDetailToFormData(plotDetail)
       : defaultPlotFormData,
   });
+
+  // plotDetail が後から到着した場合にフォームを更新
+  useEffect(() => {
+    if (plotDetail) {
+      reset(plotDetailToFormData(plotDetail));
+    }
+  }, [plotDetail, reset]);
 
   const {
     fields: familyContactFields,
@@ -71,8 +80,8 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     onSave(data);
   };
 
-  const onError = (_validationErrors: Record<string, unknown>) => {
-    // Validation errors are displayed inline via the form UI
+  const onError = () => {
+    showWarning('入力エラーがあります', 'エラー箇所を確認してください');
   };
 
   const tabBaseProps = {
@@ -84,18 +93,206 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     masterData,
   };
 
-  // エラーメッセージを整形
-  const errorMessages = Object.entries(errors)
-    .map(([key, value]) => {
-      if (typeof value === 'object' && value && 'message' in value && value.message) {
-        return `${key}: ${value.message}`;
+  // タブ定義: フィールドグループ → タブ名の対応
+  const tabConfig = {
+    'basic-info': {
+      label: '区画・契約情報',
+      sections: ['physicalPlot', 'contractPlot', 'saleContract', 'customer', 'usageFee', 'managementFee', 'gravestoneInfo'],
+    },
+    'work-billing': {
+      label: '勤務先・請求',
+      sections: ['workInfo', 'billingInfo'],
+    },
+    'contacts': {
+      label: '連絡先/家族',
+      sections: ['familyContacts'],
+    },
+    'burial-info': {
+      label: '埋葬情報',
+      sections: ['buriedPersons', 'collectiveBurial'],
+    },
+  } satisfies Record<string, { label: string; sections: string[] }>;
+
+  // フィールドパス → 日本語ラベルのマッピング
+  const fieldLabels: Record<string, string> = {
+    // 物理区画
+    'physicalPlot.plotNumber': '区画番号',
+    'physicalPlot.areaName': '区画（期）',
+    'physicalPlot.areaSqm': '面積',
+    'physicalPlot.notes': '備考',
+    // 契約区画
+    'contractPlot.contractAreaSqm': '契約面積',
+    'contractPlot.locationDescription': '区画位置詳細',
+    // 販売契約
+    'saleContract.contractDate': '契約日',
+    'saleContract.price': '金額',
+    'saleContract.paymentStatus': '支払状態',
+    'saleContract.reservationDate': '予約日',
+    'saleContract.acceptanceNumber': '受付番号',
+    'saleContract.acceptanceDate': '受付日',
+    'saleContract.permitDate': '許可日',
+    'saleContract.permitNumber': '許可番号',
+    'saleContract.startDate': '使用開始日',
+    'saleContract.staffInCharge': '担当者',
+    'saleContract.agentName': '取扱',
+    'saleContract.notes': '備考',
+    // 契約者
+    'customer.name': '氏名',
+    'customer.nameKana': '氏名カナ',
+    'customer.birthDate': '生年月日',
+    'customer.gender': '性別',
+    'customer.postalCode': '郵便番号',
+    'customer.address': '住所',
+    'customer.addressLine2': '住所2',
+    'customer.registeredAddress': '本籍地',
+    'customer.phoneNumber': '電話番号',
+    'customer.faxNumber': 'FAX',
+    'customer.email': 'メール',
+    'customer.role': '役割',
+    'customer.notes': '備考',
+    // 勤務先
+    'workInfo.companyName': '勤務先名称',
+    'workInfo.companyNameKana': '勤務先名称カナ',
+    'workInfo.workPostalCode': '勤務先郵便番号',
+    'workInfo.workPhoneNumber': '勤務先電話番号',
+    'workInfo.workAddress': '勤務先住所',
+    'workInfo.dmSetting': 'DM送信設定',
+    'workInfo.addressType': '宛先区分',
+    'workInfo.notes': '備考',
+    // 請求情報
+    'billingInfo.billingType': '請求区分',
+    'billingInfo.bankName': '金融機関名',
+    'billingInfo.branchName': '支店名',
+    'billingInfo.accountType': '口座種別',
+    'billingInfo.accountNumber': '口座番号',
+    'billingInfo.accountHolder': '口座名義',
+    // 使用料
+    'usageFee.calculationType': '計算区分',
+    'usageFee.taxType': '税区分',
+    'usageFee.billingType': '請求区分',
+    'usageFee.billingYears': '請求年数',
+    'usageFee.usageFee': '使用料',
+    'usageFee.area': '面積',
+    'usageFee.unitPrice': '単価',
+    'usageFee.paymentMethod': '支払方法',
+    // 管理料
+    'managementFee.calculationType': '計算区分',
+    'managementFee.taxType': '税区分',
+    'managementFee.billingType': '請求区分',
+    'managementFee.billingYears': '請求年数',
+    'managementFee.area': '面積',
+    'managementFee.billingMonth': '請求月',
+    'managementFee.managementFee': '管理料',
+    'managementFee.unitPrice': '単価',
+    'managementFee.lastBillingMonth': '最終請求月',
+    'managementFee.paymentMethod': '支払方法',
+    // 墓石情報
+    'gravestoneInfo.gravestoneBase': '墓石台',
+    'gravestoneInfo.enclosurePosition': '外柵位置',
+    'gravestoneInfo.gravestoneDealer': '石材店',
+    'gravestoneInfo.gravestoneType': '墓石種類',
+    'gravestoneInfo.surroundingArea': '周辺面積',
+    'gravestoneInfo.gravestoneCost': '墓石代',
+    'gravestoneInfo.establishmentDeadline': '建立期限',
+    'gravestoneInfo.establishmentDate': '建立日',
+    // 家族連絡先（配列内フィールド）
+    'name': '氏名',
+    'nameKana': '読み（かな）',
+    'relationship': '続柄',
+    'birthDate': '生年月日',
+    'postalCode': '郵便番号',
+    'address': '住所',
+    'phoneNumber': '電話番号',
+    'phoneNumber2': '電話番号2',
+    'faxNumber': 'FAX',
+    'email': 'メール',
+    'registeredAddress': '本籍地',
+    'mailingType': '宛先区分',
+    'workCompanyName': '勤務先名称',
+    'workCompanyNameKana': '勤務先かな',
+    'workAddress': '勤務先住所',
+    'workPhoneNumber': '勤務先電話番号',
+    'contactMethod': '連絡区分',
+    'notes': '備考',
+    // 埋葬者（配列内フィールド）
+    'deathDate': '命日',
+    'age': '享年',
+    'gender': '性別',
+    'burialDate': '埋葬日',
+    'posthumousName': '戒名',
+    'reportDate': '届出日',
+    'religion': '宗派',
+    // 合祀設定
+    'collectiveBurial.burialCapacity': '埋葬上限数',
+    'collectiveBurial.validityPeriodYears': '有効期間（年）',
+    'collectiveBurial.billingAmount': '請求金額',
+    'collectiveBurial.notes': '備考',
+  };
+
+  // 配列フィールドのセクション名
+  const arraySectionLabels: Record<string, string> = {
+    familyContacts: '家族連絡先',
+    buriedPersons: '埋葬者',
+  };
+
+  // フィールドパスからタブ名を取得
+  const getTabLabel = (path: string): string => {
+    const topKey = path.split('.')[0];
+    for (const tab of Object.values(tabConfig)) {
+      if (tab.sections.includes(topKey)) return tab.label;
+    }
+    return '';
+  };
+
+  // フィールドパスから日本語ラベルを取得
+  const getFieldLabel = (path: string): string => {
+    // 完全一致
+    if (fieldLabels[path]) return fieldLabels[path];
+
+    // 配列パターン: familyContacts.0.name → 家族連絡先[1] 氏名
+    const arrayMatch = path.match(/^(\w+)\.(\d+)\.(.+)$/);
+    if (arrayMatch) {
+      const [, section, index, field] = arrayMatch;
+      const sectionLabel = arraySectionLabels[section] || section;
+      const fieldLabel = fieldLabels[field] || field;
+      return `${sectionLabel}[${Number(index) + 1}] ${fieldLabel}`;
+    }
+
+    return path;
+  };
+
+  // エラーメッセージを整形（ネストされたエラーも再帰的に収集）
+  const collectErrors = (obj: Record<string, unknown>, prefix = ''): string[] => {
+    const messages: string[] = [];
+    for (const [key, value] of Object.entries(obj)) {
+      if (value && typeof value === 'object') {
+        if ('message' in value && typeof value.message === 'string') {
+          const path = `${prefix}${key}`;
+          const tabLabel = getTabLabel(path);
+          const fieldLabel = getFieldLabel(path);
+          const label = tabLabel ? `[${tabLabel}] ${fieldLabel}` : fieldLabel;
+          messages.push(`${label}: ${value.message}`);
+        } else {
+          messages.push(...collectErrors(value as Record<string, unknown>, `${prefix}${key}.`));
+        }
       }
-      return null;
-    })
-    .filter(Boolean);
+    }
+    return messages;
+  };
+  const errorMessages = collectErrors(errors as Record<string, unknown>);
+
+  // エラーがあるタブを判定
+  const tabsWithErrors = new Set<string>();
+  for (const key of Object.keys(errors)) {
+    for (const [tabKey, tab] of Object.entries(tabConfig)) {
+      if (tab.sections.includes(key)) {
+        tabsWithErrors.add(tabKey);
+      }
+    }
+  }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit, onError)} className="w-full">
+    <form onSubmit={handleSubmit(onSubmit, onError)} noValidate className="w-full">
       {errorMessages.length > 0 && (
         <div className="mb-4 p-4 bg-beni-50 border border-beni-200 rounded-elegant">
           <h4 className="text-beni-dark font-semibold mb-2">入力エラーがあります</h4>
@@ -109,30 +306,25 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
 
       <Tabs defaultValue="basic-info" className="w-full">
         <TabsList className="grid w-full grid-cols-4 h-auto">
-          <TabsTrigger
-            value="basic-info"
-            className="py-2 data-[state=active]:bg-matsu data-[state=active]:text-white"
-          >
-            区画・契約情報
-          </TabsTrigger>
-          <TabsTrigger
-            value="work-billing"
-            className="py-2 data-[state=active]:bg-matsu data-[state=active]:text-white"
-          >
-            勤務先・請求
-          </TabsTrigger>
-          <TabsTrigger
-            value="contacts"
-            className="py-2 data-[state=active]:bg-matsu data-[state=active]:text-white"
-          >
-            連絡先/家族
-          </TabsTrigger>
-          <TabsTrigger
-            value="burial-info"
-            className="py-2 data-[state=active]:bg-matsu data-[state=active]:text-white"
-          >
-            埋葬情報
-          </TabsTrigger>
+          {Object.entries(tabConfig).map(([tabKey, tab]) => {
+            const hasError = tabsWithErrors.has(tabKey);
+            return (
+              <TabsTrigger
+                key={tabKey}
+                value={tabKey}
+                className={`relative py-2 data-[state=active]:bg-matsu data-[state=active]:text-white ${
+                  hasError ? 'text-beni border-b-2 border-beni data-[state=active]:bg-beni' : ''
+                }`}
+              >
+                {hasError && (
+                  <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-beni text-white text-[10px] font-bold leading-none">
+                    !
+                  </span>
+                )}
+                {tab.label}
+              </TabsTrigger>
+            );
+          })}
         </TabsList>
 
         <TabsContent value="basic-info" className="space-y-6 mt-6">

--- a/src/components/plot-management.tsx
+++ b/src/components/plot-management.tsx
@@ -38,7 +38,7 @@ export default function PlotManagement({ initialView = 'registry' }: PlotManagem
   const [isLoading, setIsLoading] = useState(false);
 
   // 選択中の区画詳細を取得（編集モードで使用）
-  const { plot: selectedPlotDetail } = usePlotDetail(selectedPlotId || '');
+  const { plot: selectedPlotDetail, isLoading: isPlotDetailLoading } = usePlotDetail(selectedPlotId || '');
 
   // 削除ダイアログ用のstate
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -214,12 +214,18 @@ export default function PlotManagement({ initialView = 'registry' }: PlotManagem
             </div>
 
             <div className="flex-1 p-6">
-              <PlotForm
-                plotDetail={currentView === 'edit' ? selectedPlotDetail || undefined : undefined}
-                onSave={handleSavePlot}
-                onCancel={handleCancelForm}
-                isLoading={isLoading}
-              />
+              {currentView === 'edit' && isPlotDetailLoading && !selectedPlotDetail ? (
+                <div className="flex items-center justify-center h-64 text-hai">
+                  区画情報を読み込み中...
+                </div>
+              ) : (
+                <PlotForm
+                  plotDetail={currentView === 'edit' ? selectedPlotDetail || undefined : undefined}
+                  onSave={handleSavePlot}
+                  onCancel={handleCancelForm}
+                  isLoading={isLoading}
+                />
+              )}
             </div>
           </>
         ) : currentView === 'collective-burial' ? (

--- a/src/lib/validations/plot-form.ts
+++ b/src/lib/validations/plot-form.ts
@@ -18,6 +18,18 @@ import {
 
 // ===== 共通バリデーション =====
 
+// オプショナル非負数値（空欄/NaN → null、数値 → number）
+const optionalNonnegativeNumber = z.preprocess(
+  (val) => (val === '' || val === null || val === undefined || Number.isNaN(val) ? null : val),
+  z.coerce.number({ message: '数値を入力してください' }).nonnegative('0以上の数値を入力してください').nullable(),
+);
+
+// オプショナル非負整数
+const optionalNonnegativeInt = z.preprocess(
+  (val) => (val === '' || val === null || val === undefined || Number.isNaN(val) ? null : val),
+  z.coerce.number({ message: '数値を入力してください' }).int('整数を入力してください').nonnegative('0以上の数値を入力してください').nullable(),
+);
+
 // 日付文字列（YYYY-MM-DD形式）
 const dateString = z
   .string()
@@ -47,7 +59,7 @@ const optionalEmail = z
 export const physicalPlotSchema = z.object({
   plotNumber: z.string().min(1, '区画番号は必須です'),
   areaName: z.string().min(1, '区画（期）は必須です'),
-  areaSqm: z.coerce.number().positive('面積は正の数値で入力してください').default(3.6),
+  areaSqm: z.coerce.number().positive('面積は正の数値で入力してください').min(1.8, '面積は1.8㎡以上で入力してください').default(3.6),
   notes: z.string().optional().nullable(),
 });
 
@@ -61,7 +73,7 @@ export const contractPlotSchema = z.object({
 // ===== 販売契約スキーマ =====
 
 export const saleContractSchema = z.object({
-  contractDate: z.string().min(1, '契約日は必須です'),
+  contractDate: z.string().min(1, '契約日は必須です').regex(/^\d{4}-\d{2}-\d{2}$/, '契約日はYYYY-MM-DD形式で入力してください'),
   price: z.coerce.number().nonnegative('価格は0以上で入力してください'),
   paymentStatus: z.nativeEnum(PaymentStatus).optional().default(PaymentStatus.Unpaid),
   reservationDate: dateString,
@@ -79,7 +91,7 @@ export const saleContractSchema = z.object({
 
 export const customerSchema = z.object({
   name: z.string().min(1, '氏名は必須です'),
-  nameKana: z.string().min(1, '氏名カナは必須です'),
+  nameKana: z.string().min(1, '氏名カナは必須です').regex(/^[ァ-ヶー\s]+$/, '氏名カナはカタカナで入力してください'),
   birthDate: dateString.nullable(),
   gender: z.nativeEnum(Gender).optional().nullable(),
   postalCode: postalCode,
@@ -153,7 +165,7 @@ export const gravestoneInfoSchema = z.object({
   gravestoneDealer: z.string().optional().nullable(),
   gravestoneType: z.string().optional().nullable(),
   surroundingArea: z.string().optional().nullable(),
-  gravestoneCost: z.coerce.number().nonnegative().optional().nullable(),
+  gravestoneCost: optionalNonnegativeNumber.optional(),
   establishmentDeadline: dateString.nullable(),
   establishmentDate: dateString.nullable(),
 });
@@ -192,7 +204,7 @@ export const buriedPersonSchema = z.object({
   relationship: z.string().optional().nullable(),
   birthDate: dateString.nullable(),
   deathDate: dateString.nullable(),
-  age: z.coerce.number().int().nonnegative().optional().nullable(),
+  age: optionalNonnegativeInt.optional(),
   gender: z.nativeEnum(Gender).optional().nullable(),
   burialDate: dateString.nullable(),
   posthumousName: z.string().optional().nullable(),
@@ -206,7 +218,7 @@ export const buriedPersonSchema = z.object({
 export const collectiveBurialSchema = z.object({
   burialCapacity: z.coerce.number().int().positive('埋葬上限は1以上で入力してください'),
   validityPeriodYears: z.coerce.number().int().positive('有効期間は1年以上で入力してください'),
-  billingAmount: z.coerce.number().nonnegative().optional().nullable(),
+  billingAmount: optionalNonnegativeNumber.optional(),
   notes: z.string().optional().nullable(),
 });
 
@@ -617,6 +629,15 @@ export function plotFormDataToUpdateRequest(formData: PlotUpdateFormData): Updat
 // ===== PlotDetailResponse → PlotFormData 変換（編集時のデフォルト値生成） =====
 
 /**
+ * ISO日付文字列をYYYY-MM-DD形式に正規化
+ * "2024-01-15T00:00:00.000Z" → "2024-01-15"
+ */
+function toDateOnly(date: string | null | undefined): string {
+  if (!date) return '';
+  return date.split('T')[0];
+}
+
+/**
  * PlotDetailResponse を PlotFormData に変換
  * 編集フォームの defaultValues として使用
  */
@@ -637,23 +658,23 @@ export function plotDetailToFormData(detail: PlotDetailResponse): PlotFormData {
       locationDescription: detail.locationDescription,
     },
     saleContract: {
-      contractDate: detail.contractDate,
+      contractDate: toDateOnly(detail.contractDate),
       price: detail.price,
       paymentStatus: detail.paymentStatus,
-      reservationDate: detail.reservationDate || '',
+      reservationDate: toDateOnly(detail.reservationDate),
       acceptanceNumber: detail.acceptanceNumber || '',
-      acceptanceDate: detail.acceptanceDate || '',
+      acceptanceDate: toDateOnly(detail.acceptanceDate),
       staffInCharge: detail.staffInCharge || null,
       agentName: detail.agentName || null,
-      permitDate: detail.permitDate || '',
+      permitDate: toDateOnly(detail.permitDate),
       permitNumber: detail.permitNumber || '',
-      startDate: detail.startDate || '',
+      startDate: toDateOnly(detail.startDate),
       notes: detail.contractNotes,
     },
     customer: {
       name: customer?.name || '',
       nameKana: customer?.nameKana || '',
-      birthDate: customer?.birthDate || null,
+      birthDate: toDateOnly(customer?.birthDate) || null,
       gender: customer?.gender || null,
       postalCode: customer?.postalCode || '',
       address: customer?.address || '',
@@ -721,8 +742,8 @@ export function plotDetailToFormData(detail: PlotDetailResponse): PlotFormData {
         gravestoneType: detail.gravestoneInfo.gravestoneType,
         surroundingArea: detail.gravestoneInfo.surroundingArea,
         gravestoneCost: detail.gravestoneInfo.gravestoneCost,
-        establishmentDeadline: detail.gravestoneInfo.establishmentDeadline,
-        establishmentDate: detail.gravestoneInfo.establishmentDate,
+        establishmentDeadline: toDateOnly(detail.gravestoneInfo.establishmentDeadline),
+        establishmentDate: toDateOnly(detail.gravestoneInfo.establishmentDate),
       }
       : null,
     familyContacts: detail.familyContacts.map((fc) => ({
@@ -730,7 +751,7 @@ export function plotDetailToFormData(detail: PlotDetailResponse): PlotFormData {
       emergencyContactFlag: false,
       name: fc.name,
       nameKana: fc.nameKana || null,
-      birthDate: fc.birthDate || null,
+      birthDate: toDateOnly(fc.birthDate) || null,
       relationship: fc.relationship,
       postalCode: fc.postalCode,
       address: fc.address,
@@ -752,13 +773,13 @@ export function plotDetailToFormData(detail: PlotDetailResponse): PlotFormData {
       name: bp.name,
       nameKana: bp.nameKana,
       relationship: bp.relationship,
-      birthDate: bp.birthDate || null,
-      deathDate: bp.deathDate || null,
+      birthDate: toDateOnly(bp.birthDate) || null,
+      deathDate: toDateOnly(bp.deathDate) || null,
       age: bp.age,
       gender: bp.gender,
-      burialDate: bp.burialDate || null,
+      burialDate: toDateOnly(bp.burialDate) || null,
       posthumousName: bp.posthumousName || null,
-      reportDate: bp.reportDate || null,
+      reportDate: toDateOnly(bp.reportDate) || null,
       religion: bp.religion || null,
       notes: bp.notes,
     })),


### PR DESCRIPTION
## Summary
- 区画編集フォームで更新ボタンを押してもリクエストが飛ばない問題を修正（合祀フィールドの型不一致によるサイレントバリデーション失敗）
- バリデーションエラー時のUXを大幅改善（トースト通知、日本語ラベル表示、タブ別エラー表示）
- 編集時に既存データがフォームに反映されない問題を修正
- フロント/バックエンド間のバリデーション不整合を修正（日付形式、カタカナチェック、面積制約）

## Changes

### バリデーション修正
- 合祀フィールド（burialCapacity, validityPeriodYears, billingAmount）に `valueAsNumber: true` 追加
- オプショナル数値フィールド（billingAmount, gravestoneCost, age）で空欄時に `NaN` → `null` 変換する `z.preprocess` 適用
- `contractDate` に YYYY-MM-DD 形式チェック追加
- `nameKana` にカタカナバリデーション追加（バックエンドと一致）
- `areaSqm` に最小 1.8㎡ 制約追加（バックエンドと一致）
- `noValidate` でブラウザネイティブバリデーション無効化

### エラー表示UX改善
- `onError` コールバックでトースト通知表示
- ネストされたバリデーションエラーを再帰的に収集して表示
- 全フィールドの日本語ラベルマッピング（英語パス名 → 画面ラベル）
- エラーメッセージにタブ名プレフィックス付与（例: `[区画・契約情報] 郵便番号: ...`）
- エラーがあるタブに赤色テキスト + `!` バッジ表示

### データ反映修正
- `plotDetailToFormData` で API レスポンスの ISO 日付を YYYY-MM-DD に正規化
- `useEffect` + `reset()` で `plotDetail` の後着時にフォーム再設定
- 編集モードでデータ未取得時のローディング表示追加

## Test plan
- [ ] 区画編集画面で合祀設定を入力して更新 → リクエストが送信されること
- [ ] 必須項目を空にして更新 → トースト通知とエラー一覧が日本語で表示されること
- [ ] エラーがあるタブに赤色 + ! バッジが表示されること
- [ ] 既存区画の編集画面で既存データが全フィールドに反映されること
- [ ] 氏名カナにひらがなを入力 → カタカナエラーが表示されること
- [ ] 面積に 1.0 を入力 → 1.8㎡以上エラーが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)