### PR TITLE
fix(ui): /bulk-import を3ステップウィザード化

### DIFF
--- a/src/components/bulk-import/BulkCreatePlotPanel.tsx
+++ b/src/components/bulk-import/BulkCreatePlotPanel.tsx
@@ -18,8 +18,17 @@ import {
   ValidationErrorList,
   SubmitResultCard,
 } from './shared';
+import { WizardStepper, WizardNav, WizardStep } from './WizardStepper';
+
+const STEPS: WizardStep[] = [
+  { id: 'download', label: 'テンプレート取得', description: 'Excelファイルをダウンロード' },
+  { id: 'prepare', label: 'データ入力', description: 'Excelで区画情報を入力' },
+  { id: 'upload', label: 'アップロード', description: '検証して一括登録' },
+];
 
 export function BulkCreatePlotPanel() {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [maxReachedStep, setMaxReachedStep] = useState(0);
   const [file, setFile] = useState<File | null>(null);
   const [plots, setPlots] = useState<ParsedPlot[]>([]);
   const [errors, setErrors] = useState<ValidationError[]>([]);
@@ -35,6 +44,16 @@ export function BulkCreatePlotPanel() {
       error: { message: string; details?: Array<{ field?: string; message: string }> };
     }>;
   } | null>(null);
+
+  const goToStep = useCallback((next: number) => {
+    setCurrentStep(next);
+    setMaxReachedStep((prev) => Math.max(prev, next));
+  }, []);
+
+  const handleDownload = useCallback(() => {
+    downloadPlotTemplate('create');
+    setMaxReachedStep((prev) => Math.max(prev, 1));
+  }, []);
 
   const handleFileSelect = useCallback(async (f: File) => {
     const ext = f.name.split('.').pop()?.toLowerCase();
@@ -102,94 +121,159 @@ export function BulkCreatePlotPanel() {
     setErrors([]);
     setIsValidated(false);
     setSubmitResult(null);
+    setCurrentStep(0);
+    setMaxReachedStep(0);
   }, []);
 
   const rowCount = plots.length;
   const hasErrors = errors.length > 0;
 
   return (
-    <div className="space-y-6 mt-4">
-      {/* テンプレートダウンロード */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">テンプレートダウンロード</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-hai mb-4">
-            一括登録用のテンプレートファイルをダウンロードし、データを入力してください。
-            メインの「区画情報」シートに加え、家族連絡先・埋葬者・工事情報の各シートが含まれます。
-          </p>
-          <Button variant="outline" onClick={() => downloadPlotTemplate('create')}>
-            <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-              />
-            </svg>
-            一括登録テンプレート (.xlsx)
-          </Button>
-        </CardContent>
-      </Card>
+    <div className="space-y-4 mt-4">
+      <WizardStepper
+        steps={STEPS}
+        currentStep={currentStep}
+        maxReachedStep={maxReachedStep}
+        onStepChange={goToStep}
+      />
 
-      {/* フォーマット仕様 */}
-      <PlotFormatSpec mode="create" />
+      {/* Step 1: テンプレートダウンロード */}
+      {currentStep === 0 && (
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">テンプレートをダウンロード</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-hai mb-4">
+                一括登録用のテンプレートファイルをダウンロードしてください。
+                メインの「区画情報」シートに加え、家族連絡先・埋葬者・工事情報の各シートが含まれます。
+              </p>
+              <Button variant="outline" onClick={handleDownload}>
+                <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
+                </svg>
+                一括登録テンプレート (.xlsx)
+              </Button>
+            </CardContent>
+          </Card>
 
-      {/* ファイルアップロード */}
-      {!submitResult && (
-        <FileUploadZone
-          file={file}
-          onFileSelect={handleFileSelect}
-          helperText={`最大${MAX_PLOTS_PER_BATCH}件まで一括登録可能`}
-        />
+          <PlotFormatSpec mode="create" />
+
+          <WizardNav onNext={() => goToStep(1)} nextLabel="データ入力へ進む" />
+        </div>
       )}
 
-      {/* プレビュー */}
-      {rowCount > 0 && !submitResult && (
-        <>
-          <PlotPreview plots={plots} errors={errors} totalRowCount={rowCount} />
-
+      {/* Step 2: データ入力案内 */}
+      {currentStep === 1 && (
+        <div className="space-y-4">
           <Card>
             <CardContent className="pt-6">
-              {isValidated && <ValidationErrorList errors={errors} />}
-
-              {isValidated && !hasErrors && (
-                <div className="mt-4 p-4 bg-matsu-50 border border-matsu-200 rounded-lg">
-                  <p className="text-sm text-matsu font-medium">
-                    バリデーション成功: 全{rowCount}件のデータに問題はありません。
-                  </p>
+              <div className="flex items-start gap-3 p-4 bg-ai-50 rounded-lg border border-ai-200">
+                <svg
+                  className="w-5 h-5 text-ai flex-shrink-0 mt-0.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                  />
+                </svg>
+                <div className="text-sm text-sumi space-y-2">
+                  <p className="font-semibold">ダウンロードしたテンプレートに、Excelでデータを入力してください</p>
+                  <ul className="list-disc list-inside space-y-1 ml-1 text-hai">
+                    <li>1ファイルに最大 <span className="font-medium text-sumi">{MAX_PLOTS_PER_BATCH}件</span> まで入力できます</li>
+                    <li>必須項目は「区画番号」「エリア名」「面積」の3項目</li>
+                    <li>関連データ（家族連絡先・埋葬者・工事情報）は別シートに記入</li>
+                    <li>入力が終わったら保存して、次のステップでアップロードします</li>
+                  </ul>
                 </div>
-              )}
+              </div>
 
-              <div className="mt-6 flex items-center gap-3 flex-wrap">
-                {!isValidated ? (
-                  <Button onClick={handleValidate}>データを検証する</Button>
-                ) : !hasErrors ? (
-                  <Button onClick={handleSubmit} disabled={isSubmitting}>
-                    {isSubmitting ? '送信中...' : `${rowCount}件を一括登録する`}
-                  </Button>
-                ) : (
-                  <Button onClick={handleValidate}>再検証する</Button>
-                )}
-                <Button variant="outline" onClick={handleReset}>
-                  リセット
-                </Button>
+              <div className="mt-4 p-3 bg-kinari rounded-lg text-xs text-hai">
+                💡 フォーマットの詳細はステップ1の「フォーマット仕様」で確認できます（ステップ1に戻って確認可能）
               </div>
             </CardContent>
           </Card>
-        </>
+
+          <WizardNav
+            onBack={() => goToStep(0)}
+            onNext={() => goToStep(2)}
+            nextLabel="入力完了、アップロードへ"
+          />
+        </div>
       )}
 
-      {/* 結果 */}
-      {submitResult && (
-        <SubmitResultCard
-          mode="create"
-          totalRequested={submitResult.totalRequested}
-          succeeded={submitResult.succeeded}
-          failed={submitResult.failed}
-          onReset={handleReset}
-        />
+      {/* Step 3: アップロード */}
+      {currentStep === 2 && (
+        <div className="space-y-4">
+          {!submitResult && (
+            <FileUploadZone
+              file={file}
+              onFileSelect={handleFileSelect}
+              helperText={`最大${MAX_PLOTS_PER_BATCH}件まで一括登録可能`}
+            />
+          )}
+
+          {rowCount > 0 && !submitResult && (
+            <>
+              <PlotPreview plots={plots} errors={errors} totalRowCount={rowCount} />
+
+              <Card>
+                <CardContent className="pt-6">
+                  {isValidated && <ValidationErrorList errors={errors} />}
+
+                  {isValidated && !hasErrors && (
+                    <div className="mt-4 p-4 bg-matsu-50 border border-matsu-200 rounded-lg">
+                      <p className="text-sm text-matsu font-medium">
+                        バリデーション成功: 全{rowCount}件のデータに問題はありません。
+                      </p>
+                    </div>
+                  )}
+
+                  <div className="mt-6 flex items-center gap-3 flex-wrap">
+                    {!isValidated ? (
+                      <Button onClick={handleValidate}>データを検証する</Button>
+                    ) : !hasErrors ? (
+                      <Button onClick={handleSubmit} disabled={isSubmitting}>
+                        {isSubmitting ? '送信中...' : `${rowCount}件を一括登録する`}
+                      </Button>
+                    ) : (
+                      <Button onClick={handleValidate}>再検証する</Button>
+                    )}
+                    <Button variant="outline" onClick={handleReset}>
+                      リセット
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            </>
+          )}
+
+          {submitResult && (
+            <SubmitResultCard
+              mode="create"
+              totalRequested={submitResult.totalRequested}
+              succeeded={submitResult.succeeded}
+              failed={submitResult.failed}
+              onReset={handleReset}
+            />
+          )}
+
+          {!submitResult && (
+            <WizardNav onBack={() => goToStep(1)} />
+          )}
+        </div>
       )}
 
       <ConfirmDialog

--- a/src/components/bulk-import/BulkStaffPanel.tsx
+++ b/src/components/bulk-import/BulkStaffPanel.tsx
@@ -10,6 +10,13 @@ import { showSuccess, showError, showApiError } from '@/lib/toast';
 import { ConfirmDialog } from '@/components/shared/dialogs';
 import { FileUploadZone, SubmitResultCard } from './shared';
 import { MAX_STAFF_PER_BATCH } from './plotFields';
+import { WizardStepper, WizardNav, WizardStep } from './WizardStepper';
+
+const STEPS: WizardStep[] = [
+  { id: 'download', label: 'テンプレート取得', description: 'Excelファイルをダウンロード' },
+  { id: 'prepare', label: 'データ入力', description: 'Excelでスタッフ情報を入力' },
+  { id: 'upload', label: 'アップロード', description: '検証して一括登録' },
+];
 
 interface StaffRow {
   name: string;
@@ -104,6 +111,8 @@ async function downloadStaffTemplate() {
 }
 
 export function BulkStaffPanel() {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [maxReachedStep, setMaxReachedStep] = useState(0);
   const [file, setFile] = useState<File | null>(null);
   const [rows, setRows] = useState<StaffRow[]>([]);
   const [errors, setErrors] = useState<StaffValidationError[]>([]);
@@ -116,6 +125,16 @@ export function BulkStaffPanel() {
   } | null>(null);
 
   const errorRows = new Set(errors.map((e) => e.row));
+
+  const goToStep = useCallback((next: number) => {
+    setCurrentStep(next);
+    setMaxReachedStep((prev) => Math.max(prev, next));
+  }, []);
+
+  const handleDownload = useCallback(async () => {
+    await downloadStaffTemplate();
+    setMaxReachedStep((prev) => Math.max(prev, 1));
+  }, []);
 
   const handleFileSelect = useCallback(async (f: File) => {
     const ext = f.name.split('.').pop()?.toLowerCase();
@@ -176,170 +195,236 @@ export function BulkStaffPanel() {
     setErrors([]);
     setIsValidated(false);
     setSubmitResult(null);
+    setCurrentStep(0);
+    setMaxReachedStep(0);
   }, []);
 
   const rowCount = rows.length;
   const hasErrors = errors.length > 0;
 
   return (
-    <div className="space-y-6 mt-4">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">テンプレートダウンロード</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-hai mb-4">
-            一括登録用のテンプレートファイルをダウンロードして、データを入力してください。
-          </p>
-          <Button variant="outline" onClick={downloadStaffTemplate}>
-            <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-              />
-            </svg>
-            スタッフ情報テンプレート (.xlsx)
-          </Button>
-        </CardContent>
-      </Card>
+    <div className="space-y-4 mt-4">
+      <WizardStepper
+        steps={STEPS}
+        currentStep={currentStep}
+        maxReachedStep={maxReachedStep}
+        onStepChange={goToStep}
+      />
 
-      <Card>
-        <CardContent className="pt-6">
-          <h3 className="text-sm font-medium text-sumi mb-3">フォーマット仕様</h3>
-          <div className="overflow-x-auto border border-gin rounded-lg">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-kinari border-b border-gin">
-                  <th className="px-4 py-2 text-left font-semibold text-sumi">フィールド</th>
-                  <th className="px-4 py-2 text-center font-semibold text-sumi">必須</th>
-                  <th className="px-4 py-2 text-left font-semibold text-sumi">説明</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr className="border-b border-gin">
-                  <td className="px-4 py-2 font-medium">名前</td>
-                  <td className="px-4 py-2 text-center text-beni">○</td>
-                  <td className="px-4 py-2 text-hai">スタッフ名</td>
-                </tr>
-                <tr className="border-b border-gin">
-                  <td className="px-4 py-2 font-medium">メールアドレス</td>
-                  <td className="px-4 py-2 text-center text-beni">○</td>
-                  <td className="px-4 py-2 text-hai">有効なメールアドレス形式</td>
-                </tr>
-                <tr>
-                  <td className="px-4 py-2 font-medium">ロール</td>
-                  <td className="px-4 py-2 text-center text-beni">○</td>
-                  <td className="px-4 py-2 text-hai">viewer / operator / manager / admin</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <div className="mt-4 text-sm text-hai space-y-1">
-            <p className="font-medium text-sumi">注意事項:</p>
-            <ul className="list-disc list-inside space-y-0.5 ml-1">
-              <li>1回の登録で最大{MAX_STAFF_PER_BATCH}件まで対応</li>
-              <li>対応ファイル形式: .xlsx / .csv</li>
-              <li>1行目はヘッダー行として自動スキップ</li>
-              <li>1件でもエラーがあると全件登録されません（全件ロールバック）</li>
-              <li>空行は自動的にスキップされます</li>
-            </ul>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Step 1: テンプレート取得 + フォーマット仕様 */}
+      {currentStep === 0 && (
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">テンプレートをダウンロード</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-hai mb-4">
+                一括登録用のテンプレートファイルをダウンロードしてください。
+              </p>
+              <Button variant="outline" onClick={handleDownload}>
+                <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
+                </svg>
+                スタッフ情報テンプレート (.xlsx)
+              </Button>
+            </CardContent>
+          </Card>
 
-      {!submitResult && (
-        <FileUploadZone
-          file={file}
-          onFileSelect={handleFileSelect}
-          helperText={`最大${MAX_STAFF_PER_BATCH}件まで一括登録可能`}
-        />
-      )}
-
-      {rowCount > 0 && !submitResult && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">データプレビュー ({rowCount}件)</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto border border-gin rounded-lg">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="bg-kinari border-b border-gin">
-                    <th className="px-4 py-3 text-left font-semibold text-sumi">行</th>
-                    <th className="px-4 py-3 text-left font-semibold text-sumi">名前</th>
-                    <th className="px-4 py-3 text-left font-semibold text-sumi">メールアドレス</th>
-                    <th className="px-4 py-3 text-left font-semibold text-sumi">ロール</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((row, idx) => {
-                    const rowNum = idx + 2;
-                    const hasError = errorRows.has(rowNum);
-                    return (
-                      <tr
-                        key={idx}
-                        className={`border-b border-gin last:border-0 ${hasError ? 'bg-beni-50' : 'hover:bg-kinari'
-                          }`}
-                      >
-                        <td className="px-4 py-2 text-hai">{rowNum}</td>
-                        <td className="px-4 py-2">{row.name || '-'}</td>
-                        <td className="px-4 py-2">{row.email || '-'}</td>
-                        <td className="px-4 py-2">{row.role || '-'}</td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-
-            {isValidated && hasErrors && (
-              <div className="mt-4 p-4 bg-beni-50 border border-beni-200 rounded-lg">
-                <h4 className="font-semibold text-beni mb-2">バリデーションエラー ({errors.length}件)</h4>
-                <ul className="space-y-1">
-                  {errors.map((err, idx) => (
-                    <li key={idx} className="text-sm text-beni">
-                      行{err.row} [{err.field}]: {err.message}
-                    </li>
-                  ))}
+          <Card>
+            <CardContent className="pt-6">
+              <h3 className="text-sm font-medium text-sumi mb-3">フォーマット仕様</h3>
+              <div className="overflow-x-auto border border-gin rounded-lg">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-kinari border-b border-gin">
+                      <th className="px-4 py-2 text-left font-semibold text-sumi">フィールド</th>
+                      <th className="px-4 py-2 text-center font-semibold text-sumi">必須</th>
+                      <th className="px-4 py-2 text-left font-semibold text-sumi">説明</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr className="border-b border-gin">
+                      <td className="px-4 py-2 font-medium">名前</td>
+                      <td className="px-4 py-2 text-center text-beni">○</td>
+                      <td className="px-4 py-2 text-hai">スタッフ名</td>
+                    </tr>
+                    <tr className="border-b border-gin">
+                      <td className="px-4 py-2 font-medium">メールアドレス</td>
+                      <td className="px-4 py-2 text-center text-beni">○</td>
+                      <td className="px-4 py-2 text-hai">有効なメールアドレス形式</td>
+                    </tr>
+                    <tr>
+                      <td className="px-4 py-2 font-medium">ロール</td>
+                      <td className="px-4 py-2 text-center text-beni">○</td>
+                      <td className="px-4 py-2 text-hai">viewer / operator / manager / admin</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div className="mt-4 text-sm text-hai space-y-1">
+                <p className="font-medium text-sumi">注意事項:</p>
+                <ul className="list-disc list-inside space-y-0.5 ml-1">
+                  <li>1回の登録で最大{MAX_STAFF_PER_BATCH}件まで対応</li>
+                  <li>対応ファイル形式: .xlsx / .csv</li>
+                  <li>1行目はヘッダー行として自動スキップ</li>
+                  <li>1件でもエラーがあると全件登録されません（全件ロールバック）</li>
+                  <li>空行は自動的にスキップされます</li>
                 </ul>
               </div>
-            )}
+            </CardContent>
+          </Card>
 
-            {isValidated && !hasErrors && (
-              <div className="mt-4 p-4 bg-matsu-50 border border-matsu-200 rounded-lg">
-                <p className="text-sm text-matsu font-medium">
-                  バリデーション成功: 全{rowCount}件のデータに問題はありません。
-                </p>
-              </div>
-            )}
-
-            <div className="mt-6 flex items-center gap-3 flex-wrap">
-              {!isValidated ? (
-                <Button onClick={handleValidate}>データを検証する</Button>
-              ) : !hasErrors ? (
-                <Button onClick={() => setShowConfirm(true)} disabled={isSubmitting}>
-                  {isSubmitting ? '送信中...' : `${rowCount}件を一括登録する`}
-                </Button>
-              ) : (
-                <Button onClick={handleValidate}>再検証する</Button>
-              )}
-              <Button variant="outline" onClick={handleReset}>
-                リセット
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+          <WizardNav onNext={() => goToStep(1)} nextLabel="データ入力へ進む" />
+        </div>
       )}
 
-      {submitResult && (
-        <SubmitResultCard
-          mode="create"
-          totalRequested={submitResult.totalRequested}
-          succeeded={submitResult.created}
-          onReset={handleReset}
-        />
+      {/* Step 2: データ入力案内 */}
+      {currentStep === 1 && (
+        <div className="space-y-4">
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-start gap-3 p-4 bg-ai-50 rounded-lg border border-ai-200">
+                <svg
+                  className="w-5 h-5 text-ai flex-shrink-0 mt-0.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                  />
+                </svg>
+                <div className="text-sm text-sumi space-y-2">
+                  <p className="font-semibold">ダウンロードしたテンプレートに、Excelでスタッフ情報を入力してください</p>
+                  <ul className="list-disc list-inside space-y-1 ml-1 text-hai">
+                    <li>1ファイルに最大 <span className="font-medium text-sumi">{MAX_STAFF_PER_BATCH}件</span> まで入力できます</li>
+                    <li>必須項目: 名前、メールアドレス、ロール（すべて）</li>
+                    <li>ロールは <span className="font-medium text-sumi">viewer / operator / manager / admin</span> のいずれか</li>
+                    <li>入力が終わったら保存して、次のステップでアップロードします</li>
+                  </ul>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <WizardNav
+            onBack={() => goToStep(0)}
+            onNext={() => goToStep(2)}
+            nextLabel="入力完了、アップロードへ"
+          />
+        </div>
+      )}
+
+      {/* Step 3: アップロード */}
+      {currentStep === 2 && (
+        <div className="space-y-4">
+          {!submitResult && (
+            <FileUploadZone
+              file={file}
+              onFileSelect={handleFileSelect}
+              helperText={`最大${MAX_STAFF_PER_BATCH}件まで一括登録可能`}
+            />
+          )}
+
+          {rowCount > 0 && !submitResult && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">データプレビュー ({rowCount}件)</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="overflow-x-auto border border-gin rounded-lg">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="bg-kinari border-b border-gin">
+                        <th className="px-4 py-3 text-left font-semibold text-sumi">行</th>
+                        <th className="px-4 py-3 text-left font-semibold text-sumi">名前</th>
+                        <th className="px-4 py-3 text-left font-semibold text-sumi">メールアドレス</th>
+                        <th className="px-4 py-3 text-left font-semibold text-sumi">ロール</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map((row, idx) => {
+                        const rowNum = idx + 2;
+                        const hasError = errorRows.has(rowNum);
+                        return (
+                          <tr
+                            key={idx}
+                            className={`border-b border-gin last:border-0 ${hasError ? 'bg-beni-50' : 'hover:bg-kinari'
+                              }`}
+                          >
+                            <td className="px-4 py-2 text-hai">{rowNum}</td>
+                            <td className="px-4 py-2">{row.name || '-'}</td>
+                            <td className="px-4 py-2">{row.email || '-'}</td>
+                            <td className="px-4 py-2">{row.role || '-'}</td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+
+                {isValidated && hasErrors && (
+                  <div className="mt-4 p-4 bg-beni-50 border border-beni-200 rounded-lg">
+                    <h4 className="font-semibold text-beni mb-2">バリデーションエラー ({errors.length}件)</h4>
+                    <ul className="space-y-1">
+                      {errors.map((err, idx) => (
+                        <li key={idx} className="text-sm text-beni">
+                          行{err.row} [{err.field}]: {err.message}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {isValidated && !hasErrors && (
+                  <div className="mt-4 p-4 bg-matsu-50 border border-matsu-200 rounded-lg">
+                    <p className="text-sm text-matsu font-medium">
+                      バリデーション成功: 全{rowCount}件のデータに問題はありません。
+                    </p>
+                  </div>
+                )}
+
+                <div className="mt-6 flex items-center gap-3 flex-wrap">
+                  {!isValidated ? (
+                    <Button onClick={handleValidate}>データを検証する</Button>
+                  ) : !hasErrors ? (
+                    <Button onClick={() => setShowConfirm(true)} disabled={isSubmitting}>
+                      {isSubmitting ? '送信中...' : `${rowCount}件を一括登録する`}
+                    </Button>
+                  ) : (
+                    <Button onClick={handleValidate}>再検証する</Button>
+                  )}
+                  <Button variant="outline" onClick={handleReset}>
+                    リセット
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {submitResult && (
+            <SubmitResultCard
+              mode="create"
+              totalRequested={submitResult.totalRequested}
+              succeeded={submitResult.created}
+              onReset={handleReset}
+            />
+          )}
+
+          {!submitResult && (
+            <WizardNav onBack={() => goToStep(1)} />
+          )}
+        </div>
       )}
 
       <ConfirmDialog

--- a/src/components/bulk-import/BulkUpdatePlotPanel.tsx
+++ b/src/components/bulk-import/BulkUpdatePlotPanel.tsx
@@ -18,6 +18,13 @@ import {
   ValidationErrorList,
   SubmitResultCard,
 } from './shared';
+import { WizardStepper, WizardNav, WizardStep } from './WizardStepper';
+
+const STEPS: WizardStep[] = [
+  { id: 'download', label: 'テンプレート取得', description: 'テンプレートまたは既存データから' },
+  { id: 'prepare', label: 'データ編集', description: 'Excelで編集（空欄=変更なし）' },
+  { id: 'upload', label: 'アップロード', description: '検証して一括編集' },
+];
 
 /**
  * 区画 一括編集パネル
@@ -30,6 +37,8 @@ import {
  * zaitsu82/komine-crm-backend#74 で実装予定。
  */
 export function BulkUpdatePlotPanel() {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [maxReachedStep, setMaxReachedStep] = useState(0);
   const [file, setFile] = useState<File | null>(null);
   const [plots, setPlots] = useState<ParsedPlot[]>([]);
   const [errors, setErrors] = useState<ValidationError[]>([]);
@@ -45,6 +54,16 @@ export function BulkUpdatePlotPanel() {
       error: { message: string; details?: Array<{ field?: string; message: string }> };
     }>;
   } | null>(null);
+
+  const goToStep = useCallback((next: number) => {
+    setCurrentStep(next);
+    setMaxReachedStep((prev) => Math.max(prev, next));
+  }, []);
+
+  const handleDownload = useCallback(() => {
+    downloadPlotTemplate('update');
+    setMaxReachedStep((prev) => Math.max(prev, 1));
+  }, []);
 
   const handleFileSelect = useCallback(async (f: File) => {
     const ext = f.name.split('.').pop()?.toLowerCase();
@@ -112,124 +131,179 @@ export function BulkUpdatePlotPanel() {
     setErrors([]);
     setIsValidated(false);
     setSubmitResult(null);
+    setCurrentStep(0);
+    setMaxReachedStep(0);
   }, []);
 
   const rowCount = plots.length;
   const hasErrors = errors.length > 0;
 
   return (
-    <div className="space-y-6 mt-4">
-      {/* 背景ノート */}
-      <Card>
-        <CardContent className="pt-6">
-          <div className="flex items-start gap-3 p-4 bg-kinari rounded-lg border border-gin">
-            <svg
-              className="w-5 h-5 text-matsu flex-shrink-0 mt-0.5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <div className="text-sm text-sumi space-y-1">
-              <p className="font-semibold">一括編集の使い方</p>
-              <ul className="list-disc list-inside space-y-0.5 ml-1 text-hai">
-                <li>
-                  テンプレートをダウンロード、または区画一覧画面から対象区画を選択してエクスポート
-                </li>
-                <li>Excelで値を編集（<span className="font-medium">空欄=変更しない</span>、既存値を保持）</li>
-                <li>アップロード → データを検証 → 一括編集を実行</li>
-                <li>マッチングキーは <span className="font-medium">区画番号</span>。既存データに存在しない区画番号はエラーになります</li>
-              </ul>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+    <div className="space-y-4 mt-4">
+      {/* 背景ノート（常時表示） */}
+      <div className="flex items-start gap-3 p-3 md:p-4 bg-kinari rounded-lg border border-gin">
+        <svg
+          className="w-5 h-5 text-matsu flex-shrink-0 mt-0.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <div className="text-xs md:text-sm text-sumi space-y-1">
+          <p className="font-semibold">一括編集の要点</p>
+          <ul className="list-disc list-inside space-y-0.5 ml-1 text-hai">
+            <li>空欄セルは <span className="font-medium">変更しない</span>（既存値を保持）</li>
+            <li>マッチングキーは <span className="font-medium">区画番号</span>。存在しない番号はエラー</li>
+          </ul>
+        </div>
+      </div>
 
-      {/* テンプレートダウンロード */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">テンプレートダウンロード</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-hai mb-4">
-            新規でテンプレートから作る場合はこちら。実データから編集したい場合は区画一覧画面からエクスポートしてください（準備中）。
-          </p>
-          <Button variant="outline" onClick={() => downloadPlotTemplate('update')}>
-            <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-              />
-            </svg>
-            一括編集テンプレート (.xlsx)
-          </Button>
-        </CardContent>
-      </Card>
+      <WizardStepper
+        steps={STEPS}
+        currentStep={currentStep}
+        maxReachedStep={maxReachedStep}
+        onStepChange={goToStep}
+      />
 
-      {/* フォーマット仕様 */}
-      <PlotFormatSpec mode="update" />
+      {/* Step 1: テンプレート取得 */}
+      {currentStep === 0 && (
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">テンプレートをダウンロード</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-hai mb-4">
+                新規でテンプレートから作る場合はこちら。実データから編集したい場合は区画一覧画面からエクスポートしてください（準備中）。
+              </p>
+              <Button variant="outline" onClick={handleDownload}>
+                <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
+                </svg>
+                一括編集テンプレート (.xlsx)
+              </Button>
+            </CardContent>
+          </Card>
 
-      {/* ファイルアップロード */}
-      {!submitResult && (
-        <FileUploadZone
-          file={file}
-          onFileSelect={handleFileSelect}
-          helperText={`最大${MAX_PLOTS_PER_BATCH}件まで一括編集可能`}
-        />
+          <PlotFormatSpec mode="update" />
+
+          <WizardNav onNext={() => goToStep(1)} nextLabel="データ編集へ進む" />
+        </div>
       )}
 
-      {rowCount > 0 && !submitResult && (
-        <>
-          <PlotPreview plots={plots} errors={errors} totalRowCount={rowCount} />
-
+      {/* Step 2: データ編集案内 */}
+      {currentStep === 1 && (
+        <div className="space-y-4">
           <Card>
             <CardContent className="pt-6">
-              {isValidated && <ValidationErrorList errors={errors} />}
-
-              {isValidated && !hasErrors && (
-                <div className="mt-4 p-4 bg-matsu-50 border border-matsu-200 rounded-lg">
-                  <p className="text-sm text-matsu font-medium">
-                    バリデーション成功: 全{rowCount}件のデータに問題はありません。
-                  </p>
+              <div className="flex items-start gap-3 p-4 bg-ai-50 rounded-lg border border-ai-200">
+                <svg
+                  className="w-5 h-5 text-ai flex-shrink-0 mt-0.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                  />
+                </svg>
+                <div className="text-sm text-sumi space-y-2">
+                  <p className="font-semibold">ダウンロードしたファイルをExcelで編集してください</p>
+                  <ul className="list-disc list-inside space-y-1 ml-1 text-hai">
+                    <li>マッチングキー: <span className="font-medium text-sumi">区画番号</span>（既存に存在しない番号はエラー）</li>
+                    <li>空欄セル = <span className="font-medium text-sumi">変更しない</span>（既存値を保持）</li>
+                    <li>1ファイルに最大 <span className="font-medium text-sumi">{MAX_PLOTS_PER_BATCH}件</span> まで編集可能</li>
+                    <li>編集が終わったら保存して、次のステップでアップロードします</li>
+                  </ul>
                 </div>
-              )}
-
-              <div className="mt-6 flex items-center gap-3 flex-wrap">
-                {!isValidated ? (
-                  <Button onClick={handleValidate}>データを検証する</Button>
-                ) : !hasErrors ? (
-                  <Button onClick={handleSubmit} disabled={isSubmitting}>
-                    {isSubmitting ? '送信中...' : `${rowCount}件を一括編集する`}
-                  </Button>
-                ) : (
-                  <Button onClick={handleValidate}>再検証する</Button>
-                )}
-                <Button variant="outline" onClick={handleReset}>
-                  リセット
-                </Button>
               </div>
             </CardContent>
           </Card>
-        </>
+
+          <WizardNav
+            onBack={() => goToStep(0)}
+            onNext={() => goToStep(2)}
+            nextLabel="編集完了、アップロードへ"
+          />
+        </div>
       )}
 
-      {submitResult && (
-        <SubmitResultCard
-          mode="update"
-          totalRequested={submitResult.totalRequested}
-          succeeded={submitResult.succeeded}
-          failed={submitResult.failed}
-          onReset={handleReset}
-        />
+      {/* Step 3: アップロード */}
+      {currentStep === 2 && (
+        <div className="space-y-4">
+          {!submitResult && (
+            <FileUploadZone
+              file={file}
+              onFileSelect={handleFileSelect}
+              helperText={`最大${MAX_PLOTS_PER_BATCH}件まで一括編集可能`}
+            />
+          )}
+
+          {rowCount > 0 && !submitResult && (
+            <>
+              <PlotPreview plots={plots} errors={errors} totalRowCount={rowCount} />
+
+              <Card>
+                <CardContent className="pt-6">
+                  {isValidated && <ValidationErrorList errors={errors} />}
+
+                  {isValidated && !hasErrors && (
+                    <div className="mt-4 p-4 bg-matsu-50 border border-matsu-200 rounded-lg">
+                      <p className="text-sm text-matsu font-medium">
+                        バリデーション成功: 全{rowCount}件のデータに問題はありません。
+                      </p>
+                    </div>
+                  )}
+
+                  <div className="mt-6 flex items-center gap-3 flex-wrap">
+                    {!isValidated ? (
+                      <Button onClick={handleValidate}>データを検証する</Button>
+                    ) : !hasErrors ? (
+                      <Button onClick={handleSubmit} disabled={isSubmitting}>
+                        {isSubmitting ? '送信中...' : `${rowCount}件を一括編集する`}
+                      </Button>
+                    ) : (
+                      <Button onClick={handleValidate}>再検証する</Button>
+                    )}
+                    <Button variant="outline" onClick={handleReset}>
+                      リセット
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            </>
+          )}
+
+          {submitResult && (
+            <SubmitResultCard
+              mode="update"
+              totalRequested={submitResult.totalRequested}
+              succeeded={submitResult.succeeded}
+              failed={submitResult.failed}
+              onReset={handleReset}
+            />
+          )}
+
+          {!submitResult && (
+            <WizardNav onBack={() => goToStep(1)} />
+          )}
+        </div>
       )}
 
       <ConfirmDialog

--- a/src/components/bulk-import/WizardStepper.tsx
+++ b/src/components/bulk-import/WizardStepper.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface WizardStep {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+interface WizardStepperProps {
+  steps: WizardStep[];
+  currentStep: number;
+  maxReachedStep: number;
+  onStepChange: (index: number) => void;
+}
+
+export function WizardStepper({
+  steps,
+  currentStep,
+  maxReachedStep,
+  onStepChange,
+}: WizardStepperProps) {
+  return (
+    <nav aria-label="一括インポート手順" className="mb-4 md:mb-6">
+      <ol className="flex items-center gap-1 md:gap-2">
+        {steps.map((step, index) => {
+          const isCurrent = index === currentStep;
+          const isCompleted = index < maxReachedStep || index < currentStep;
+          const isAccessible = index <= maxReachedStep;
+
+          return (
+            <li key={step.id} className="flex-1 flex items-center min-w-0">
+              <button
+                type="button"
+                onClick={() => isAccessible && onStepChange(index)}
+                disabled={!isAccessible}
+                aria-current={isCurrent ? 'step' : undefined}
+                className={cn(
+                  'flex-1 flex items-center gap-2 md:gap-3 px-2 md:px-3 py-2 md:py-2.5 rounded-elegant border transition-all duration-200 text-left min-w-0',
+                  isCurrent
+                    ? 'bg-ai-50 border-ai shadow-elegant-sm'
+                    : isCompleted
+                      ? 'bg-matsu-50 border-matsu-200 hover:bg-matsu-100'
+                      : 'bg-white border-gin opacity-60 cursor-not-allowed'
+                )}
+              >
+                <span
+                  className={cn(
+                    'shrink-0 w-6 h-6 md:w-7 md:h-7 rounded-full flex items-center justify-center text-xs md:text-sm font-bold tabular-nums',
+                    isCurrent
+                      ? 'bg-ai text-white'
+                      : isCompleted
+                        ? 'bg-matsu text-white'
+                        : 'bg-kinari text-hai border border-gin'
+                  )}
+                >
+                  {isCompleted && !isCurrent ? (
+                    <Check className="w-3.5 h-3.5 md:w-4 md:h-4" />
+                  ) : (
+                    index + 1
+                  )}
+                </span>
+                <div className="min-w-0">
+                  <div
+                    className={cn(
+                      'text-xs md:text-sm font-semibold truncate',
+                      isCurrent ? 'text-ai' : isCompleted ? 'text-matsu-dark' : 'text-hai'
+                    )}
+                  >
+                    {step.label}
+                  </div>
+                  {step.description && (
+                    <div className="hidden md:block text-[11px] text-hai truncate">
+                      {step.description}
+                    </div>
+                  )}
+                </div>
+              </button>
+              {index < steps.length - 1 && (
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'shrink-0 w-4 md:w-8 h-px mx-1',
+                    isCompleted ? 'bg-matsu' : 'bg-gin'
+                  )}
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+interface WizardNavProps {
+  onBack?: () => void;
+  onNext?: () => void;
+  nextLabel?: string;
+  backLabel?: string;
+  nextDisabled?: boolean;
+  className?: string;
+}
+
+export function WizardNav({
+  onBack,
+  onNext,
+  nextLabel = '次へ',
+  backLabel = '戻る',
+  nextDisabled,
+  className,
+}: WizardNavProps) {
+  return (
+    <div className={cn('mt-4 flex items-center gap-3 flex-wrap', className)}>
+      {onBack && (
+        <button
+          type="button"
+          onClick={onBack}
+          className="px-4 py-2 text-sm font-medium text-hai hover:text-sumi border border-gin rounded-elegant hover:bg-kinari transition-colors"
+        >
+          ← {backLabel}
+        </button>
+      )}
+      {onNext && (
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={nextDisabled}
+          className="px-4 py-2 text-sm font-medium text-white bg-ai hover:bg-ai-dark rounded-elegant transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {nextLabel} →
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Refs #104（UI/UXフェーズ4 個別画面改修の2/4）

## Summary

issue #104 フェーズ4のうち \`/bulk-import\` を対応。上から下に全情報が縦積みだった設計を、3ステップのウィザード形式に変更。

### 変更点

- **新規** \`src/components/bulk-import/WizardStepper.tsx\`
  - プログレス表示（完了=✓チェック、現在=番号強調、未到達=disabled）
  - 各ステップをクリックで移動可能（未到達ステップは不可）
  - \`WizardNav\` ヘルパー（戻る/次へ）も同梱
- **区画一括登録 / 一括編集 / スタッフ一括登録** の3パネルすべてを同じウィザード構成に統一:
  - Step 1: テンプレート取得 — DLボタン + フォーマット仕様
  - Step 2: データ入力・編集 — Excelでの作業手順をガイド
  - Step 3: アップロード — ファイル選択 → 検証 → 送信 → 結果
- 各ステップで不要な情報を非表示にし、**初期状態の情報密度を大幅削減**
- DLボタンクリックでStep2が解放、Step2の次へでStep3が解放
- リセット時はStep1に戻る
- **一括編集パネル**は「空欄=変更なし・マッチングキーは区画番号」の要点ノートをステッパー上部に常時表示（重要な注意事項のため）

### 既存動作の保持

- バリデーション・送信・結果表示・エラーリスト・プレビュー — すべて従来と同じ
- テンプレートダウンロード関数や API呼び出しは変更なし
- 確認ダイアログも従来通り

## Test plan

- [ ] \`npm run lint\` エラー無し
- [ ] \`npm run build\` 成功（/bulk-import: 272kB → 274kB）
- [ ] /bulk-import を開き、3タブ（区画登録/区画編集/スタッフ登録）でそれぞれウィザードが表示される
- [ ] Step1でテンプレートDL後、Step2が解放される
- [ ] Step2の「入力完了、次へ」でStep3が解放される
- [ ] Step3でファイルをアップロード → 検証 → 送信までできる
- [ ] リセット時にStep1に戻る
- [ ] ステッパーの完了済みステップをクリックして戻れる
- [ ] モバイル375pxでもステッパーが読める（ラベルのみ表示、説明は sm: 以降）
- [ ] 一括編集タブで背景ノート（「空欄=変更なし」）が全ステップで表示される