### PR TITLE
fix(sidebar): モバイルで閉じるボタンが中途半端に残る不具合を修正

### DIFF
--- a/src/components/layout/GlobalSidebar.tsx
+++ b/src/components/layout/GlobalSidebar.tsx
@@ -95,7 +95,13 @@ export default function GlobalSidebar({
             </Link>
           )}
           <button
-            onClick={onToggleCollapse}
+            onClick={() => {
+              if (mobileOpen) {
+                onMobileClose?.();
+              } else {
+                onToggleCollapse();
+              }
+            }}
             className={`p-2 rounded-md text-hai hover:text-sumi hover:bg-white cursor-pointer transition-colors ${focusRing}`}
             aria-label={collapsed ? 'メニューを開く' : 'メニューを閉じる'}
           >


### PR DESCRIPTION
## Summary
- モバイルでサイドバーを開いた状態で左上トグルボタンを押すと、一旦 `collapsed`（アイコンのみ）状態になり、さらに背景オーバーレイをタップして初めて閉じる2段階挙動を修正
- トグルボタンの onClick を `mobileOpen` 判定で分岐し、モバイル時は `onMobileClose` を直接呼ぶように変更

## 背景
`GlobalSidebar.tsx` のトグルボタンは `onToggleCollapse` だけを呼んでいたため、モバイル環境で押下すると `sidebarCollapsed=true` だけが立ち、`mobileSidebarOpen=true` は残ったままになる。結果として「幅 16 のアイコン列がスライドインしたまま残る」中途半端な状態が発生していた。

デスクトップでは `mobileSidebarOpen` は一度も true にならない（`page-header.tsx` のハンバーガーが `md:hidden` のため）ので、分岐は従来動作と完全互換。

## 変更ファイル
- `src/components/layout/GlobalSidebar.tsx`（onClick 1箇所のみ）

## Test plan
- [ ] モバイル幅（375px）でハンバーガーからサイドバーを開き、左上トグルボタン（double-chevron）で一発閉じられること
- [ ] モバイルで背景オーバーレイタップでも引き続き閉じられること
- [ ] デスクトップ幅で展開/アイコンモードの切り替えが従来通り動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)