### PR TITLE
fix(ui): StatCardのダークモード視認性改善 (Phase 1 フォローアップ)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -134,45 +134,45 @@ body {
   --color-shiro: #1a1d23;
   --color-kinari: #1a1d23;
 
-  /* 松葉色 - ダーク */
+  /* 松葉色 - ダーク（カード背景 #1a1d23 と区別できる明度に調整） */
   --color-matsu: #7db190;
   --color-matsu-light: #a8cbb5;
   --color-matsu-dark: #7db190;
-  --color-matsu-50: #15241b;
-  --color-matsu-100: #1c3325;
-  --color-matsu-200: #1e3d29;
+  --color-matsu-50: #213828;
+  --color-matsu-100: #2a4434;
+  --color-matsu-200: #365542;
   /* 300-900 はアクセント色のためライトと同値を維持 */
 
   /* 茶色 - ダーク */
   --color-cha: #c4b095;
   --color-cha-light: #d9ccba;
   --color-cha-dark: #c4b095;
-  --color-cha-50: #2a221a;
-  --color-cha-100: #3a2f23;
+  --color-cha-50: #322820;
+  --color-cha-100: #453929;
   --color-cha-200: #5f503b;
 
   /* 藍色 - ダーク */
   --color-ai: #8fb0b6;
   --color-ai-light: #a3b3b7;
   --color-ai-dark: #8fb0b6;
-  --color-ai-50: #142225;
-  --color-ai-100: #1b2e32;
-  --color-ai-200: #1a3033;
+  --color-ai-50: #1e2e33;
+  --color-ai-100: #273b40;
+  --color-ai-200: #355056;
 
   /* 紅色 - ダーク */
   --color-beni: #db8585;
   --color-beni-light: #e8a8a8;
   --color-beni-dark: #db8585;
-  --color-beni-50: #2a1515;
-  --color-beni-100: #3a1d1d;
+  --color-beni-50: #331c1c;
+  --color-beni-100: #4a2828;
   --color-beni-200: #5b2626;
 
   /* 琥珀色 - ダーク */
   --color-kohaku: #d4b87a;
   --color-kohaku-light: #f2d98f;
   --color-kohaku-dark: #d4b87a;
-  --color-kohaku-50: #2a230f;
-  --color-kohaku-100: #3a3015;
+  --color-kohaku-50: #342b14;
+  --color-kohaku-100: #4a3c20;
   --color-kohaku-200: #644c1a;
 
   /* グラデーション - ダーク */

--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -36,7 +36,8 @@ const iconWrapperVariants = cva(
         ai: 'bg-ai-50 text-ai',
         kohaku: 'bg-kohaku-50 text-kohaku-dark',
         beni: 'bg-beni-50 text-beni',
-        sumi: 'bg-kinari text-sumi',
+        // sumi: bg-kinari はダークでカード背景と同色になるため hai-50 に差し替え
+        sumi: 'bg-kinari dark:bg-hai-50 text-sumi',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## 背景

Phase 1 (#101) でマージ済みの共通プリミティブについて、マージ後のダークモード検証で StatCard に視認性の問題が見つかったためフォローアップ対応。

前セッションの引き継ぎメモ ([#101 コメント](https://github.com/zaitsu82/komine-crm-frontend/issues/101)) に記載されていた3つの問題を解消する。

## 修正内容

### 1. `.dark` セクションの -50/-100/-200 シェードを再調整

ダーク時のカード背景 (`--color-shiro` = `#1a1d23`) との輝度差が小さすぎて、
アイコンボックスや淡色背景、ボーダーが「カード内に沈む」状態だった。
`matsu` / `cha` / `ai` / `kohaku` / `beni` の -50/-100/-200 を全体的に明るめへ調整：

| トークン | Before | After |
|---|---|---|
| `--color-matsu-50` | `#15241b` | `#213828` |
| `--color-matsu-100` | `#1c3325` | `#2a4434` |
| `--color-matsu-200` | `#1e3d29` | `#365542` |
| `--color-cha-50` | `#2a221a` | `#322820` |
| `--color-cha-100` | `#3a2f23` | `#453929` |
| `--color-ai-50` | `#142225` | `#1e2e33` |
| `--color-ai-100` | `#1b2e32` | `#273b40` |
| `--color-ai-200` | `#1a3033` | `#355056` |
| `--color-kohaku-50` | `#2a230f` | `#342b14` |
| `--color-kohaku-100` | `#3a3015` | `#4a3c20` |
| `--color-beni-50` | `#2a1515` | `#331c1c` |
| `--color-beni-100` | `#3a1d1d` | `#4a2828` |

これにより StatCard だけでなく `bg-{color}-50/100` / `border-{color}-100` を使う
他コンポーネント（`bulk-import`、`plot-form`、`yucho` 等）のダーク表示も副次的に改善される。

### 2. `sumi` テーマのアイコン背景を dark 時に差し替え

`bg-kinari` はダークで `#1a1d23`（カード背景と同色）になり sumi テーマのアイコンボックスが
完全に消えていた。`dark:bg-hai-50` (= `#232730`) を追加して解消。

```tsx
sumi: 'bg-kinari dark:bg-hai-50 text-sumi',
```

## 検証

`ui-playground` + `scripts/playground-screenshots.js` で Playwright 経由にライト/ダーク両方の
スクショを取得し、以下を確認：

- [x] sumi テーマのアイコンボックスがダークでも見える
- [x] matsu / cha / ai / kohaku / beni 全てアイコン背景が識別できる
- [x] カードのボーダーがカード背景と区別できる
- [x] ライトモードに視認性回帰が発生していない

検証用ファイル (`src/app/ui-playground/`、`scripts/playground-screenshots.js`、
`komine-docs/ui-audit/playground/`) は確認後に削除済み。

## 関連

- Fixes: #101 (Phase 1 フォローアップ)
- 次フェーズ: #102 (Phase 2 — モバイルテーブル / StatusBadge 適用 / EmptyState 適用 / サマリーカード)

🤖 Generated with [Claude Code](https://claude.com/claude-code)