### PR TITLE
feat(ui): UI/UXフェーズ1 — デザインシステム基盤整備

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,50 @@ const { user, login, logout, isAuthenticated } = useAuth();
 - `Dialog` - モーダルダイアログ
 - `Table` - テーブル
 - `Tabs` - タブ
+- `StatCard` - KPI/統計値表示カード（`theme`: matsu/cha/ai/kohaku/beni/sumi）
+- `EmptyState` - データ0件時の空状態表示（icon + title + description + action）
+- `StatusBadge` - 支払い/契約/区画状態バッジ（色+パターン記号で色覚対応）
+- `PageSection` - セクション見出し+コンテンツの統一レイアウト
+
+### デザインシステム（カラー・タイポグラフィ）
+
+#### 和モダンカラートークン
+
+全トークンは`globals.css`でCSS変数として定義、`tailwind.config.ts`で参照。ライト/ダークモード自動切替。
+
+| トークン | 用途 | 例 |
+|---|---|---|
+| `matsu`（松葉） | プライマリ（主要アクション） | `bg-matsu`（ボタン）、`text-matsu`（リンク） |
+| `cha`（茶） | セカンダリ | `bg-cha-50 border-cha-200`（情報カード） |
+| `ai`（藍） | アクセント・情報系 | 情報タイプバッジ、リンク強調 |
+| `kohaku`（琥珀） | 警告・未完了 | 「未入金」「要対応」 |
+| `beni`（紅） | エラー・破壊的操作 | 「滞納」「削除」 |
+| `sumi`（墨） | テキスト（本文） | `text-sumi` |
+| `hai`（灰） | テキスト（補足・muted） | `text-hai` |
+| `gin`（銀） | ボーダー | `border-gin` |
+| `shiro`（白） | カード背景 | `bg-shiro`、`bg-white` |
+| `kinari`（生成） | muted背景 | `bg-kinari` |
+
+**shadcn互換エイリアス**（新規shadcn系コンポーネント用）: `card` / `muted` / `input` / `ring` / `destructive` など
+
+#### 使用ルール
+
+- **Tailwind標準色（`gray-*`/`red-*`/`green-*`等）は極力使わない**。既存の和モダントークンに置き換える（既存コードで混在しているのは徐々に置換）
+- **状態色は `StatusBadge` 経由**で表現する。生の `bg-red-*` 等を直接使わない
+- **新規コンポーネントは `StatCard` / `EmptyState` / `StatusBadge` / `PageSection` を再利用**してスタイルを統一
+
+#### タイポグラフィ
+
+| 種類 | Tailwindクラス | 用途 |
+|---|---|---|
+| 明朝 | `font-mincho` | 見出し（h1〜h3）、タイトル |
+| ゴシック（デフォルト） | `font-sans` | 本文・ラベル |
+| 等幅数字 | `tabular-nums` | 金額・数値（ゼロ幅揃え） |
+
+ルール:
+- **明朝は見出しのみ**。本文で使うと可読性低下
+- **数値は必ず `tabular-nums`** を付ける（特にテーブルのカラム揃え）
+- フォントサイズはモバイルベース（`text-xs` → `md:text-sm` のように段階的に）
 
 ### カスタムフック
 

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const emptyStateVariants = cva(
+  'flex flex-col items-center justify-center text-center',
+  {
+    variants: {
+      size: {
+        sm: 'py-8 px-4 gap-2',
+        default: 'py-12 px-6 gap-3',
+        lg: 'py-16 px-8 gap-4',
+      },
+      container: {
+        bordered: 'rounded-elegant-lg border border-dashed border-gin bg-kinari/40',
+        plain: '',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+      container: 'bordered',
+    },
+  }
+);
+
+export interface EmptyStateProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof emptyStateVariants> {
+  icon?: React.ReactNode;
+  title: string;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+}
+
+const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
+  ({ className, size, container, icon, title, description, action, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        role="status"
+        aria-live="polite"
+        className={cn(emptyStateVariants({ size, container }), className)}
+        {...props}
+      >
+        {icon && (
+          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-kinari text-hai" aria-hidden="true">
+            {icon}
+          </div>
+        )}
+        <div className="space-y-1">
+          <p className="font-mincho text-base md:text-lg text-sumi">{title}</p>
+          {description && (
+            <p className="text-xs md:text-sm text-hai max-w-md">{description}</p>
+          )}
+        </div>
+        {action && <div className="mt-2">{action}</div>}
+      </div>
+    );
+  }
+);
+EmptyState.displayName = 'EmptyState';
+
+export { EmptyState, emptyStateVariants };

--- a/src/components/ui/page-section.tsx
+++ b/src/components/ui/page-section.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const pageSectionVariants = cva('rounded-elegant-lg border border-gin bg-white', {
+  variants: {
+    padding: {
+      none: '',
+      sm: 'p-3 md:p-4',
+      default: 'p-4 md:p-6',
+      lg: 'p-6 md:p-8',
+    },
+  },
+  defaultVariants: {
+    padding: 'default',
+  },
+});
+
+export interface PageSectionProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'title'>,
+    VariantProps<typeof pageSectionVariants> {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  icon?: React.ReactNode;
+  action?: React.ReactNode;
+  /** セクションヘッダーの左にブランドカラーの縦線を表示 */
+  accent?: 'matsu' | 'cha' | 'ai' | 'kohaku' | 'beni' | false;
+}
+
+const ACCENT_CLASS: Record<Exclude<PageSectionProps['accent'], false | undefined>, string> = {
+  matsu: 'border-l-matsu',
+  cha: 'border-l-cha',
+  ai: 'border-l-ai',
+  kohaku: 'border-l-kohaku',
+  beni: 'border-l-beni',
+};
+
+const PageSection = React.forwardRef<HTMLElement, PageSectionProps>(
+  ({ className, padding, title, description, icon, action, accent = 'matsu', children, ...props }, ref) => {
+    const hasHeader = Boolean(title || description || icon || action);
+    return (
+      <section
+        ref={ref}
+        className={cn(pageSectionVariants({ padding }), className)}
+        {...props}
+      >
+        {hasHeader && (
+          <header
+            className={cn(
+              'mb-4 flex items-start justify-between gap-3 pl-3 border-l-4',
+              accent ? ACCENT_CLASS[accent] : 'border-l-transparent'
+            )}
+          >
+            <div className="flex items-start gap-2 min-w-0">
+              {icon && <div className="mt-0.5 text-matsu flex-shrink-0">{icon}</div>}
+              <div className="min-w-0">
+                {title && (
+                  <h3 className="font-mincho text-base md:text-lg font-semibold text-sumi truncate">
+                    {title}
+                  </h3>
+                )}
+                {description && (
+                  <p className="text-xs md:text-sm text-hai mt-0.5">{description}</p>
+                )}
+              </div>
+            </div>
+            {action && <div className="flex-shrink-0">{action}</div>}
+          </header>
+        )}
+        {children}
+      </section>
+    );
+  }
+);
+PageSection.displayName = 'PageSection';
+
+export { PageSection, pageSectionVariants };

--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const statCardVariants = cva(
+  'relative rounded-elegant-lg border bg-white p-4 md:p-5 transition-all duration-250 ease-elegant',
+  {
+    variants: {
+      theme: {
+        matsu: 'border-matsu-100',
+        cha: 'border-cha-100',
+        ai: 'border-ai-100',
+        kohaku: 'border-kohaku-100',
+        beni: 'border-beni-100',
+        sumi: 'border-gin',
+      },
+      interactive: {
+        true: 'cursor-pointer hover:shadow-elegant hover:-translate-y-0.5',
+        false: 'shadow-elegant-sm',
+      },
+    },
+    defaultVariants: {
+      theme: 'sumi',
+      interactive: false,
+    },
+  }
+);
+
+const iconWrapperVariants = cva(
+  'inline-flex items-center justify-center w-8 h-8 md:w-9 md:h-9 rounded-lg flex-shrink-0',
+  {
+    variants: {
+      theme: {
+        matsu: 'bg-matsu-50 text-matsu',
+        cha: 'bg-cha-50 text-cha',
+        ai: 'bg-ai-50 text-ai',
+        kohaku: 'bg-kohaku-50 text-kohaku-dark',
+        beni: 'bg-beni-50 text-beni',
+        sumi: 'bg-kinari text-sumi',
+      },
+    },
+    defaultVariants: {
+      theme: 'sumi',
+    },
+  }
+);
+
+export interface StatCardProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof statCardVariants> {
+  label: string;
+  value: React.ReactNode;
+  unit?: string;
+  description?: React.ReactNode;
+  icon?: React.ReactNode;
+}
+
+const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
+  ({ className, theme, interactive, label, value, unit, description, icon, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(statCardVariants({ theme, interactive }), className)}
+        {...props}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-xs md:text-sm text-hai truncate">{label}</p>
+            <div className="mt-1.5 flex items-baseline gap-1">
+              <span className="text-xl md:text-2xl font-semibold text-sumi tabular-nums">
+                {value}
+              </span>
+              {unit && <span className="text-xs md:text-sm text-hai">{unit}</span>}
+            </div>
+            {description && (
+              <p className="mt-1 text-xs text-hai truncate">{description}</p>
+            )}
+          </div>
+          {icon && <div className={cn(iconWrapperVariants({ theme }))}>{icon}</div>}
+        </div>
+      </div>
+    );
+  }
+);
+StatCard.displayName = 'StatCard';
+
+export { StatCard, statCardVariants };

--- a/src/components/ui/status-badge.tsx
+++ b/src/components/ui/status-badge.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+/**
+ * StatusBadge — 支払い・契約・区画状態などのステータス表示を統一。
+ * 色のみに依存せず、記号（●▲■◆○）で色覚多様性にも対応する。
+ */
+const statusBadgeVariants = cva(
+  'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap',
+  {
+    variants: {
+      variant: {
+        // 支払い・入金系
+        paid: 'bg-matsu-50 text-matsu-dark border-matsu-200',
+        unpaid: 'bg-kohaku-50 text-kohaku-dark border-kohaku-200',
+        partial: 'bg-ai-50 text-ai border-ai-200',
+        overdue: 'bg-beni-50 text-beni border-beni-200',
+        refunded: 'bg-kinari text-hai-dark border-gin',
+        cancelled: 'bg-kinari text-hai border-gin line-through',
+        // 契約・区画状態
+        active: 'bg-matsu-50 text-matsu-dark border-matsu-200',
+        pending: 'bg-kohaku-50 text-kohaku-dark border-kohaku-200',
+        sold: 'bg-beni-50 text-beni border-beni-200',
+        available: 'bg-shiro text-hai border-gin',
+        // 汎用
+        info: 'bg-ai-50 text-ai border-ai-200',
+        warning: 'bg-kohaku-50 text-kohaku-dark border-kohaku-200',
+        error: 'bg-beni-50 text-beni border-beni-200',
+        success: 'bg-matsu-50 text-matsu-dark border-matsu-200',
+        neutral: 'bg-kinari text-hai-dark border-gin',
+      },
+      size: {
+        sm: 'text-[10px] px-1.5 py-0.5',
+        default: 'text-xs px-2 py-0.5',
+        lg: 'text-sm px-2.5 py-1',
+      },
+    },
+    defaultVariants: {
+      variant: 'neutral',
+      size: 'default',
+    },
+  }
+);
+
+// バリアントごとのパターン記号（色覚多様性対応）
+const VARIANT_SYMBOLS: Record<NonNullable<StatusBadgeProps['variant']>, string> = {
+  paid: '●',
+  unpaid: '▲',
+  partial: '◐',
+  overdue: '■',
+  refunded: '↩',
+  cancelled: '×',
+  active: '●',
+  pending: '▲',
+  sold: '■',
+  available: '○',
+  info: 'ⓘ',
+  warning: '▲',
+  error: '■',
+  success: '●',
+  neutral: '・',
+};
+
+export interface StatusBadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof statusBadgeVariants> {
+  /** true にすると variant に応じたパターン記号を自動で先頭に表示 */
+  withSymbol?: boolean;
+}
+
+const StatusBadge = React.forwardRef<HTMLSpanElement, StatusBadgeProps>(
+  ({ className, variant, size, withSymbol, children, ...props }, ref) => {
+    const symbol = withSymbol && variant ? VARIANT_SYMBOLS[variant] : null;
+    return (
+      <span
+        ref={ref}
+        className={cn(statusBadgeVariants({ variant, size }), className)}
+        {...props}
+      >
+        {symbol && <span aria-hidden="true">{symbol}</span>}
+        <span>{children}</span>
+      </span>
+    );
+  }
+);
+StatusBadge.displayName = 'StatusBadge';
+
+export { StatusBadge, statusBadgeVariants };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -150,7 +150,25 @@ const config: Config = {
           'text': 'var(--color-sumi)',
           'bg-light': 'var(--color-shiro)',
           'border': 'var(--color-gin)',
-        }
+        },
+
+        // ===============================================================
+        // Semantic tokens (shadcn互換エイリアス)
+        // 和モダントークン（shiro/kinari/sumi/hai/gin/beni）の用途別別名。
+        // これらは新規 shadcn 系コンポーネント実装時に使う。
+        // 既存コンポーネントで和モダントークンを直接使っている箇所は
+        // そのままでOK（どちらも同じCSS変数を参照）。
+        // ===============================================================
+        'card': 'var(--color-shiro)',              // カード背景 = 白
+        'card-foreground': 'var(--color-sumi)',    // カード上のテキスト
+        'muted': 'var(--color-kinari)',            // muted背景 = 生成色
+        'muted-foreground': 'var(--color-hai)',    // muted背景上のテキスト = 灰
+        'popover': 'var(--color-shiro)',           // ポップオーバー背景
+        'popover-foreground': 'var(--color-sumi)',
+        'input': 'var(--color-gin)',               // 入力フィールドボーダー
+        'ring': 'var(--color-matsu)',              // フォーカスリング
+        'destructive': 'var(--color-beni)',        // 破壊的アクション（削除等）
+        'destructive-foreground': '#ffffff',
       },
       // タッチ対応の最小タップサイズ
       spacing: {


### PR DESCRIPTION
親issue: #100
Refs: #101

## Summary

UI/UX全体診断（#100）で抽出した改善計画の **フェーズ1** を実施。
今後のUI改修を速くするための共通プリミティブとデザイントークンの土台を整備した。

- 和モダンのカラートークン（松葉/茶/藍/紅/琥珀）を使った共通UIプリミティブ4つを追加
- shadcn互換のsemantic token（card/muted/input/ring等）をTailwindに追加
- `CLAUDE.md` にデザインシステム使用ルールを明文化

## 変更内容

### 追加ファイル

| ファイル | 内容 |
|---|---|
| `src/components/ui/stat-card.tsx` | KPI/統計値カード。`theme` propで6種類のブランドカラーに対応 |
| `src/components/ui/empty-state.tsx` | データ0件時の統一表示（icon + title + description + action） |
| `src/components/ui/status-badge.tsx` | 状態バッジ15バリアント。色+パターン記号（●▲■◐○）で色覚多様性対応 |
| `src/components/ui/page-section.tsx` | セクション見出し+コンテンツ。ブランドカラーの縦線アクセント付き |

### 修正ファイル

- `tailwind.config.ts` — shadcn互換 semantic token エイリアス追加
- `CLAUDE.md` — デザインシステムセクション（カラートークン用途・タイポグラフィルール）追記

## 影響範囲

新規ファイルの追加と config/ドキュメントの追記のみ。**既存コンポーネントには一切変更なし**。
既存の `bg-matsu` / `text-sumi` 等のクラス名もそのまま使える（エイリアスは並列定義）。

## スコープ外（follow-up）

`#101` のチェックリストのうち、以下は影響範囲が広いため別PRで画面単位に切り分けて対応する：
- `gray-*` 等のTailwind標準色を和モダントークンに置換
- `globals.css` の `!important` 上書き削減

## Test plan

- [x] `npx tsc --noEmit` で新規コンポーネントに型エラーなし（既存テストファイルの別エラーは本PR対象外）
- [x] `npx eslint` で新規コンポーネントに lint エラーなし
- [ ] マージ後、フェーズ2（#102）で新プリミティブを実際に使用して動作確認
- [ ] 後続PRでダークモード表示の目視チェック

🤖 Generated with [Claude Code](https://claude.com/claude-code)