### PR TITLE
feat(staff): 招待メール再送ボタンをスタッフ管理画面に追加 (Refs #94)

### DIFF
--- a/src/__tests__/lib/api/staff-resend.test.ts
+++ b/src/__tests__/lib/api/staff-resend.test.ts
@@ -1,0 +1,80 @@
+import { resendInvitation } from '@/lib/api/staff';
+
+const apiPostMock = jest.fn();
+const shouldUseMockDataMock = jest.fn();
+
+jest.mock('@/lib/api/client', () => ({
+  apiGet: jest.fn(),
+  apiPost: (...args: unknown[]) => apiPostMock(...args),
+  apiPut: jest.fn(),
+  apiDelete: jest.fn(),
+  shouldUseMockData: () => shouldUseMockDataMock(),
+}));
+
+describe('resendInvitation', () => {
+  beforeEach(() => {
+    apiPostMock.mockReset();
+    shouldUseMockDataMock.mockReset();
+  });
+
+  describe('real API', () => {
+    beforeEach(() => {
+      shouldUseMockDataMock.mockReturnValue(false);
+    });
+
+    it('POST /staff/:id/resend-invitation を呼び出す', async () => {
+      apiPostMock.mockResolvedValue({
+        success: true,
+        data: { message: '招待メールを再送信しました' },
+      });
+
+      const result = await resendInvitation(42);
+
+      expect(apiPostMock).toHaveBeenCalledWith('/staff/42/resend-invitation');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.message).toBe('招待メールを再送信しました');
+      }
+    });
+
+    it('エラーレスポンスをそのまま返す', async () => {
+      apiPostMock.mockResolvedValue({
+        success: false,
+        error: { code: 'NOT_FOUND', message: 'スタッフが見つかりません' },
+      });
+
+      const result = await resendInvitation(999);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error?.code).toBe('NOT_FOUND');
+      }
+    });
+  });
+
+  describe('mock mode', () => {
+    beforeEach(() => {
+      shouldUseMockDataMock.mockReturnValue(true);
+    });
+
+    it('存在するID(1)で成功レスポンスを返し、APIは呼ばれない', async () => {
+      const result = await resendInvitation(1);
+
+      expect(apiPostMock).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.message).toBe('招待メールを再送信しました');
+      }
+    });
+
+    it('存在しないIDでNOT_FOUNDを返す', async () => {
+      const result = await resendInvitation(99999);
+
+      expect(apiPostMock).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error?.code).toBe('NOT_FOUND');
+      }
+    });
+  });
+});

--- a/src/components/staff-management.tsx
+++ b/src/components/staff-management.tsx
@@ -15,6 +15,7 @@ import {
   updateStaff as apiUpdateStaff,
   deleteStaff as apiDeleteStaff,
   toggleStaffActive as apiToggleStaffActive,
+  resendInvitation as apiResendInvitation,
   StaffListItem,
   CreateStaffRequest,
   UpdateStaffRequest,
@@ -129,6 +130,9 @@ export default function StaffManagement() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [staffToDelete, setStaffToDelete] = useState<StaffListItem | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // 招待メール再送
+  const [resendingStaffId, setResendingStaffId] = useState<number | null>(null);
 
   // スタッフ一覧を取得
   const fetchStaffList = useCallback(async () => {
@@ -360,6 +364,29 @@ export default function StaffManagement() {
       }
     } catch {
       showError('状態の変更中にエラーが発生しました');
+    }
+  };
+
+  // 招待メール再送
+  const handleResendInvitation = async (staff: StaffListItem) => {
+    if (!window.confirm(`${staff.name}（${staff.email}）に招待メールを再送しますか？`)) {
+      return;
+    }
+
+    setResendingStaffId(staff.id);
+
+    try {
+      const response = await apiResendInvitation(staff.id);
+
+      if (response.success) {
+        showSuccess(`${staff.name}に招待メールを再送しました`);
+      } else {
+        showApiError('招待メールの再送', response.error?.message, response.error?.details);
+      }
+    } catch {
+      showError('招待メールの再送中にエラーが発生しました');
+    } finally {
+      setResendingStaffId(null);
     }
   };
 
@@ -729,12 +756,20 @@ export default function StaffManagement() {
                       </td>
                       {isAdminUser && (
                         <td className="px-4 py-3 text-center">
-                          <div className="flex items-center justify-center gap-2">
+                          <div className="flex items-center justify-center gap-2 flex-wrap">
                             <button
                               onClick={() => handleOpenEditDialog(staff)}
                               className="border border-gin text-sumi hover:bg-kinari rounded-elegant px-3 py-1.5 transition-all duration-200 text-xs font-medium"
                             >
                               編集
+                            </button>
+                            <button
+                              onClick={() => handleResendInvitation(staff)}
+                              disabled={resendingStaffId === staff.id}
+                              className="border border-ai text-ai hover:bg-ai-50 rounded-elegant px-3 py-1.5 transition-all duration-200 text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                              title="パスワード未設定のスタッフに招待メールを再送します"
+                            >
+                              {resendingStaffId === staff.id ? '再送中...' : '招待再送'}
                             </button>
                             <button
                               onClick={() => handleToggleActive(staff)}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -78,6 +78,7 @@ export {
   updateStaff,
   deleteStaff,
   toggleStaffActive,
+  resendInvitation,
   ROLE_LABELS,
 } from './staff';
 export type {
@@ -88,6 +89,7 @@ export type {
   CreateStaffRequest,
   UpdateStaffRequest,
   ToggleActiveResponse,
+  ResendInvitationResponse,
   StaffSearchParams,
 } from './staff';
 

--- a/src/lib/api/staff.ts
+++ b/src/lib/api/staff.ts
@@ -61,6 +61,11 @@ export interface ToggleActiveResponse {
   message: string;
 }
 
+// 招待メール再送レスポンス
+export interface ResendInvitationResponse {
+  message: string;
+}
+
 // スタッフ検索パラメータ
 export interface StaffSearchParams {
   page?: number;
@@ -299,6 +304,32 @@ async function mockDeleteStaff(id: number): Promise<ApiResponse<{ message: strin
 }
 
 /**
+ * モック: 招待メール再送信
+ */
+async function mockResendInvitation(id: number): Promise<ApiResponse<ResendInvitationResponse>> {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  const staff = MOCK_STAFF.find((s) => s.id === id);
+
+  if (!staff) {
+    return {
+      success: false,
+      error: {
+        code: 'NOT_FOUND',
+        message: 'スタッフが見つかりません',
+      },
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      message: '招待メールを再送信しました',
+    },
+  };
+}
+
+/**
  * モック: スタッフ有効/無効切り替え
  */
 async function mockToggleStaffActive(id: number): Promise<ApiResponse<ToggleActiveResponse>> {
@@ -426,4 +457,15 @@ export async function toggleStaffActive(id: number): Promise<ApiResponse<ToggleA
   }
 
   return apiPut<ToggleActiveResponse>(`/staff/${id}/toggle-active`);
+}
+
+/**
+ * 招待メール再送信
+ */
+export async function resendInvitation(id: number): Promise<ApiResponse<ResendInvitationResponse>> {
+  if (shouldUseMockData()) {
+    return mockResendInvitation(id);
+  }
+
+  return apiPost<ResendInvitationResponse>(`/staff/${id}/resend-invitation`);
 }


### PR DESCRIPTION
## Summary
- バックエンドの `POST /staff/:id/resend-invitation`（admin のみ）はあったが、フロントから呼べる動線が無かったため追加
- スタッフ管理画面の操作列に「招待再送」ボタンを追加。confirm → API 呼び出し → 成功/失敗トースト
- issue #94 の「トークン期限切れ時のUX確認（エラーメッセージ、再送動線）」残項目に対応

## 変更内容
- `src/lib/api/staff.ts` — `resendInvitation(id)` + mock 実装 + `ResendInvitationResponse` 型
- `src/lib/api/index.ts` — barrel から re-export
- `src/components/staff-management.tsx` — 操作列に「招待再送」ボタン追加、再送中は disable
- `src/__tests__/lib/api/staff-resend.test.ts` — 4件のユニットテスト（real API × 2, mock × 2）

## 補足
- 招待メール再送はパスワード未設定のスタッフが対象だが、UI上はパスワード設定状態を判定できる情報（`supabase_uid` が `pending_` プレフィックスか等）が `StaffListItem` に含まれていないため、全スタッフに対してボタンを表示。バックエンド側は既存ユーザーでも Supabase の再送APIが処理するので、誤ってクリックしても安全
- confirm ダイアログは `window.confirm` を使用。既存の削除確認ダイアログとパターンを合わせる場合は別途リファクタ推奨

## Test plan
- [x] `npm test` → 268/268 pass（`staff-resend.test.ts` 4件含む）
- [x] `npm run lint` → 0 errors（warnings は既存）
- [ ] 実環境で admin ログイン → /staff → 招待再送ボタンクリック → トースト表示確認
- [ ] 非 admin で /staff を閲覧しても操作列が表示されないこと（既存挙動）

Refs #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)