### PR TITLE
fix: モバイルヘッダーもPageHeaderに統合

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,13 +1,18 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { AuthGuard } from '@/components/auth-guard';
 import GlobalSidebar from '@/components/layout/GlobalSidebar';
-import UserMenu from '@/components/user-menu';
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    const handleOpenSidebar = () => setMobileSidebarOpen(true);
+    window.addEventListener('open-mobile-sidebar', handleOpenSidebar);
+    return () => window.removeEventListener('open-mobile-sidebar', handleOpenSidebar);
+  }, []);
 
   const sidebarWidth = sidebarCollapsed ? 'md:ml-16' : 'md:ml-64';
 
@@ -22,23 +27,6 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         />
 
         <div className={`flex-1 flex flex-col ml-0 ${sidebarWidth} transition-all duration-300`}>
-          {/* Mobile header */}
-          <div className="md:hidden flex items-center justify-between h-14 px-4 border-b border-gin bg-white flex-shrink-0">
-            <div className="flex items-center">
-              <button
-                onClick={() => setMobileSidebarOpen(true)}
-                className="p-2 -ml-2 rounded-md text-sumi hover:bg-kinari"
-                aria-label="メニューを開く"
-              >
-                <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-              </button>
-              <span className="ml-3 font-mincho text-base font-semibold text-sumi truncate">小嶺霊園CRM</span>
-            </div>
-            <UserMenu />
-          </div>
-
           {children}
         </div>
       </div>

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -35,6 +35,15 @@ export default function PageHeader({ title, subtitle, icon, theme }: PageHeaderP
 
   return (
     <div className="h-14 md:h-16 border-b border-gin bg-white flex items-center px-3 md:px-5 flex-shrink-0">
+      <button
+        onClick={() => window.dispatchEvent(new Event('open-mobile-sidebar'))}
+        className="md:hidden p-2 -ml-1 mr-1 rounded-md text-sumi hover:bg-kinari flex-shrink-0"
+        aria-label="メニューを開く"
+      >
+        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
       <div className="flex items-center min-w-0 flex-1">
         <div className={`w-8 h-8 md:w-10 md:h-10 rounded-lg ${styles.iconBg} flex items-center justify-center flex-shrink-0`}>
           {icon}
@@ -46,7 +55,7 @@ export default function PageHeader({ title, subtitle, icon, theme }: PageHeaderP
           )}
         </div>
       </div>
-      <div className="hidden md:block flex-shrink-0 ml-4">
+      <div className="flex-shrink-0 ml-4">
         <UserMenu />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- `layout.tsx` のモバイルヘッダー（ハンバーガー+「小嶺霊園CRM」+UserMenu）を削除
- `page-header.tsx` にハンバーガーボタン（`md:hidden`）を追加し、UserMenuをモバイルでも表示
- カスタムイベント `open-mobile-sidebar` で `layout.tsx` のサイドバー開閉stateと連携
- 「小嶺霊園CRM」テキストはサイドバーと重複するため削除

#78 の追加対応（#81 はデスクトップのみ対応済み）

## Test plan
- [ ] モバイル: PageHeaderの左端にハンバーガーボタン、右端にUserMenuが表示される
- [ ] モバイル: ハンバーガーボタンでサイドバーが開閉できる
- [ ] モバイル: 旧モバイルヘッダー（「小嶺霊園CRM」テキスト行）が消えている
- [ ] デスクトップ: 表示に影響がないこと（#81 の変更が維持されている）
- [ ] 全ページで正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)