### PR TITLE
fix: 履歴情報タブでUUID値を省略表示に

### DIFF
--- a/src/components/plot-form/HistoryTab.tsx
+++ b/src/components/plot-form/HistoryTab.tsx
@@ -46,6 +46,15 @@ interface HistoryEntry {
 }
 
 /**
+ * UUID形式の判定
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuidValue(value: unknown): boolean {
+  return typeof value === 'string' && UUID_REGEX.test(value);
+}
+
+/**
  * 値を表示用文字列に整形する
  */
 function formatValue(value: unknown): string {
@@ -59,6 +68,10 @@ function formatValue(value: unknown): string {
     return value.toLocaleString('ja-JP');
   }
   if (typeof value === 'string') {
+    // UUID値は省略表示（バックエンド側でフィルタされるが、既存データ用のフォールバック）
+    if (isUuidValue(value)) {
+      return `（ID: ${value.substring(0, 8)}…）`;
+    }
     // ISO 日付っぽい文字列は日本語日時表記に
     if (/^\d{4}-\d{2}-\d{2}T/.test(value)) {
       const d = new Date(value);


### PR DESCRIPTION
## Summary
- `HistoryTab.tsx`にUUID判定関数を追加
- UUID値を「（ID: xxxxxxxx…）」形式で省略表示
- バックエンド側でフィルタされない既存データへのフォールバック対応

## 関連
- バックエンドPR: zaitsu82/komine-crm-backend#69
- バックエンド側でシステムフィールド・FKのフィルタリングを実装済み

## Test plan
- [x] ESLint通過
- [ ] 履歴情報タブでUUIDが省略表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)