### PR TITLE
fix(ui): 合祀管理の年次ヘッダーバーがダークモードで発光して見える問題を修正

### DIFF
--- a/src/components/collective-burial/ListView.tsx
+++ b/src/components/collective-burial/ListView.tsx
@@ -274,7 +274,7 @@ export default function CollectiveBurialListView({
         {/* 今年の請求対象者サマリカード */}
         <div className="px-3 md:px-6 pt-3 md:pt-6">
           <div className="bg-white rounded-elegant-lg shadow-elegant overflow-hidden border-2 border-matsu-300">
-            <div className="bg-gradient-to-r from-matsu to-matsu-light px-4 md:px-6 py-3 md:py-4 relative overflow-hidden">
+            <div className="bg-gradient-matsu px-4 md:px-6 py-3 md:py-4 relative overflow-hidden">
               <div className="absolute top-0 right-0 w-40 h-40 bg-white/5 rounded-full -translate-y-1/2 translate-x-1/2" />
               <div className="relative flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2 md:gap-3 min-w-0">
@@ -405,7 +405,7 @@ export default function CollectiveBurialListView({
                   {/* 年ヘッダー */}
                   <div
                     className={`px-3 md:px-6 py-3 md:py-4 relative overflow-hidden ${
-                      isCurrentYear ? 'bg-gradient-to-r from-matsu to-matsu-light' : 'bg-gradient-cha'
+                      isCurrentYear ? 'bg-gradient-matsu' : 'bg-gradient-cha'
                     }`}
                   >
                     <div className="absolute top-0 right-0 w-32 h-32 bg-white/5 rounded-full -translate-y-1/2 translate-x-1/2" />


### PR DESCRIPTION
## 概要
合祀管理画面で「今年 2026年 請求対象者」の緑色グラデーションヘッダーバーが、ダークモード時に白文字と合わさって発光したように見えて視認性が低い問題を修正。

## スクリーンショット（発生画面）
キャプチャ: `komine-docs/キャプチャ/image.png`

## 原因
`src/components/collective-burial/ListView.tsx` の2箇所で `bg-gradient-to-r from-matsu to-matsu-light` を使用していた。ダークモードでは以下のように色が反転される:

- `--color-matsu` → `#7db190` (明るい薄緑)
- `--color-matsu-light` → `#a8cbb5` (さらに薄い緑)

結果: 明るいグラデーション背景に白テキスト → 発光して見える

## 修正
CSS 変数ベースの `bg-gradient-matsu` (定義: `linear-gradient(135deg, #2d5a3d 0%, #1e3d29 100%)`) に変更。`:root` で深い松葉色を定義しており、`.dark` で上書きしないのでダークモードでも同じ濃い緑色が維持される。

- `collective-burial/ListView.tsx:277` — 今年の請求対象者サマリカード
- `collective-burial/ListView.tsx:408` — 年別グループヘッダー (isCurrentYear の場合)

## 関連PR
同じパターン（Tailwind の `from-xxx` ユーティリティ経由のブランド色グラデーションがダークモードで白く発光する）は、PageHeaderでも発生しており別PRで対応中: #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)