### PR TITLE
feat(bulk-import): consume partial-success response from bulk APIs

### DIFF
--- a/src/components/bulk-import/BulkCreatePlotPanel.tsx
+++ b/src/components/bulk-import/BulkCreatePlotPanel.tsx
@@ -28,7 +28,12 @@ export function BulkCreatePlotPanel() {
   const [showConfirm, setShowConfirm] = useState(false);
   const [submitResult, setSubmitResult] = useState<{
     totalRequested: number;
-    created: number;
+    succeeded: number;
+    failed: Array<{
+      row: number;
+      plotNumber?: string | null;
+      error: { message: string; details?: Array<{ field?: string; message: string }> };
+    }>;
   } | null>(null);
 
   const handleFileSelect = useCallback(async (f: File) => {
@@ -72,11 +77,15 @@ export function BulkCreatePlotPanel() {
       const payload = buildBulkCreatePayload(plots);
       const response = await bulkCreatePlots(payload);
       if (response.success) {
-        setSubmitResult({
-          totalRequested: response.data.totalRequested,
-          created: response.data.created,
-        });
-        showSuccess(`${response.data.created}件の区画情報を登録しました`);
+        const { totalRequested, succeeded, failed } = response.data;
+        setSubmitResult({ totalRequested, succeeded, failed });
+        if (failed.length === 0) {
+          showSuccess(`${succeeded}件の区画情報を登録しました`);
+        } else if (succeeded === 0) {
+          showError(`${failed.length}件すべての登録に失敗しました`);
+        } else {
+          showError(`${succeeded}件成功 / ${failed.length}件失敗`);
+        }
       } else {
         showApiError('一括登録', response.error?.message, response.error?.details);
       }
@@ -177,7 +186,8 @@ export function BulkCreatePlotPanel() {
         <SubmitResultCard
           mode="create"
           totalRequested={submitResult.totalRequested}
-          succeeded={submitResult.created}
+          succeeded={submitResult.succeeded}
+          failed={submitResult.failed}
           onReset={handleReset}
         />
       )}

--- a/src/components/bulk-import/BulkUpdatePlotPanel.tsx
+++ b/src/components/bulk-import/BulkUpdatePlotPanel.tsx
@@ -38,7 +38,12 @@ export function BulkUpdatePlotPanel() {
   const [showConfirm, setShowConfirm] = useState(false);
   const [submitResult, setSubmitResult] = useState<{
     totalRequested: number;
-    updated: number;
+    succeeded: number;
+    failed: Array<{
+      row: number;
+      plotNumber?: string | null;
+      error: { message: string; details?: Array<{ field?: string; message: string }> };
+    }>;
   } | null>(null);
 
   const handleFileSelect = useCallback(async (f: File) => {
@@ -82,11 +87,15 @@ export function BulkUpdatePlotPanel() {
       const payload = buildBulkUpdatePayload(plots);
       const response = await bulkUpdatePlots(payload);
       if (response.success) {
-        setSubmitResult({
-          totalRequested: response.data.totalRequested,
-          updated: response.data.updated,
-        });
-        showSuccess(`${response.data.updated}件の区画情報を更新しました`);
+        const { totalRequested, succeeded, failed } = response.data;
+        setSubmitResult({ totalRequested, succeeded, failed });
+        if (failed.length === 0) {
+          showSuccess(`${succeeded}件の区画情報を更新しました`);
+        } else if (succeeded === 0) {
+          showError(`${failed.length}件すべての更新に失敗しました`);
+        } else {
+          showError(`${succeeded}件成功 / ${failed.length}件失敗`);
+        }
       } else {
         showApiError('一括編集', response.error?.message, response.error?.details);
       }
@@ -217,7 +226,8 @@ export function BulkUpdatePlotPanel() {
         <SubmitResultCard
           mode="update"
           totalRequested={submitResult.totalRequested}
-          succeeded={submitResult.updated}
+          succeeded={submitResult.succeeded}
+          failed={submitResult.failed}
           onReset={handleReset}
         />
       )}

--- a/src/components/bulk-import/shared.tsx
+++ b/src/components/bulk-import/shared.tsx
@@ -166,10 +166,20 @@ export function ValidationErrorList({ errors }: ValidationErrorListProps) {
   );
 }
 
+export interface BulkFailureItem {
+  row: number;
+  plotNumber?: string | null;
+  error: {
+    message: string;
+    details?: Array<{ field?: string; message: string }>;
+  };
+}
+
 export interface SubmitResultCardProps {
   mode: 'create' | 'update';
   totalRequested: number;
   succeeded: number;
+  failed?: BulkFailureItem[];
   onReset: () => void;
 }
 
@@ -177,10 +187,32 @@ export function SubmitResultCard({
   mode,
   totalRequested,
   succeeded,
+  failed = [],
   onReset,
 }: SubmitResultCardProps) {
-  const title = mode === 'create' ? '一括登録が完了しました' : '一括編集が完了しました';
+  const allSucceeded = failed.length === 0;
+  const allFailed = succeeded === 0 && failed.length > 0;
+  const partial = !allSucceeded && !allFailed;
+
+  const title = allSucceeded
+    ? mode === 'create'
+      ? '一括登録が完了しました'
+      : '一括編集が完了しました'
+    : allFailed
+      ? mode === 'create'
+        ? '一括登録が失敗しました'
+        : '一括編集が失敗しました'
+      : mode === 'create'
+        ? '一括登録が部分的に完了しました'
+        : '一括編集が部分的に完了しました';
   const action = mode === 'create' ? '登録成功' : '更新成功';
+
+  const summaryClass = allSucceeded
+    ? 'bg-matsu-50 border-matsu-200'
+    : allFailed
+      ? 'bg-beni-50 border-beni-200'
+      : 'bg-kinari border-gin';
+  const titleClass = allSucceeded ? 'text-matsu' : allFailed ? 'text-beni' : 'text-sumi';
 
   return (
     <Card>
@@ -188,26 +220,69 @@ export function SubmitResultCard({
         <CardTitle className="text-lg">処理結果</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="p-6 bg-matsu-50 border border-matsu-200 rounded-lg text-center">
+        <div className={`p-6 border rounded-lg text-center ${summaryClass}`}>
           <svg
-            className="w-16 h-16 mx-auto mb-4 text-matsu"
+            className={`w-16 h-16 mx-auto mb-4 ${titleClass}`}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
             aria-hidden="true"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
+            {allSucceeded ? (
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            ) : (
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"
+              />
+            )}
           </svg>
-          <h3 className="text-xl font-semibold text-matsu mb-2">{title}</h3>
+          <h3 className={`text-xl font-semibold mb-2 ${titleClass}`}>{title}</h3>
           <p className="text-sumi">
             リクエスト数: {totalRequested}件 / {action}: {succeeded}件
+            {failed.length > 0 && ` / 失敗: ${failed.length}件`}
           </p>
         </div>
+
+        {failed.length > 0 && (
+          <div className="mt-6 p-4 bg-beni-50 border border-beni-200 rounded-lg">
+            <h4 className="font-semibold text-beni mb-2">
+              失敗した行 ({failed.length}件)
+              {partial && ' — 他行は正常に処理されました'}
+            </h4>
+            <ul className="space-y-1 max-h-96 overflow-y-auto">
+              {failed.slice(0, 100).map((f, idx) => (
+                <li key={idx} className="text-sm text-beni">
+                  行{f.row + 1}
+                  {f.plotNumber ? `（${f.plotNumber}）` : ''}: {f.error.message}
+                  {f.error.details && f.error.details.length > 0 && (
+                    <ul className="ml-4 text-xs opacity-80">
+                      {f.error.details.map((d, i) => (
+                        <li key={i}>
+                          {d.field ? `[${d.field}] ` : ''}
+                          {d.message}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              ))}
+              {failed.length > 100 && (
+                <li className="text-sm text-beni font-medium">
+                  ...他 {failed.length - 100} 件
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
+
         <div className="mt-6 flex justify-center">
           <Button onClick={onReset}>新しいファイルをアップロード</Button>
         </div>

--- a/src/lib/api/plots.ts
+++ b/src/lib/api/plots.ts
@@ -14,6 +14,8 @@ import {
   PaymentStatus,
   ContractStatus,
   ContractRole,
+  BulkCreatePlotsResponse,
+  BulkUpdatePlotsResponse,
 } from '@komine/types';
 import { apiGet, apiPost, apiPut, apiDelete, shouldUseMockData } from './client';
 import { ApiResponse } from './types';
@@ -553,15 +555,11 @@ export function sortPlotsByNumber(plots: PlotListItem[]): PlotListItem[] {
  * 区画情報の一括登録
  *
  * items は CreatePlotRequest 形式の配列。簡易用途として旧シグネチャ（4項目）にも対応。
- * バックエンドの対応フィールド拡充は zaitsu82/komine-crm-backend#74 で進行中。
+ * レスポンスは部分成功許容（issue #76 Phase 1）: failed[] に失敗行の詳細が入る。
  */
 export async function bulkCreatePlots(
   items: Array<Record<string, unknown>>
-): Promise<ApiResponse<{
-  totalRequested: number;
-  created: number;
-  results: Array<{ row: number; id: string; plotNumber: string; areaName: string }>;
-}>> {
+): Promise<ApiResponse<BulkCreatePlotsResponse>> {
   // 旧シグネチャ（{ plotNumber, areaName, areaSqm?, notes? }）との互換のため、
   // 平坦な形で渡された場合は physicalPlot にネストする
   const normalized = items.map((item) => {
@@ -585,17 +583,11 @@ export async function bulkCreatePlots(
  *
  * items の各要素は plotNumber を必須とし、その他のフィールドは部分更新。
  * 空欄（undefined）のフィールドは既存値を保持する。
- *
- * バックエンドエンドポイント PUT /api/v1/plots/bulk は
- * zaitsu82/komine-crm-backend#74 で実装予定。
+ * レスポンスは部分成功許容（issue #76 Phase 1）。
  */
 export async function bulkUpdatePlots(
   items: Array<{ plotNumber: string } & Record<string, unknown>>
-): Promise<ApiResponse<{
-  totalRequested: number;
-  updated: number;
-  results: Array<{ row: number; id: string; plotNumber: string }>;
-}>> {
+): Promise<ApiResponse<BulkUpdatePlotsResponse>> {
   return apiPut('/plots/bulk', { items });
 }
 


### PR DESCRIPTION
## Summary
- `bulkCreatePlots` / `bulkUpdatePlots` 戻り値型を `@komine/types` の `BulkCreatePlotsResponse` / `BulkUpdatePlotsResponse` に更新
- `BulkCreatePlotPanel` / `BulkUpdatePlotPanel` で `succeeded` / `failed[]` を扱う
- `SubmitResultCard` を拡張して **失敗行のリストを表示**（部分成功・全失敗のUI分岐追加）

## 背景
バックエンド Phase 1（zaitsu82/komine-crm-backend#76）でレスポンス形式が変わるため追従。

旧: `{ totalRequested, created/updated, results[] }`
新: `{ totalRequested, succeeded, failed: [{row, plotNumber, error}], results[] }`

## 依存
- [x] 先にマージ: zaitsu82/komine-types#8 （新レスポンス型を追加）
- [x] 先にマージ＆デプロイ: zaitsu82/komine-crm-backend#84

## Test plan
- [x] フロント 253 tests passing
- [x] lint 0 errors
- [ ] 手動: 一括登録で数件失敗を含むファイルをアップロード → 失敗行が一覧表示されること
- [ ] 手動: 全件成功時・全件失敗時のUI表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)