### PR TITLE
fix: 区画詳細UIの統一 + ダークモードホバー修正

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -216,6 +216,17 @@ body {
   border-color: #644c1a !important;
 }
 
+/* --- ホバー背景色 --- */
+.dark .hover\:bg-white:hover,
+.dark .hover\:bg-matsu-50:hover {
+  background-color: #232730 !important;
+}
+
+.dark .hover\:bg-gray-50:hover,
+.dark .hover\:bg-kinari:hover {
+  background-color: #232730 !important;
+}
+
 /* --- グラデーション --- */
 .dark .bg-gradient-warm {
   background-image: linear-gradient(135deg, #1a1d23 0%, #15181d 100%) !important;

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -270,9 +270,11 @@ function FeeInfoTab({ plot }: { plot: PlotDetailResponse }) {
       )}
 
       {!plot.usageFee && !plot.managementFee && (
-        <div className="text-center text-hai py-8">
-          料金情報が登録されていません
-        </div>
+        <Section title="料金情報">
+          <div className="col-span-full text-center text-hai py-4">
+            料金情報が登録されていません
+          </div>
+        </Section>
       )}
     </div>
   );
@@ -285,7 +287,7 @@ function ContactsTab({ plot }: { plot: PlotDetailResponse }) {
       <Section title="契約関係者">
         {plot.roles.length > 0 ? (
           plot.roles.map((role, idx) => (
-            <div key={role.id || idx} className="col-span-full border border-gin rounded-elegant p-4 mb-2 bg-kinari/30">
+            <div key={role.id || idx} className={`col-span-full ${idx > 0 ? 'border-t border-gin pt-4' : ''}`}>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <InfoField label="役割" value={CONTRACT_ROLE_LABELS[role.role as ContractRole]} />
                 <InfoField label="氏名" value={role.customer.name} />
@@ -308,7 +310,7 @@ function ContactsTab({ plot }: { plot: PlotDetailResponse }) {
       <Section title="家族連絡先">
         {plot.familyContacts && plot.familyContacts.length > 0 ? (
           plot.familyContacts.map((contact, idx) => (
-            <div key={contact.id || idx} className="col-span-full border border-gin rounded-elegant p-4 mb-2 bg-kinari/30">
+            <div key={contact.id || idx} className={`col-span-full ${idx > 0 ? 'border-t border-gin pt-4' : ''}`}>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <InfoField label="氏名" value={contact.name} />
                 <InfoField label="ふりがな" value={contact.nameKana} />
@@ -360,7 +362,7 @@ function BurialInfoTab({ plot }: { plot: PlotDetailResponse }) {
       <Section title="埋葬者一覧">
         {plot.buriedPersons && plot.buriedPersons.length > 0 ? (
           plot.buriedPersons.map((person, idx) => (
-            <div key={person.id || idx} className="col-span-full border border-gin rounded-elegant p-4 mb-2 bg-kinari/30">
+            <div key={person.id || idx} className={`col-span-full ${idx > 0 ? 'border-t border-gin pt-4' : ''}`}>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <InfoField label="氏名" value={person.name} />
                 <InfoField label="ふりがな" value={person.nameKana} />
@@ -425,7 +427,7 @@ function ConstructionInfoTab({ plot }: { plot: PlotDetailResponse }) {
       <Section title="工事記録">
         {plot.constructionInfos && plot.constructionInfos.length > 0 ? (
           plot.constructionInfos.map((record, idx) => (
-            <div key={record.id || idx} className="col-span-full border border-gin rounded-elegant p-4 mb-2 bg-kinari/30">
+            <div key={record.id || idx} className={`col-span-full ${idx > 0 ? 'border-t border-gin pt-4' : ''}`}>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <InfoField label="施工業者" value={record.contractor} />
                 <InfoField label="監督者" value={record.supervisor} />

--- a/src/components/plot-form/BurialInfoTab.tsx
+++ b/src/components/plot-form/BurialInfoTab.tsx
@@ -74,6 +74,11 @@ export function BurialInfoTab({
 
       {/* Burial Person Rows */}
       <div className="space-y-3">
+        {buriedPersonFields.length === 0 && (
+          <div className="text-center text-hai py-4 border border-gin rounded-lg">
+            埋葬者が登録されていません
+          </div>
+        )}
         {buriedPersonFields.map((field, index) => {
           const gender = watch(`buriedPersons.${index}.gender`);
           const genderLabel = gender ? genderLabels[gender as Gender] : '-';

--- a/src/components/plot-form/ContactsTab.tsx
+++ b/src/components/plot-form/ContactsTab.tsx
@@ -42,6 +42,11 @@ export function ContactsTab({
       </div>
 
       <div className="space-y-3">
+        {familyContactFields.length === 0 && (
+          <div className="text-center text-hai py-4 border border-gin rounded-lg">
+            家族連絡先が登録されていません
+          </div>
+        )}
         {familyContactFields.map((field, index) => (
           <div key={field.id} className="border rounded-lg overflow-hidden">
             {/* Summary Line */}


### PR DESCRIPTION
## Summary
- **#68**: 空状態UIをタブ間で統一（FeeInfoTabにSection追加、編集モードのContactsTab/BurialInfoTabに空状態メッセージ追加）
- **#69**: データ表示時のbg-kinari/30ネストカードを削除し、border-t区切り線スタイルに統一（FeeInfoTabと同じフラットパターン）
- **#70**: ダークモードのサイドバー等でhover:bg-whiteが白背景になり文字が見えない問題を修正

Closes #68, Closes #69, Closes #70

## Test plan
- [ ] 区画詳細の各タブ（料金・連絡先・埋葬・工事）でデータ未登録時の空状態表示が統一されていること
- [ ] 編集モードのContactsTab/BurialInfoTabで0件時に空状態メッセージが表示されること
- [ ] 各タブのデータ表示時にbg-kinari/30カードが消え、区切り線で視覚的に分離されていること
- [ ] ダークモードでサイドバーホバー時に背景が暗色（#232730）になり文字が視認できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)