### PR TITLE
fix(ui): UI/UXフェーズ2 P0問題の即時対応

### DIFF
--- a/src/components/collective-burial/ListView.tsx
+++ b/src/components/collective-burial/ListView.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { EmptyState } from '@/components/ui/empty-state';
 import {
   useCollectiveBurialList,
   useCollectiveBurialStats,
@@ -296,8 +297,18 @@ export default function CollectiveBurialListView({
             </div>
 
             {currentYearSummary.totalCount === 0 ? (
-              <div className="px-4 md:px-6 py-6 md:py-8 text-center">
-                <p className="text-hai text-sm md:text-base">今年の請求対象者はいません</p>
+              <div className="px-4 md:px-6 py-4 md:py-6 bg-white">
+                <EmptyState
+                  container="plain"
+                  size="sm"
+                  icon={
+                    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                  }
+                  title={`${currentYear}年の請求対象者はいません`}
+                  description="合祀者の登録時に「初回請求年」を設定すると、該当年度にこの一覧へ表示されます。"
+                />
               </div>
             ) : (
               <div className="px-4 md:px-6 py-4 md:py-5">
@@ -385,135 +396,155 @@ export default function CollectiveBurialListView({
               </Button>
             </div>
           ) : groupedByYear.length === 0 ? (
-            <div className="text-center py-16 bg-white rounded-elegant-lg border border-gin">
-              <svg className="w-16 h-16 mx-auto mb-4 text-gin" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              <p className="text-hai text-lg">該当するデータがありません</p>
-            </div>
+            <EmptyState
+              icon={
+                <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z" />
+                </svg>
+              }
+              title="該当する合祀データが見つかりませんでした"
+              description={
+                (searchQuery || billingStatus !== 'all' || selectedYear !== 'all')
+                  ? '検索語・請求状況・請求年の条件を緩めて再検索してください。'
+                  : 'まだ合祀者が登録されていません。新規登録ボタンから追加できます。'
+              }
+              action={
+                (searchQuery || billingStatus !== 'all' || selectedYear !== 'all') ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setSearchQuery('');
+                      setBillingStatus('all');
+                      setSelectedYear('all');
+                      search({});
+                    }}
+                  >
+                    条件をクリア
+                  </Button>
+                ) : undefined
+              }
+            />
           ) : (
             <div className="space-y-8">
               {groupedByYear.map(group => {
                 const isCurrentYear = group.year === currentYear;
                 return (
-                <div
-                  key={group.year}
-                  className={`bg-white rounded-elegant-lg shadow-elegant overflow-hidden ${
-                    isCurrentYear ? 'border-2 border-matsu-300 ring-2 ring-matsu-100' : 'border border-gin'
-                  }`}
-                >
-                  {/* 年ヘッダー */}
                   <div
-                    className={`px-3 md:px-6 py-3 md:py-4 relative overflow-hidden ${
-                      isCurrentYear ? 'bg-gradient-matsu' : 'bg-gradient-cha'
-                    }`}
+                    key={group.year}
+                    className={`bg-white rounded-elegant-lg shadow-elegant overflow-hidden ${isCurrentYear ? 'border-2 border-matsu-300 ring-2 ring-matsu-100' : 'border border-gin'
+                      }`}
                   >
-                    <div className="absolute top-0 right-0 w-32 h-32 bg-white/5 rounded-full -translate-y-1/2 translate-x-1/2" />
-                    <div className="relative flex items-center justify-between gap-2">
-                      <div className="flex items-center gap-2 min-w-0">
-                        {isCurrentYear && (
-                          <span className="bg-white/25 text-white px-2 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap">
-                            今年
-                          </span>
-                        )}
-                        <h3 className="font-mincho text-xl font-semibold text-white tracking-wide truncate">
-                          {group.year === 0 ? '請求予定日未設定' : `${group.year}年 請求予定`}
-                        </h3>
+                    {/* 年ヘッダー */}
+                    <div
+                      className={`px-3 md:px-6 py-3 md:py-4 relative overflow-hidden ${isCurrentYear ? 'bg-gradient-matsu' : 'bg-gradient-cha'
+                        }`}
+                    >
+                      <div className="absolute top-0 right-0 w-32 h-32 bg-white/5 rounded-full -translate-y-1/2 translate-x-1/2" />
+                      <div className="relative flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2 min-w-0">
+                          {isCurrentYear && (
+                            <span className="bg-white/25 text-white px-2 py-0.5 rounded-full text-xs font-semibold whitespace-nowrap">
+                              今年
+                            </span>
+                          )}
+                          <h3 className="font-mincho text-xl font-semibold text-white tracking-wide truncate">
+                            {group.year === 0 ? '請求予定日未設定' : `${group.year}年 請求予定`}
+                          </h3>
+                        </div>
+                        <span className={`px-4 py-1.5 rounded-full text-sm font-semibold shadow-sm whitespace-nowrap ${isCurrentYear ? 'bg-white text-matsu-700' : 'bg-white text-cha'
+                          }`}>
+                          {group.totalCount} 件
+                        </span>
                       </div>
-                      <span className={`px-4 py-1.5 rounded-full text-sm font-semibold shadow-sm whitespace-nowrap ${
-                        isCurrentYear ? 'bg-white text-matsu-700' : 'bg-white text-cha'
-                      }`}>
-                        {group.totalCount} 件
-                      </span>
+                    </div>
+
+                    {/* テーブル */}
+                    <div className="overflow-x-auto">
+                      <table className="w-full table-fixed">
+                        <thead className="bg-kinari border-b border-gin">
+                          <tr>
+                            <th className="text-left px-2 md:px-4 py-3 text-sm font-semibold text-sumi" style={{ width: '140px' }}>契約者名</th>
+                            <th className="text-left px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden sm:table-cell" style={{ width: '80px' }}>区画</th>
+                            <th className="text-left px-2 md:px-4 py-3 text-sm font-semibold text-sumi" style={{ width: '100px' }}>区画番号</th>
+                            <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden md:table-cell" style={{ width: '80px' }}>契約年</th>
+                            <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden md:table-cell" style={{ width: '100px' }}>納骨日</th>
+                            <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden lg:table-cell" style={{ width: '80px' }}>合祀年</th>
+                            <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden lg:table-cell" style={{ width: '80px' }}>埋葬上限</th>
+                            <th className="text-right px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden sm:table-cell" style={{ width: '100px' }}>請求金額</th>
+                            <th className="text-left px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden lg:table-cell" style={{ width: '120px' }}>備考</th>
+                            <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi" style={{ width: '90px' }}>ステータス</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gin">
+                          {group.items.map((record) => {
+                            // 最新の納骨日を取得
+                            const latestBurialDate = record.buriedPersons
+                              .map(bp => bp.burialDate)
+                              .filter((d): d is string => d !== null)
+                              .sort()
+                              .at(-1) || null;
+
+                            // 合祀年（請求予定日の年）
+                            const collectiveBurialYear = record.billingScheduledDate
+                              ? new Date(record.billingScheduledDate).getFullYear()
+                              : null;
+
+                            // 契約年
+                            const contractYear = record.contractDate
+                              ? new Date(record.contractDate).getFullYear()
+                              : null;
+
+                            return (
+                              <tr
+                                key={record.id}
+                                className="cursor-pointer transition-all duration-200 hover:bg-cha-50"
+                                onClick={() => onSelectRecord?.(record)}
+                              >
+                                <td className="px-2 md:px-4 py-3">
+                                  <div className="font-medium text-sumi truncate">{record.applicantName || '-'}</div>
+                                  {record.applicantNameKana && (
+                                    <div className="text-xs text-hai truncate">{record.applicantNameKana}</div>
+                                  )}
+                                </td>
+                                <td className="px-2 md:px-4 py-3 text-sm text-hai hidden sm:table-cell">
+                                  {record.areaName}
+                                </td>
+                                <td className="px-2 md:px-4 py-3">
+                                  <span className="font-semibold text-sumi">{record.plotNumber}</span>
+                                </td>
+                                <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden md:table-cell">
+                                  {contractYear ? `${contractYear}年` : '-'}
+                                </td>
+                                <td className="px-2 md:px-4 py-3 text-center text-sm text-hai hidden md:table-cell">
+                                  {formatDate(latestBurialDate)}
+                                </td>
+                                <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden lg:table-cell">
+                                  {collectiveBurialYear ? `${collectiveBurialYear}年` : '-'}
+                                </td>
+                                <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden lg:table-cell">
+                                  {record.burialCapacity}
+                                </td>
+                                <td className="px-2 md:px-4 py-3 text-right text-sm text-sumi hidden sm:table-cell">
+                                  {record.billingAmount != null
+                                    ? `¥${record.billingAmount.toLocaleString()}`
+                                    : '-'}
+                                </td>
+                                <td className="px-2 md:px-4 py-3 text-sm text-hai truncate hidden lg:table-cell">
+                                  {record.notes || '-'}
+                                </td>
+                                <td className="px-2 md:px-4 py-3 text-center">
+                                  <span className={`px-2 py-1 rounded text-xs font-medium ${BILLING_STATUS_COLORS[record.billingStatus as BillingStatus]}`}>
+                                    {BILLING_STATUS_LABELS[record.billingStatus as BillingStatus]}
+                                  </span>
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
                     </div>
                   </div>
-
-                  {/* テーブル */}
-                  <div className="overflow-x-auto">
-                    <table className="w-full table-fixed">
-                      <thead className="bg-kinari border-b border-gin">
-                        <tr>
-                          <th className="text-left px-2 md:px-4 py-3 text-sm font-semibold text-sumi" style={{ width: '140px' }}>契約者名</th>
-                          <th className="text-left px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden sm:table-cell" style={{ width: '80px' }}>区画</th>
-                          <th className="text-left px-2 md:px-4 py-3 text-sm font-semibold text-sumi" style={{ width: '100px' }}>区画番号</th>
-                          <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden md:table-cell" style={{ width: '80px' }}>契約年</th>
-                          <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden md:table-cell" style={{ width: '100px' }}>納骨日</th>
-                          <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden lg:table-cell" style={{ width: '80px' }}>合祀年</th>
-                          <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden lg:table-cell" style={{ width: '80px' }}>埋葬上限</th>
-                          <th className="text-right px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden sm:table-cell" style={{ width: '100px' }}>請求金額</th>
-                          <th className="text-left px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden lg:table-cell" style={{ width: '120px' }}>備考</th>
-                          <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi" style={{ width: '90px' }}>ステータス</th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y divide-gin">
-                        {group.items.map((record) => {
-                          // 最新の納骨日を取得
-                          const latestBurialDate = record.buriedPersons
-                            .map(bp => bp.burialDate)
-                            .filter((d): d is string => d !== null)
-                            .sort()
-                            .at(-1) || null;
-
-                          // 合祀年（請求予定日の年）
-                          const collectiveBurialYear = record.billingScheduledDate
-                            ? new Date(record.billingScheduledDate).getFullYear()
-                            : null;
-
-                          // 契約年
-                          const contractYear = record.contractDate
-                            ? new Date(record.contractDate).getFullYear()
-                            : null;
-
-                          return (
-                            <tr
-                              key={record.id}
-                              className="cursor-pointer transition-all duration-200 hover:bg-cha-50"
-                              onClick={() => onSelectRecord?.(record)}
-                            >
-                              <td className="px-2 md:px-4 py-3">
-                                <div className="font-medium text-sumi truncate">{record.applicantName || '-'}</div>
-                                {record.applicantNameKana && (
-                                  <div className="text-xs text-hai truncate">{record.applicantNameKana}</div>
-                                )}
-                              </td>
-                              <td className="px-2 md:px-4 py-3 text-sm text-hai hidden sm:table-cell">
-                                {record.areaName}
-                              </td>
-                              <td className="px-2 md:px-4 py-3">
-                                <span className="font-semibold text-sumi">{record.plotNumber}</span>
-                              </td>
-                              <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden md:table-cell">
-                                {contractYear ? `${contractYear}年` : '-'}
-                              </td>
-                              <td className="px-2 md:px-4 py-3 text-center text-sm text-hai hidden md:table-cell">
-                                {formatDate(latestBurialDate)}
-                              </td>
-                              <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden lg:table-cell">
-                                {collectiveBurialYear ? `${collectiveBurialYear}年` : '-'}
-                              </td>
-                              <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden lg:table-cell">
-                                {record.burialCapacity}
-                              </td>
-                              <td className="px-2 md:px-4 py-3 text-right text-sm text-sumi hidden sm:table-cell">
-                                {record.billingAmount != null
-                                  ? `¥${record.billingAmount.toLocaleString()}`
-                                  : '-'}
-                              </td>
-                              <td className="px-2 md:px-4 py-3 text-sm text-hai truncate hidden lg:table-cell">
-                                {record.notes || '-'}
-                              </td>
-                              <td className="px-2 md:px-4 py-3 text-center">
-                                <span className={`px-2 py-1 rounded text-xs font-medium ${BILLING_STATUS_COLORS[record.billingStatus as BillingStatus]}`}>
-                                  {BILLING_STATUS_LABELS[record.billingStatus as BillingStatus]}
-                                </span>
-                              </td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
-                </div>
                 );
               })}
             </div>

--- a/src/components/collective-burial/Management.tsx
+++ b/src/components/collective-burial/Management.tsx
@@ -6,10 +6,13 @@
  */
 
 import { useState, useCallback } from 'react';
+import { FileQuestion } from 'lucide-react';
 import CollectiveBurialListView from './ListView';
 import CollectiveBurialDetailView from './DetailView';
 import { useCollectiveBurialDetail } from '@/hooks/useCollectiveBurials';
 import { CollectiveBurialListItem } from '@/lib/api';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Button } from '@/components/ui/button';
 type ViewMode = 'list' | 'detail';
 
 interface CollectiveBurialManagementProps {
@@ -66,16 +69,17 @@ export default function CollectiveBurialManagement({ onBack }: CollectiveBurialM
 
   if (!detailData) {
     return (
-      <div className="h-full flex items-center justify-center bg-shiro">
-        <div className="text-center">
-          <p className="text-hai mb-4">データが見つかりません</p>
-          <button
-            onClick={handleCloseDetail}
-            className="px-4 py-2 bg-cha text-white rounded hover:bg-cha-dark"
-          >
-            一覧に戻る
-          </button>
-        </div>
+      <div className="h-full flex items-center justify-center bg-shiro p-4">
+        <EmptyState
+          icon={<FileQuestion />}
+          title="データが見つかりません"
+          description="指定された合祀データは存在しないか、削除された可能性があります"
+          action={
+            <Button onClick={handleCloseDetail} variant="default">
+              一覧に戻る
+            </Button>
+          }
+        />
       </div>
     );
   }

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
+import { StatusBadge, type StatusBadgeProps } from '@/components/ui/status-badge';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { HistoryTab } from '@/components/plot-form/HistoryTab';
@@ -54,6 +55,15 @@ const PAYMENT_STATUS_LABELS: Record<PaymentStatus, string> = {
   [PaymentStatus.Cancelled]: 'キャンセル',
 };
 
+const PAYMENT_STATUS_VARIANTS: Record<PaymentStatus, StatusBadgeProps['variant']> = {
+  [PaymentStatus.Unpaid]: 'unpaid',
+  [PaymentStatus.Paid]: 'paid',
+  [PaymentStatus.PartialPaid]: 'partial',
+  [PaymentStatus.Overdue]: 'overdue',
+  [PaymentStatus.Refunded]: 'refunded',
+  [PaymentStatus.Cancelled]: 'cancelled',
+};
+
 const CONTRACT_STATUS_LABELS: Record<ContractStatus, string> = {
   [ContractStatus.Draft]: '下書き',
   [ContractStatus.Reserved]: '予約済',
@@ -64,10 +74,26 @@ const CONTRACT_STATUS_LABELS: Record<ContractStatus, string> = {
   [ContractStatus.Transferred]: '継承済',
 };
 
+const CONTRACT_STATUS_VARIANTS: Record<ContractStatus, StatusBadgeProps['variant']> = {
+  [ContractStatus.Draft]: 'neutral',
+  [ContractStatus.Reserved]: 'info',
+  [ContractStatus.Active]: 'active',
+  [ContractStatus.Suspended]: 'warning',
+  [ContractStatus.Terminated]: 'neutral',
+  [ContractStatus.Cancelled]: 'cancelled',
+  [ContractStatus.Transferred]: 'info',
+};
+
 const PHYSICAL_STATUS_LABELS: Record<PhysicalPlotStatus, string> = {
   [PhysicalPlotStatus.Available]: '利用可能',
   [PhysicalPlotStatus.PartiallySold]: '一部販売済',
   [PhysicalPlotStatus.SoldOut]: '完売',
+};
+
+const PHYSICAL_STATUS_VARIANTS: Record<PhysicalPlotStatus, StatusBadgeProps['variant']> = {
+  [PhysicalPlotStatus.Available]: 'available',
+  [PhysicalPlotStatus.PartiallySold]: 'pending',
+  [PhysicalPlotStatus.SoldOut]: 'sold',
 };
 
 const GENDER_LABELS: Record<Gender, string> = {
@@ -637,31 +663,64 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete }: Plo
         </div>
       </div>
 
-      {/* ステータスバッジ */}
-      <div className="flex flex-wrap gap-2 mb-4">
-        <span className={cn(
-          'px-3 py-1 rounded-full text-sm font-medium',
-          plot.paymentStatus === PaymentStatus.Paid ? 'bg-matsu-50 text-matsu' :
-            plot.paymentStatus === PaymentStatus.Unpaid ? 'bg-kohaku-50 text-kohaku-dark' :
-              plot.paymentStatus === PaymentStatus.Overdue ? 'bg-beni-50 text-beni' :
-                'bg-kinari text-hai'
-        )}>
-          {PAYMENT_STATUS_LABELS[plot.paymentStatus as PaymentStatus]}
-        </span>
-        <span className={cn(
-          'px-3 py-1 rounded-full text-sm font-medium',
-          plot.contractStatus === ContractStatus.Active ? 'bg-ai-50 text-ai-dark' :
-            plot.contractStatus === ContractStatus.Suspended ? 'bg-kohaku-50 text-kohaku-dark' :
-              'bg-kinari text-hai'
-        )}>
-          {CONTRACT_STATUS_LABELS[plot.contractStatus as ContractStatus]}
-        </span>
-        <span className={cn(
-          'px-3 py-1 rounded-full text-sm font-medium',
-          (plot.uncollectedAmount ?? 0) > 0 ? 'bg-beni-50 text-beni' : 'bg-kinari text-hai'
-        )}>
-          未集金額: {(plot.uncollectedAmount ?? 0).toLocaleString()}円
-        </span>
+      {/* サマリーカード */}
+      <div className="mb-4 md:mb-6 rounded-elegant-lg border border-gin bg-white shadow-elegant-sm p-4 md:p-5">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-6">
+          {/* 契約者 */}
+          <div className="min-w-0 col-span-2 md:col-span-1">
+            <p className="text-[11px] md:text-xs text-hai">契約者</p>
+            <p className="mt-1 font-mincho text-base md:text-lg font-semibold text-sumi truncate">
+              {primaryCustomer?.name || '-'}
+            </p>
+            {primaryCustomer?.nameKana && (
+              <p className="text-[11px] md:text-xs text-hai truncate">
+                {primaryCustomer.nameKana}
+              </p>
+            )}
+          </div>
+          {/* 未収金額 */}
+          <div className="min-w-0">
+            <p className="text-[11px] md:text-xs text-hai">未収金額</p>
+            <p className={cn(
+              'mt-1 text-lg md:text-2xl font-semibold tabular-nums',
+              (plot.uncollectedAmount ?? 0) > 0 ? 'text-beni' : 'text-sumi'
+            )}>
+              {(plot.uncollectedAmount ?? 0).toLocaleString()}
+              <span className="text-xs md:text-sm text-hai ml-1 font-normal">円</span>
+            </p>
+          </div>
+          {/* 直近請求月（管理料） */}
+          <div className="min-w-0">
+            <p className="text-[11px] md:text-xs text-hai">直近請求</p>
+            <p className="mt-1 text-sm md:text-base font-semibold text-sumi tabular-nums truncate">
+              {plot.managementFee?.lastBillingMonth || '―'}
+            </p>
+          </div>
+          {/* 区画状態 */}
+          <div className="min-w-0 col-span-2 md:col-span-1">
+            <p className="text-[11px] md:text-xs text-hai mb-1.5">状態</p>
+            <div className="flex flex-wrap gap-1.5">
+              <StatusBadge
+                variant={PAYMENT_STATUS_VARIANTS[plot.paymentStatus as PaymentStatus]}
+                withSymbol
+              >
+                {PAYMENT_STATUS_LABELS[plot.paymentStatus as PaymentStatus]}
+              </StatusBadge>
+              <StatusBadge
+                variant={CONTRACT_STATUS_VARIANTS[plot.contractStatus as ContractStatus]}
+                withSymbol
+              >
+                {CONTRACT_STATUS_LABELS[plot.contractStatus as ContractStatus]}
+              </StatusBadge>
+              <StatusBadge
+                variant={PHYSICAL_STATUS_VARIANTS[plot.physicalPlot.status]}
+                withSymbol
+              >
+                {PHYSICAL_STATUS_LABELS[plot.physicalPlot.status]}
+              </StatusBadge>
+            </div>
+          </div>
+        </div>
       </div>
 
       {/* タブ */}

--- a/src/components/plot-list-table.tsx
+++ b/src/components/plot-list-table.tsx
@@ -13,6 +13,8 @@ import { usePlots } from '@/hooks/usePlots';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { StatusBadge, type StatusBadgeProps } from '@/components/ui/status-badge';
+import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 
 // ===== 型定義 =====
@@ -56,13 +58,13 @@ const PAYMENT_STATUS_LABELS: Record<PaymentStatus, string> = {
   [PaymentStatus.Cancelled]: 'キャンセル',
 };
 
-const PAYMENT_STATUS_COLORS: Record<PaymentStatus, string> = {
-  [PaymentStatus.Unpaid]: 'text-kohaku-dark bg-kohaku-50',
-  [PaymentStatus.Paid]: 'text-matsu-dark bg-matsu-50',
-  [PaymentStatus.PartialPaid]: 'text-kohaku-dark bg-kohaku-50',
-  [PaymentStatus.Overdue]: 'text-beni bg-beni-50',
-  [PaymentStatus.Refunded]: 'text-ai bg-ai-50',
-  [PaymentStatus.Cancelled]: 'text-hai bg-kinari',
+const PAYMENT_STATUS_VARIANTS: Record<PaymentStatus, StatusBadgeProps['variant']> = {
+  [PaymentStatus.Unpaid]: 'unpaid',
+  [PaymentStatus.Paid]: 'paid',
+  [PaymentStatus.PartialPaid]: 'partial',
+  [PaymentStatus.Overdue]: 'overdue',
+  [PaymentStatus.Refunded]: 'refunded',
+  [PaymentStatus.Cancelled]: 'cancelled',
 };
 
 // ===== ヘルパー関数 =====
@@ -330,7 +332,7 @@ export default function PlotListTable({
                 </th>
                 <th
                   className={cn(
-                    'px-4 py-3 text-left text-sm font-semibold text-sumi cursor-pointer transition-colors duration-200 hover:bg-cha-50',
+                    'px-4 py-3 text-left text-sm font-semibold text-sumi cursor-pointer transition-colors duration-200 hover:bg-cha-50 hidden sm:table-cell',
                     sortKey === 'areaName' && 'bg-cha-50'
                   )}
                   onClick={() => handleSort('areaName')}
@@ -402,7 +404,7 @@ export default function PlotListTable({
                 </th>
                 <th
                   className={cn(
-                    'px-4 py-3 text-right text-sm font-semibold text-sumi cursor-pointer transition-colors duration-200 hover:bg-cha-50',
+                    'px-4 py-3 text-right text-sm font-semibold text-sumi cursor-pointer transition-colors duration-200 hover:bg-cha-50 hidden sm:table-cell',
                     sortKey === 'uncollectedAmount' && 'bg-cha-50'
                   )}
                   onClick={() => handleSort('uncollectedAmount')}
@@ -453,12 +455,21 @@ export default function PlotListTable({
                           <div className="text-xs md:text-sm text-hai">
                             {plot.customerNameKana || ''}
                           </div>
+                          {/* モバイル専用: エリアと未集金額を補足表示 */}
+                          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-hai sm:hidden">
+                            {plot.areaName && <span>{plot.areaName}</span>}
+                            {(plot.uncollectedAmount ?? 0) > 0 && (
+                              <span className="text-beni font-medium tabular-nums">
+                                未収 {(plot.uncollectedAmount ?? 0).toLocaleString()}円
+                              </span>
+                            )}
+                          </div>
                         </div>
                       </td>
-                      <td className="px-2 md:px-4 py-2 md:py-3 whitespace-nowrap text-sm text-sumi">
+                      <td className="px-2 md:px-4 py-2 md:py-3 whitespace-nowrap text-sm text-sumi hidden sm:table-cell">
                         {plot.areaName || '-'}
                       </td>
-                      <td className="px-2 md:px-4 py-2 md:py-3 whitespace-nowrap text-sm font-semibold text-sumi">
+                      <td className="px-2 md:px-4 py-2 md:py-3 whitespace-nowrap text-sm font-semibold text-sumi tabular-nums">
                         {plot.plotNumber || '-'}
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap text-sm text-sumi hidden sm:table-cell">
@@ -479,21 +490,19 @@ export default function PlotListTable({
                       <td className="px-4 py-3 whitespace-nowrap text-sm text-sumi text-right hidden md:table-cell">
                         {plot.managementFee ? `${Number(plot.managementFee).toLocaleString()}円` : '-'}
                       </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm">
+                      <td className="px-2 md:px-4 py-2 md:py-3 whitespace-nowrap text-sm">
                         {paymentStatus && (
-                          <span
-                            className={cn(
-                              'px-3 py-1 rounded-full text-xs font-medium',
-                              PAYMENT_STATUS_COLORS[paymentStatus]
-                            )}
+                          <StatusBadge
+                            variant={PAYMENT_STATUS_VARIANTS[paymentStatus]}
+                            withSymbol
                           >
                             {PAYMENT_STATUS_LABELS[paymentStatus]}
-                          </span>
+                          </StatusBadge>
                         )}
                       </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm text-right">
+                      <td className="px-4 py-3 whitespace-nowrap text-sm text-right hidden sm:table-cell">
                         <span className={cn(
-                          'font-medium',
+                          'font-medium tabular-nums',
                           (plot.uncollectedAmount ?? 0) > 0 ? 'text-beni' : 'text-sumi'
                         )}>
                           {(plot.uncollectedAmount ?? 0).toLocaleString()}円
@@ -504,17 +513,36 @@ export default function PlotListTable({
                 })
               ) : (
                 <tr>
-                  <td colSpan={11} className="px-6 py-8 text-center text-sm text-hai">
-                    <div className="flex flex-col items-center">
-                      <svg className="w-12 h-12 text-gin mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
-                      </svg>
-                      <p className="text-base font-medium">
-                        {searchQuery.trim()
-                          ? '検索条件に該当するデータが見つかりませんでした'
-                          : 'データがありません'}
-                      </p>
-                    </div>
+                  <td colSpan={11} className="px-4 md:px-6 py-6">
+                    <EmptyState
+                      container="plain"
+                      icon={
+                        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z" />
+                        </svg>
+                      }
+                      title={
+                        searchQuery.trim()
+                          ? '検索条件に該当する区画が見つかりませんでした'
+                          : '区画データがまだありません'
+                      }
+                      description={
+                        searchQuery.trim()
+                          ? '氏名・区画番号・電話番号の綴りを見直すか、あいうえおタブを切り替えて再検索してください。'
+                          : '条件を変えるか、一括登録から区画を追加してください。'
+                      }
+                      action={
+                        searchQuery.trim() ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => { setSearchInput(''); setSearch(''); setAiueoTab('all'); }}
+                          >
+                            検索条件をクリア
+                          </Button>
+                        ) : undefined
+                      }
+                    />
                   </td>
                 </tr>
               )}

--- a/src/components/plot-registry.tsx
+++ b/src/components/plot-registry.tsx
@@ -19,6 +19,8 @@ import { Button } from '@/components/ui/button';
 import { cn, truncateAddressToCity } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { StatusBadge, type StatusBadgeProps } from '@/components/ui/status-badge';
+import { EmptyState } from '@/components/ui/empty-state';
 import PageHeader from '@/components/page-header';
 
 // ===== 型定義 =====
@@ -75,6 +77,15 @@ const PAYMENT_STATUS_LABELS: Record<PaymentStatus, string> = {
   [PaymentStatus.Overdue]: '滞納',
   [PaymentStatus.Refunded]: '返金済',
   [PaymentStatus.Cancelled]: 'キャンセル',
+};
+
+const PAYMENT_STATUS_VARIANTS: Record<PaymentStatus, StatusBadgeProps['variant']> = {
+  [PaymentStatus.Unpaid]: 'unpaid',
+  [PaymentStatus.Paid]: 'paid',
+  [PaymentStatus.PartialPaid]: 'partial',
+  [PaymentStatus.Overdue]: 'overdue',
+  [PaymentStatus.Refunded]: 'refunded',
+  [PaymentStatus.Cancelled]: 'cancelled',
 };
 
 const PLOT_STATUS_LABELS: Record<PhysicalPlotStatus, string> = {
@@ -708,17 +719,17 @@ export default function PlotRegistry({
                           {formatContractDate(plot.contractDate)}
                         </td>
                         <td className="px-2 py-2 text-xs text-center">
-                          <span className={cn(
-                            "px-1.5 py-0.5 rounded text-[10px] font-medium",
-                            paymentStatus === PaymentStatus.Paid && 'bg-matsu-50 text-matsu',
-                            paymentStatus === PaymentStatus.Unpaid && 'bg-kohaku-50 text-kohaku-dark',
-                            paymentStatus === PaymentStatus.PartialPaid && 'bg-kohaku-50 text-kohaku-dark',
-                            paymentStatus === PaymentStatus.Overdue && 'bg-beni-50 text-beni',
-                            paymentStatus === PaymentStatus.Refunded && 'bg-ai-50 text-ai-dark',
-                            paymentStatus === PaymentStatus.Cancelled && 'bg-gin text-hai',
-                          )}>
-                            {PAYMENT_STATUS_LABELS[paymentStatus] || '-'}
-                          </span>
+                          {paymentStatus ? (
+                            <StatusBadge
+                              variant={PAYMENT_STATUS_VARIANTS[paymentStatus]}
+                              size="sm"
+                              withSymbol
+                            >
+                              {PAYMENT_STATUS_LABELS[paymentStatus]}
+                            </StatusBadge>
+                          ) : (
+                            <span className="text-hai">-</span>
+                          )}
                         </td>
                         <td className="px-2 py-2 text-xs text-hai text-center hidden sm:table-cell">
                           {formatMoneyString(plot.managementFee)}
@@ -731,14 +742,35 @@ export default function PlotRegistry({
                   })
                 ) : (
                   <tr>
-                    <td colSpan={showBuriedPersons ? 13 : 12} className="px-4 py-12 text-center text-hai">
-                      <div className="flex flex-col items-center">
-                        <svg className="w-12 h-12 text-gin mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
-                        </svg>
-                        <p className="text-base font-medium">該当する区画が見つかりません</p>
-                        <p className="text-sm mt-1">検索条件を変更してください</p>
-                      </div>
+                    <td colSpan={showBuriedPersons ? 13 : 12} className="px-4 md:px-6 py-6">
+                      <EmptyState
+                        container="plain"
+                        icon={
+                          <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z" />
+                          </svg>
+                        }
+                        title={hasActiveFilters || searchQuery.trim() || activeTab !== '全'
+                          ? '該当する区画が見つかりませんでした'
+                          : '区画データがまだありません'}
+                        description={hasActiveFilters || searchQuery.trim() || activeTab !== '全'
+                          ? '検索語やフィルターを緩めて再検索してください。'
+                          : '新規区画を登録するとここに表示されます。'}
+                        action={(hasActiveFilters || searchQuery.trim() || activeTab !== '全') ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              setSearchInput('');
+                              setSearchQuery('');
+                              handleClearFilters();
+                              setActiveTab('全');
+                            }}
+                          >
+                            条件をクリア
+                          </Button>
+                        ) : undefined}
+                      />
                     </td>
                   </tr>
                 )}

--- a/src/components/yucho/YuchoManagement.tsx
+++ b/src/components/yucho/YuchoManagement.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { EmptyState } from '@/components/ui/empty-state';
 import { BaseDialog } from '@/components/shared/dialogs/BaseDialog';
 import { showSuccess, showError } from '@/lib/toast';
 import { useAsyncData } from '@/hooks/useAsyncData';
@@ -180,7 +181,7 @@ export default function YuchoManagement() {
                 value={String(billingYear)}
                 onValueChange={(v) => setBillingYear(Number(v))}
               >
-                <SelectTrigger className="w-32 md:w-40">
+                <SelectTrigger id="yucho-year-select" className="w-32 md:w-40">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -280,14 +281,14 @@ export default function YuchoManagement() {
               {isLoading ? (
                 <LoadingState />
               ) : (
-                <ManagementTable items={management} />
+                <ManagementTable items={management} year={billingYear} />
               )}
             </TabsContent>
             <TabsContent value="collective">
               {isLoading ? (
                 <LoadingState />
               ) : (
-                <CollectiveTable items={collective} />
+                <CollectiveTable items={collective} year={billingYear} />
               )}
             </TabsContent>
           </Tabs>
@@ -348,9 +349,28 @@ function LoadingState() {
   );
 }
 
-function ManagementTable({ items }: { items: YuchoBillingItem[] }) {
+function ManagementTable({ items, year }: { items: YuchoBillingItem[]; year: number }) {
   if (items.length === 0) {
-    return <EmptyState message="対象期間の管理料データが見つかりません" />;
+    return (
+      <EmptyState
+        icon={<Wallet className="w-6 h-6" />}
+        title={`${year}年度の管理料請求対象がありません`}
+        description="対象年度を切り替えるか、区画の管理料マスタが登録されているか確認してください。"
+        action={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              const target = document.getElementById('yucho-year-select');
+              target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+              target?.focus();
+            }}
+          >
+            対象年度を変更
+          </Button>
+        }
+      />
+    );
   }
   return (
     <>
@@ -413,9 +433,28 @@ function ManagementTable({ items }: { items: YuchoBillingItem[] }) {
   );
 }
 
-function CollectiveTable({ items }: { items: YuchoBillingItem[] }) {
+function CollectiveTable({ items, year }: { items: YuchoBillingItem[]; year: number }) {
   if (items.length === 0) {
-    return <EmptyState message="対象期間の合祀料金データが見つかりません" />;
+    return (
+      <EmptyState
+        icon={<Users className="w-6 h-6" />}
+        title={`${year}年度の合祀料金請求対象がありません`}
+        description="対象年度を切り替えるか、合祀者の請求予定年が今年度に設定されているか確認してください。"
+        action={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              const target = document.getElementById('yucho-year-select');
+              target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+              target?.focus();
+            }}
+          >
+            対象年度を変更
+          </Button>
+        }
+      />
+    );
   }
   return (
     <>
@@ -476,10 +515,3 @@ function CollectiveTable({ items }: { items: YuchoBillingItem[] }) {
   );
 }
 
-function EmptyState({ message }: { message: string }) {
-  return (
-    <div className="bg-white rounded-lg border border-gin border-dashed p-8 md:p-12 text-center">
-      <p className="text-sm text-hai">{message}</p>
-    </div>
-  );
-}


### PR DESCRIPTION
## Summary
- /plots モバイルテーブル改善: 375px で主要カラムのみ表示、エリア/未収金額は氏名サブ行に集約
- ステータスバッジ統一: `PAYMENT_STATUS_COLORS` を `StatusBadge` に置換し、色+記号で色覚対応（WCAG AA準拠）
- /plots/[id] サマリーカード追加: 契約者・未収金額・直近請求・区画状態を先頭に集約
- 空状態の `EmptyState` 統一: /yucho（年度変更導線付き）・合祀管理（一覧/詳細not-found）

## 変更ファイル
- `plot-list-table.tsx` — モバイルレイアウト + StatusBadge + EmptyState
- `plot-detail-view.tsx` — サマリーカード + StatusBadge
- `plot-registry.tsx` — StatusBadge + EmptyState
- `yucho/YuchoManagement.tsx` — 共有 EmptyState + 年度選択スクロール
- `collective-burial/ListView.tsx` — EmptyState
- `collective-burial/Management.tsx` — 詳細 not-found を EmptyState に

## Test plan
- [x] `npm run lint`: 0 errors（既存の警告のみ）
- [x] `npm test`: 268 passed
- [ ] 375px (iPhone SE) でテーブルが横スクロール無しで表示されるか確認
- [ ] StatusBadge の記号付き表示（●▲◐■↩×）が各支払い状態で正しく出るか確認
- [ ] /plots/[id] のサマリーカードが未収金額に応じて紅色強調されるか確認
- [ ] /yucho の空状態「対象年度を変更」で年度セレクトにフォーカスが飛ぶか確認

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)