### PR TITLE
fix: 区画プルダウンのマスタ反映とラベル修正 (Closes #43)

### DIFF
--- a/src/components/masters-management.tsx
+++ b/src/components/masters-management.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/lib/api';
 import { showSuccess, showError } from '@/lib/toast';
 import PageHeader from '@/components/page-header';
+import { clearMastersCache } from '@/hooks/useMasters';
 
 function formatApiError(
   message: string,
@@ -126,6 +127,7 @@ export default function MastersManagement() {
     if (editingItem) {
       const response = await updateMasterItem(selectedType.key, editingItem.id, payload);
       if (response.success) {
+        clearMastersCache();
         await fetchData();
         setShowDialog(false);
         showSuccess(`${selectedType.label}を更新しました`);
@@ -135,6 +137,7 @@ export default function MastersManagement() {
     } else {
       const response = await createMasterItem(selectedType.key, payload);
       if (response.success) {
+        clearMastersCache();
         await fetchData();
         setShowDialog(false);
         showSuccess(`${selectedType.label}を作成しました`);
@@ -152,6 +155,7 @@ export default function MastersManagement() {
 
     const response = await deleteMasterItem(selectedType.key, itemToDelete.id);
     if (response.success) {
+      clearMastersCache();
       await fetchData();
       setShowDeleteConfirm(false);
       setItemToDelete(null);

--- a/src/components/plot-form/BasicInfoTab.tsx
+++ b/src/components/plot-form/BasicInfoTab.tsx
@@ -53,10 +53,10 @@ export function BasicInfoTab({
             placeholder="例: A-001"
           />
 
-          {/* 区画（期）の選択 - 2段階セレクト */}
+          {/* 区画の選択 - 期→区画の2段階セレクト */}
           <div>
             <Label className="text-sm font-medium">
-              区画（期）
+              区画
               <span className="text-beni"> *</span>
             </Label>
             {viewMode ? (

--- a/src/components/plot-form/index.tsx
+++ b/src/components/plot-form/index.tsx
@@ -149,7 +149,7 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
   const fieldLabels: Record<string, string> = {
     // 物理区画
     'physicalPlot.plotNumber': '区画番号',
-    'physicalPlot.areaName': '区画（期）',
+    'physicalPlot.areaName': '区画',
     'physicalPlot.areaSqm': '面積',
     'physicalPlot.notes': '備考',
     // 契約区画

--- a/src/components/plot-form/previewHelper.ts
+++ b/src/components/plot-form/previewHelper.ts
@@ -32,7 +32,7 @@ const sectionConfigs: SectionConfig[] = [
     title: '物理区画情報',
     fields: [
       { key: 'physicalPlot.plotNumber', label: '区画番号' },
-      { key: 'physicalPlot.areaName', label: '区画（期）' },
+      { key: 'physicalPlot.areaName', label: '区画' },
       { key: 'physicalPlot.areaSqm', label: '面積（㎡）', format: formatNumber },
       { key: 'physicalPlot.notes', label: '備考' },
     ],

--- a/src/hooks/useMasters.ts
+++ b/src/hooks/useMasters.ts
@@ -51,6 +51,14 @@ function isCacheValid(): boolean {
 }
 
 /**
+ * useMastersのグローバルキャッシュをクリア（フック外からも呼び出し可能）
+ * マスタ更新後に呼ぶことで、次回useMasters呼び出し時に最新データを取得させる
+ */
+export function clearMastersCache(): void {
+  globalCache = { data: null, lastFetched: null };
+}
+
+/**
  * 全マスタデータ管理フック
  * キャッシュ機能付き - マスタデータは頻繁に変わらないため
  */


### PR DESCRIPTION
## Summary
- **問題1 (キャッシュ)**: マスタ管理画面で区画名マスタを更新しても、新規区画登録のプルダウンに反映されなかった問題を修正。`useMasters` のグローバルキャッシュ（30分TTL）をCRUD成功時に無効化する `clearMastersCache()` を追加
- **問題2 (ラベル)**: 「区画（期）」→「区画」にラベルを統一（UI表示3箇所 + バリデーションメッセージ）

関連: zaitsu82/komine-types#7（バリデーションメッセージの修正、マージ済）

## 変更内容

### 問題1: マスタ更新後にプルダウンに反映されない
`masters-management.tsx` は自前stateで管理しており、`useMasters` のグローバルキャッシュを無効化していなかった。`useMasters()` フックをそのまま呼ぶと副作用で余分な `/masters/all` 呼び出しが発生するため、スタンドアロン関数として切り出して対応。

- `src/hooks/useMasters.ts` — `clearMastersCache()` をexport追加
- `src/components/masters-management.tsx` — 作成/更新/削除の各成功時に `clearMastersCache()` を呼ぶ

### 問題2: ラベル修正
- `src/components/plot-form/BasicInfoTab.tsx` — 表示ラベル・コメント
- `src/components/plot-form/index.tsx` — `fieldLabelMapping`
- `src/components/plot-form/previewHelper.ts` — プレビュー表示ラベル

## 検証項目
- [ ] マスタ管理画面で区画名を追加/編集/削除
- [ ] 直後に新規区画登録画面を開き、追加した区画が「区画」プルダウンに反映されることを確認
- [ ] 新規区画登録フォームで「区画」ラベルになっていることを確認（「区画（期）」表記が残っていないこと）
- [ ] 区画未選択でバリデーションエラー時、メッセージが「区画は必須です」になっていることを確認
- [ ] `npm test` パス（関連テスト156件既にpass確認済）
- [ ] `npm run lint` エラー0件（既存warningのみ）

## スコープ外・要確認
Vercel環境の `NEXT_PUBLIC_USE_MOCK_DATA` が `true` になっていないかは本PRのスコープ外。もし `true` ならどんなキャッシュ対策をしてもmockDataが返るため、別途確認が必要。

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)