### PR TITLE
fix: バリデーションエラー時にdetailsの詳細メッセージを表示する

### DIFF
--- a/src/components/bulk-import/index.tsx
+++ b/src/components/bulk-import/index.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { bulkCreatePlots } from '@/lib/api/plots';
 import { bulkCreateStaff } from '@/lib/api/staff';
-import { showSuccess, showError } from '@/lib/toast';
+import { showSuccess, showError, showApiError } from '@/lib/toast';
 import { ConfirmDialog } from '@/components/shared/dialogs';
 import PageHeader from '@/components/page-header';
 import { ViewType } from '@/types/plot-detail';
@@ -405,7 +405,7 @@ function BulkImportPanel({ type }: { type: ImportTab }) {
           });
           showSuccess(`${response.data.created}件の区画情報を登録しました`);
         } else {
-          showError('一括登録に失敗しました', response.error?.message);
+          showApiError('一括登録', response.error?.message, response.error?.details);
         }
       } else {
         const response = await bulkCreateStaff(staffRows);
@@ -416,7 +416,7 @@ function BulkImportPanel({ type }: { type: ImportTab }) {
           });
           showSuccess(`${response.data.created}件のスタッフ情報を登録しました`);
         } else {
-          showError('一括登録に失敗しました', response.error?.message);
+          showApiError('一括登録', response.error?.message, response.error?.details);
         }
       }
     } catch {

--- a/src/components/masters-management.tsx
+++ b/src/components/masters-management.tsx
@@ -19,6 +19,17 @@ import { showSuccess, showError } from '@/lib/toast';
 import PageHeader from '@/components/page-header';
 import { ViewType } from '@/types/plot-detail';
 
+function formatApiError(
+  message: string,
+  details?: Array<{ field?: string; message: string }>,
+): string {
+  if (!details || details.length === 0) return message;
+  const detailLines = details
+    .map((d) => (d.field ? `${d.field}: ${d.message}` : d.message))
+    .join('\n');
+  return `${message}\n${detailLines}`;
+}
+
 interface MasterTypeConfig {
   key: MasterType;
   label: string;
@@ -124,7 +135,7 @@ export default function MastersManagement({ onViewChange }: MastersManagementPro
         setShowDialog(false);
         showSuccess(`${selectedType.label}を更新しました`);
       } else {
-        setFormError(response.error?.message || '更新に失敗しました');
+        setFormError(formatApiError(response.error?.message || '更新に失敗しました', response.error?.details));
       }
     } else {
       const response = await createMasterItem(selectedType.key, payload);
@@ -133,7 +144,7 @@ export default function MastersManagement({ onViewChange }: MastersManagementPro
         setShowDialog(false);
         showSuccess(`${selectedType.label}を作成しました`);
       } else {
-        setFormError(response.error?.message || '作成に失敗しました');
+        setFormError(formatApiError(response.error?.message || '作成に失敗しました', response.error?.details));
       }
     }
 
@@ -151,7 +162,7 @@ export default function MastersManagement({ onViewChange }: MastersManagementPro
       setItemToDelete(null);
       showSuccess(`${selectedType.label}を削除しました`);
     } else {
-      showError(response.error?.message || '削除に失敗しました');
+      showError(formatApiError(response.error?.message || '削除に失敗しました', response.error?.details));
     }
 
     setIsDeleting(false);

--- a/src/components/masters-management.tsx
+++ b/src/components/masters-management.tsx
@@ -25,7 +25,7 @@ function formatApiError(
 ): string {
   if (!details || details.length === 0) return message;
   const detailLines = details
-    .map((d) => (d.field ? `${d.field}: ${d.message}` : d.message))
+    .map((d) => d.message)
     .join('\n');
   return `${message}\n${detailLines}`;
 }

--- a/src/components/plot-management.tsx
+++ b/src/components/plot-management.tsx
@@ -81,7 +81,7 @@ export default function PlotManagement({ initialView = 'registry' }: PlotManagem
           setCurrentView('registry');
           showApiSuccess('作成', '区画');
         } else {
-          showApiError('区画登録', response.error?.message);
+          showApiError('区画登録', response.error?.message, response.error?.details);
         }
       } else if (currentView === 'edit' && selectedPlotId) {
         const request = plotFormDataToUpdateRequest(data);
@@ -93,7 +93,7 @@ export default function PlotManagement({ initialView = 'registry' }: PlotManagem
           setCurrentView('plot-details');
           showApiSuccess('更新', '区画情報');
         } else {
-          showApiError('区画情報更新', response.error?.message);
+          showApiError('区画情報更新', response.error?.message, response.error?.details);
         }
       }
     } catch {
@@ -134,7 +134,7 @@ export default function PlotManagement({ initialView = 'registry' }: PlotManagem
         setCurrentView('registry');
         showApiSuccess('削除', '区画データ');
       } else {
-        showApiError('データ削除', response.error?.message);
+        showApiError('データ削除', response.error?.message, response.error?.details);
       }
     } catch {
       showError('削除中にエラーが発生しました');

--- a/src/components/staff-management.tsx
+++ b/src/components/staff-management.tsx
@@ -361,7 +361,7 @@ export default function StaffManagement({ onViewChange }: StaffManagementProps) 
         await fetchStaffList();
         showSuccess(`${staff.name}を${staff.isActive ? '無効' : '有効'}にしました`);
       } else {
-        showApiError('状態の変更', response.error?.message);
+        showApiError('状態の変更', response.error?.message, response.error?.details);
       }
     } catch {
       showError('状態の変更中にエラーが発生しました');
@@ -390,7 +390,7 @@ export default function StaffManagement({ onViewChange }: StaffManagementProps) 
         showSuccess(`${staffToDelete.name}を削除しました`);
         setStaffToDelete(null);
       } else {
-        showApiError('スタッフの削除', response.error?.message);
+        showApiError('スタッフの削除', response.error?.message, response.error?.details);
       }
     } catch {
       showError('スタッフの削除中にエラーが発生しました');

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -11,9 +11,7 @@ function formatErrorDescription(
 ): string | undefined {
   if (!details || details.length === 0) return message;
 
-  const detailLines = details
-    .map((d) => (d.field ? `${d.field}: ${d.message}` : d.message))
-    .join('\n');
+  const detailLines = details.map((d) => d.message).join('\n');
 
   return message ? `${message}\n${detailLines}` : detailLines;
 }
@@ -77,7 +75,11 @@ export function showApiError(
   errorMessage?: string,
   details?: Array<{ field?: string; message: string }>,
 ) {
-  showError(`${operation}に失敗しました`, formatErrorDescription(errorMessage, details));
+  const description = formatErrorDescription(errorMessage, details);
+  toast.error(`${operation}に失敗しました`, {
+    description,
+    duration: details?.length ? 10000 : 5000,
+  });
 }
 
 /**
@@ -102,10 +104,11 @@ export function showValidationError(
   message?: string,
   details?: Array<{ field?: string; message: string }>,
 ) {
-  showError(
-    '入力エラー',
-    formatErrorDescription(message || '入力内容を確認してください。', details),
-  );
+  const description = formatErrorDescription(message || '入力内容を確認してください。', details);
+  toast.error('入力エラー', {
+    description,
+    duration: details?.length ? 10000 : 5000,
+  });
 }
 
 // 直接toast関数もエクスポート（カスタマイズが必要な場合用）

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -5,6 +5,19 @@
 
 import { toast } from 'sonner';
 
+function formatErrorDescription(
+  message?: string,
+  details?: Array<{ field?: string; message: string }>,
+): string | undefined {
+  if (!details || details.length === 0) return message;
+
+  const detailLines = details
+    .map((d) => (d.field ? `${d.field}: ${d.message}` : d.message))
+    .join('\n');
+
+  return message ? `${message}\n${detailLines}` : detailLines;
+}
+
 /**
  * 成功通知
  */
@@ -57,9 +70,14 @@ export function showApiSuccess(operation: '作成' | '更新' | '削除' | '保�
 
 /**
  * API操作エラー通知
+ * details がある場合はフィールドごとのエラーメッセージを description に表示
  */
-export function showApiError(operation: string, errorMessage?: string) {
-  showError(`${operation}に失敗しました`, errorMessage);
+export function showApiError(
+  operation: string,
+  errorMessage?: string,
+  details?: Array<{ field?: string; message: string }>,
+) {
+  showError(`${operation}に失敗しました`, formatErrorDescription(errorMessage, details));
 }
 
 /**
@@ -78,9 +96,16 @@ export function showAuthError(message?: string) {
 
 /**
  * バリデーションエラー通知
+ * details がある場合はフィールドごとのエラーメッセージを description に表示
  */
-export function showValidationError(message?: string) {
-  showError('入力エラー', message || '入力内容を確認してください。');
+export function showValidationError(
+  message?: string,
+  details?: Array<{ field?: string; message: string }>,
+) {
+  showError(
+    '入力エラー',
+    formatErrorDescription(message || '入力内容を確認してください。', details),
+  );
 }
 
 // 直接toast関数もエクスポート（カスタマイズが必要な場合用）


### PR DESCRIPTION
## Summary
- `showApiError` / `showValidationError` に `details` パラメータを追加し、バックエンドの `error.details` 配列（`{ field, message }`）をトーストの description に表示するように改善
- 各コンポーネント（plot-management, staff-management, bulk-import, masters-management）で `response.error.details` を渡すように修正
- bulk-import では `showError` → `showApiError` に統一

## Test plan
- [ ] 区画登録/更新でバリデーションエラーを発生させ、トーストにフィールド別エラーが表示されることを確認
- [ ] 一括インポートで不正データを送信し、詳細エラーが表示されることを確認
- [ ] マスタ管理で不正データを送信し、フォーム内エラーに詳細が表示されることを確認
- [ ] details がない通常のエラーで従来通りの表示になることを確認

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)