### PR TITLE
fix(ui): ダークモードでページヘッダーアイコンが白くぼやけて見える問題を修正

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,6 +113,8 @@ body {
   --gradient-matsu: linear-gradient(135deg, #2d5a3d 0%, #1e3d29 100%);
   --gradient-cha: linear-gradient(135deg, #8b7355 0%, #6b5a45 100%);
   --gradient-ai: linear-gradient(135deg, #264348 0%, #1a3033 100%);
+  --gradient-sumi: linear-gradient(135deg, #2c3139 0%, #1a1d23 100%);
+  --gradient-kohaku: linear-gradient(135deg, #a4863a 0%, #84692a 100%);
 }
 
 .dark {

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -5,21 +5,25 @@ import UserMenu from '@/components/user-menu';
 
 type ColorTheme = 'matsu' | 'cha' | 'ai' | 'sumi' | 'kohaku';
 
+// グラデーションは CSS 変数経由で定義されているため、ダークモードでも
+// ブランド色の深いグラデーションが維持される（`from-matsu` 等の
+// Tailwind ユーティリティはダーク反転で明るくなり、白アイコンが
+// 発光して見えにくくなるので使わない）。
 const themeStyles: Record<ColorTheme, { iconBg: string }> = {
   matsu: {
-    iconBg: 'bg-gradient-to-br from-matsu to-matsu-dark shadow-elegant-sm',
+    iconBg: 'bg-gradient-matsu shadow-elegant-sm',
   },
   cha: {
     iconBg: 'bg-gradient-cha shadow-cha',
   },
   ai: {
-    iconBg: 'bg-gradient-to-br from-ai to-ai-dark shadow-elegant-sm',
+    iconBg: 'bg-gradient-ai shadow-elegant-sm',
   },
   sumi: {
-    iconBg: 'bg-gradient-to-br from-sumi to-sumi-light shadow-elegant-sm',
+    iconBg: 'bg-gradient-sumi shadow-elegant-sm',
   },
   kohaku: {
-    iconBg: 'bg-gradient-to-br from-kohaku to-kohaku-dark shadow-elegant-sm',
+    iconBg: 'bg-gradient-kohaku shadow-elegant-sm',
   },
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -193,6 +193,8 @@ const config: Config = {
         'gradient-matsu': 'var(--gradient-matsu)',
         'gradient-cha': 'var(--gradient-cha)',
         'gradient-ai': 'var(--gradient-ai)',
+        'gradient-sumi': 'var(--gradient-sumi)',
+        'gradient-kohaku': 'var(--gradient-kohaku)',
       },
     },
   },


### PR DESCRIPTION
## 概要
ダークモードで各画面のページヘッダー左上のアイコンが白くぼやけて視認性が低い問題を修正。

## 原因
`PageHeader` コンポーネントのアイコン背景に `bg-gradient-to-br from-matsu to-matsu-dark` のような Tailwind ユーティリティを使っていた。ダークモードでは `--color-matsu` や `--color-ai` 等のブランド色変数が**アクセント色として読みやすいように明るい値へ反転**される（例: `#7db190`, `#8fb0b6`）。結果として、ダークモード時は:

- 明るい薄緑/薄青のグラデーション背景
- その上に `text-white` の SVG アイコン
- 白 on 薄色 = 発光した白にしか見えない

という状態になっていた。影響画面:

- マスタ管理（sumi theme）
- スタッフ管理（ai theme）
- ゆうちょ連携（ai theme）
- 一括登録・一括編集（ai theme）
- その他 PageHeader を使う全画面

## 修正方針
CSS 変数ベースの `bg-gradient-matsu` / `bg-gradient-ai` / `bg-gradient-sumi` / `bg-gradient-kohaku` を使うように統一。これらの変数は `:root` で深いブランド色グラデーション（例: `matsu: #2d5a3d → #1e3d29`）を定義しており、`.dark` で上書きしないため、ダークモードでも同じ深い色が維持される。`theme="cha"` は既にこの方式で実装されていた（cha同様の設計に統一した形）。

### 変更ファイル
- `src/app/globals.css` — `--gradient-sumi`, `--gradient-kohaku` を追加
- `tailwind.config.ts` — `bg-gradient-sumi`, `bg-gradient-kohaku` を登録
- `src/components/page-header.tsx` — 全 theme を CSS 変数ベースに統一

## 動作確認
ダークモードで各画面をブラウザで確認し、ヘッダーアイコンが深いブランド色の背景に白SVGでクリアに表示されることを確認済み。

- [x] マスタ管理: アイコンがダークグレー背景に白くクリアに表示
- [x] スタッフ管理: アイコンがダークティール背景に白くクリアに表示
- [x] ゆうちょ連携: 同上
- [x] 一括登録・一括編集: 同上

## 残作業（別PR候補）
他にも以下の箇所で同じ `from-matsu` 等のパターンが使われており、ダークモードで同様の問題が出る可能性あり（今回は報告された画面に絞って対応）:

- `src/components/plot-list-table.tsx:188` — 区画リストの行アイコン
- `src/components/plot-availability-management.tsx:346-350` — 区画残数管理の期別カラーチップ
- `src/components/collective-burial/ListView.tsx:277,408` — 合祀管理のリストヘッダー

🤖 Generated with [Claude Code](https://claude.com/claude-code)