### PR TITLE
fix(dark-mode): ブランド色背景が発光して見える問題を修正

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -241,6 +241,48 @@ body {
   background-color: #3a3015 !important;
 }
 
+/* ============================================================
+ * ダークモード: ブランド色の背景補正
+ * ------------------------------------------------------------
+ * --color-matsu / --color-cha / --color-ai / --color-beni の
+ * ベーストークンはダークモードで明るい値に反転されている
+ * （text-matsu 等のアクセント文字色として可読にするため）。
+ * そのまま bg として使うと白テキストと組み合わさって発光した
+ * ように見えるので、背景用途では -600/-500 シェードに差し替え。
+ * ============================================================ */
+
+.dark .bg-matsu {
+  background-color: var(--color-matsu-600) !important;
+}
+
+.dark .hover\:bg-matsu-light:hover {
+  background-color: var(--color-matsu-500) !important;
+}
+
+.dark .bg-cha {
+  background-color: var(--color-cha-600) !important;
+}
+
+.dark .hover\:bg-cha-light:hover {
+  background-color: var(--color-cha-500) !important;
+}
+
+.dark .bg-ai {
+  background-color: var(--color-ai-600) !important;
+}
+
+.dark .hover\:bg-ai-light:hover {
+  background-color: var(--color-ai-500) !important;
+}
+
+.dark .bg-beni {
+  background-color: var(--color-beni-600) !important;
+}
+
+.dark .hover\:bg-beni-light:hover {
+  background-color: var(--color-beni-500) !important;
+}
+
 /* テキスト（Tailwind 標準色） */
 .dark .text-gray-900,
 .dark .text-gray-800,


### PR DESCRIPTION
## Summary
- ダークモード時に検索ボタンや UserMenu のアバター円、その他 \`variant=\"matsu\"/\"cha\"/\"ai\"/\"destructive\"\` のボタンが蛍光色っぽく発光して見える問題を修正
- 原因: \`--color-matsu\` 等のベーストークンはダーク時にアクセント文字色（\`text-matsu\`）として読める明るい値に反転されており、そのまま \`bg-matsu\` として使うと白テキストと組み合わさって発光して見えていた
- 対応: \`globals.css\` にダーク時限定で \`.bg-matsu\` / \`.bg-cha\` / \`.bg-ai\` / \`.bg-beni\` とそれぞれの \`:hover\` を \`-600\` / \`-500\` シェードで上書き

## Test plan
- [ ] ライトモードで検索ボタン・「アカウント設定」アバター円・destructive ボタンの見た目が従来どおりか確認
- [ ] ダークモードに切り替えて同じボタン群が暗いブランド色で落ち着いて見えるか確認
- [ ] ダークモードでホバーした際の色変化が維持されているか確認
- [ ] PageHeader のグラデーション（\`theme=\"matsu\"/\"cha\"/\"ai\"\`）に影響が出ていないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)