### PR TITLE
test(plot-form): PlotFormコンポーネントスイートのユニットテストを追加 (#117)

### DIFF
--- a/src/__tests__/components/plot-form/basic-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/basic-info-tab.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { BasicInfoTab } from '@/components/plot-form/BasicInfoTab';
+import { TabHost, emptyMasterData } from './test-helpers';
+
+// Radix UI Select はJSDOMで動かないため最小モック
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children, value, onValueChange }: { children: React.ReactNode; value?: string; onValueChange?: (v: string) => void }) => (
+    <div data-testid="mock-select" data-value={value}>
+      <button
+        type="button"
+        data-testid={`mock-select-trigger-${value || 'empty'}`}
+        onClick={() => onValueChange?.('test-value')}
+      >
+        trigger
+      </button>
+      {children}
+    </div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <div data-testid={`mock-select-item-${value}`}>{children}</div>
+  ),
+}));
+
+describe('BasicInfoTab', () => {
+  it('物理区画情報・契約区画情報・販売契約情報・契約者情報の4セクションを表示する', () => {
+    render(
+      <TabHost>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    expect(screen.getByText('物理区画情報')).toBeInTheDocument();
+    expect(screen.getByText('契約区画情報')).toBeInTheDocument();
+    expect(screen.getByText('販売契約情報')).toBeInTheDocument();
+    expect(screen.getByText('契約者情報')).toBeInTheDocument();
+  });
+
+  it('必須項目に*マークが表示される', () => {
+    render(
+      <TabHost>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    // 区画番号、契約面積、契約日、金額、氏名、氏名カナ、郵便番号、住所、電話番号 が必須
+    const asterisks = screen.getAllByText('*');
+    expect(asterisks.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('区画番号フィールドに入力できる', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    const plotNumberInput = screen.getByPlaceholderText('例: A-001');
+    await user.type(plotNumberInput, 'B-100');
+    expect(plotNumberInput).toHaveValue('B-100');
+  });
+
+  it('氏名フィールドに入力できる', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    const nameInput = screen.getByPlaceholderText('山田 太郎');
+    await user.type(nameInput, '田中花子');
+    expect(nameInput).toHaveValue('田中花子');
+  });
+
+  it('errors props経由でエラーメッセージが表示される', () => {
+    // errors をフォームに直接埋め込んで確認できないため、
+    // BasicInfoTab に直接 errors を渡してエラー表示を確認する
+    function ErrorHost() {
+      return (
+        <TabHost>
+          {(h) => (
+            <BasicInfoTab
+              {...h}
+              errors={
+                {
+                  physicalPlot: { plotNumber: { message: '区画番号は必須です', type: 'required' } },
+                  customer: { name: { message: '氏名は必須です', type: 'required' } },
+                } as typeof h.errors
+              }
+              masterData={emptyMasterData}
+            />
+          )}
+        </TabHost>
+      );
+    }
+    render(<ErrorHost />);
+
+    expect(screen.getByText('区画番号は必須です')).toBeInTheDocument();
+    expect(screen.getByText('氏名は必須です')).toBeInTheDocument();
+  });
+
+  it('viewMode=trueの場合、入力フィールドの代わりに表示用ボックスを使う', () => {
+    render(
+      <TabHost defaultValues={{
+        physicalPlot: { plotNumber: 'A-001', areaName: '第1期', areaSqm: 3.6, notes: null },
+      }}>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} viewMode={true} />}
+      </TabHost>
+    );
+
+    // viewMode の場合、`例: A-001` プレースホルダーの入力欄は出ない
+    expect(screen.queryByPlaceholderText('例: A-001')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('山田 太郎')).not.toBeInTheDocument();
+    // 区画 (areaName) は watch() から表示する独自実装
+    expect(screen.getByText('第1期')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/plot-form/burial-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/burial-info-tab.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { BurialInfoTab } from '@/components/plot-form/BurialInfoTab';
+import { TabHost, emptyMasterData } from './test-helpers';
+
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-testid="mock-select" data-value={value}>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <div data-testid={`mock-select-item-${value}`}>{children}</div>
+  ),
+}));
+
+// Switch コンポーネントのモック（Radix UIベース）
+jest.mock('@/components/ui/switch', () => ({
+  Switch: ({ checked, onCheckedChange, id }: { checked?: boolean; onCheckedChange?: (v: boolean) => void; id?: string }) => (
+    <input
+      type="checkbox"
+      id={id}
+      checked={!!checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+    />
+  ),
+}));
+
+function BurialInfoTabHost({ defaultValues }: { defaultValues?: Parameters<typeof TabHost>[0]['defaultValues'] }) {
+  return (
+    <TabHost arrayName="buriedPersons" defaultValues={defaultValues}>
+      {(h) => (
+        <BurialInfoTab
+          {...h}
+          buriedPersonFields={h.arrayFields ?? []}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          addBuriedPerson={h.arrayAppend as any}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          removeBuriedPerson={h.arrayRemove as any}
+          masterData={emptyMasterData}
+        />
+      )}
+    </TabHost>
+  );
+}
+
+describe('BurialInfoTab', () => {
+  it('埋葬者情報・合祀設定・墓石情報のセクションヘッダーを表示する', () => {
+    render(<BurialInfoTabHost />);
+
+    expect(screen.getByText('埋葬者情報')).toBeInTheDocument();
+    expect(screen.getByText('合祀設定')).toBeInTheDocument();
+    expect(screen.getByText('墓石情報')).toBeInTheDocument();
+  });
+
+  it('初期状態では「埋葬者が登録されていません」を表示する', () => {
+    render(<BurialInfoTabHost />);
+    expect(screen.getByText('埋葬者が登録されていません')).toBeInTheDocument();
+  });
+
+  it('「埋葬者を追加」ボタンで行が追加される', async () => {
+    const user = userEvent.setup();
+    render(<BurialInfoTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /埋葬者を追加/ }));
+
+    expect(screen.getByText('未入力')).toBeInTheDocument();
+    expect(screen.queryByText('埋葬者が登録されていません')).not.toBeInTheDocument();
+  });
+
+  it('複数行追加できる', async () => {
+    const user = userEvent.setup();
+    render(<BurialInfoTabHost />);
+
+    const addBtn = screen.getByRole('button', { name: /埋葬者を追加/ });
+    await user.click(addBtn);
+    await user.click(addBtn);
+
+    expect(screen.getAllByText('未入力')).toHaveLength(2);
+  });
+
+  it('サマリー行クリックで展開され、入力欄が表示される', async () => {
+    const user = userEvent.setup();
+    render(<BurialInfoTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /埋葬者を追加/ }));
+    await user.click(screen.getByText('未入力'));
+
+    // 展開後は戒名・宗派など埋葬者特有のフィールドが見える
+    expect(screen.getByLabelText('戒名')).toBeInTheDocument();
+    expect(screen.getByLabelText('享年')).toBeInTheDocument();
+  });
+
+  it('削除ボタンで埋葬者行が削除される', async () => {
+    const user = userEvent.setup();
+    render(<BurialInfoTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /埋葬者を追加/ }));
+    expect(screen.getByText('未入力')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '埋葬者を削除' }));
+    expect(screen.queryByText('未入力')).not.toBeInTheDocument();
+    expect(screen.getByText('埋葬者が登録されていません')).toBeInTheDocument();
+  });
+
+  it('合祀対象トグルONで埋葬上限・有効期間の入力欄が表示される', async () => {
+    const user = userEvent.setup();
+    render(<BurialInfoTabHost />);
+
+    const toggle = screen.getByLabelText('合祀対象区画') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+
+    await user.click(toggle);
+
+    expect(screen.getByLabelText(/埋葬上限数/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/有効期間/)).toBeInTheDocument();
+  });
+
+  it('「墓石情報を追加」で墓石情報セクションが展開される', async () => {
+    const user = userEvent.setup();
+    render(<BurialInfoTabHost />);
+
+    await user.click(screen.getByRole('button', { name: '墓石情報を追加' }));
+    expect(screen.getByPlaceholderText('御影石')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '墓石情報を削除' })).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/plot-form/construction-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/construction-info-tab.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ConstructionInfoTab } from '@/components/plot-form/ConstructionInfoTab';
+import { TabHost, emptyMasterData } from './test-helpers';
+
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-testid="mock-select" data-value={value}>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <div data-testid={`mock-select-item-${value}`}>{children}</div>
+  ),
+}));
+
+function ConstructionInfoTabHost() {
+  return (
+    <TabHost arrayName="constructionInfos">
+      {(h) => (
+        <ConstructionInfoTab
+          {...h}
+          constructionInfoFields={h.arrayFields ?? []}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          addConstructionInfo={h.arrayAppend as any}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          removeConstructionInfo={h.arrayRemove as any}
+          masterData={emptyMasterData}
+        />
+      )}
+    </TabHost>
+  );
+}
+
+describe('ConstructionInfoTab', () => {
+  it('工事情報ヘッダー・テーブルヘッダーを表示する', () => {
+    render(<ConstructionInfoTabHost />);
+
+    expect(screen.getByText('工事情報')).toBeInTheDocument();
+    expect(screen.getByText('施工業者')).toBeInTheDocument();
+    expect(screen.getByText('工事種別')).toBeInTheDocument();
+    expect(screen.getByText('進捗')).toBeInTheDocument();
+  });
+
+  it('初期状態では「工事情報が登録されていません」を表示する', () => {
+    render(<ConstructionInfoTabHost />);
+    expect(screen.getByText('工事情報が登録されていません')).toBeInTheDocument();
+  });
+
+  it('「工事を追加」ボタンで行が追加される', async () => {
+    const user = userEvent.setup();
+    render(<ConstructionInfoTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /工事を追加/ }));
+
+    expect(screen.getByText('未入力')).toBeInTheDocument();
+    expect(screen.queryByText('工事情報が登録されていません')).not.toBeInTheDocument();
+  });
+
+  it('複数行追加できる', async () => {
+    const user = userEvent.setup();
+    render(<ConstructionInfoTabHost />);
+
+    const addBtn = screen.getByRole('button', { name: /工事を追加/ });
+    await user.click(addBtn);
+    await user.click(addBtn);
+
+    expect(screen.getAllByText('未入力')).toHaveLength(2);
+  });
+
+  it('サマリー行クリックで展開され、工事基本情報・日程セクションが表示される', async () => {
+    const user = userEvent.setup();
+    render(<ConstructionInfoTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /工事を追加/ }));
+    await user.click(screen.getByText('未入力'));
+
+    expect(screen.getByText('工事基本情報')).toBeInTheDocument();
+    expect(screen.getByText('日程')).toBeInTheDocument();
+    expect(screen.getByText('許可・申請情報')).toBeInTheDocument();
+    expect(screen.getByText('工事項目')).toBeInTheDocument();
+    expect(screen.getByText('入金情報')).toBeInTheDocument();
+  });
+
+  it('展開された行の施工業者フィールドに入力できる', async () => {
+    const user = userEvent.setup();
+    render(<ConstructionInfoTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /工事を追加/ }));
+    await user.click(screen.getByText('未入力'));
+
+    const contractorInput = screen.getByLabelText('施工業者');
+    await user.type(contractorInput, '○○建設');
+    expect(contractorInput).toHaveValue('○○建設');
+  });
+
+  it('削除ボタンで工事行が削除される', async () => {
+    const user = userEvent.setup();
+    render(<ConstructionInfoTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /工事を追加/ }));
+    await user.click(screen.getByRole('button', { name: '工事情報を削除' }));
+
+    expect(screen.queryByText('未入力')).not.toBeInTheDocument();
+    expect(screen.getByText('工事情報が登録されていません')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/plot-form/contacts-tab.test.tsx
+++ b/src/__tests__/components/plot-form/contacts-tab.test.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { ContactsTab } from '@/components/plot-form/ContactsTab';
+import { TabHost, emptyMasterData } from './test-helpers';
+
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-testid="mock-select" data-value={value}>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <div data-testid={`mock-select-item-${value}`}>{children}</div>
+  ),
+}));
+
+function ContactsTabHost() {
+  const [expandedContactId, setExpandedContactId] = useState<string | null>(null);
+  return (
+    <TabHost arrayName="familyContacts">
+      {(h) => (
+        <ContactsTab
+          {...h}
+          familyContactFields={h.arrayFields ?? []}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          addFamilyContact={h.arrayAppend as any}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          removeFamilyContact={h.arrayRemove as any}
+          expandedContactId={expandedContactId}
+          setExpandedContactId={setExpandedContactId}
+          masterData={emptyMasterData}
+        />
+      )}
+    </TabHost>
+  );
+}
+
+describe('ContactsTab', () => {
+  it('初期状態では「家族連絡先が登録されていません」を表示する', () => {
+    render(<ContactsTabHost />);
+    expect(screen.getByText('家族連絡先が登録されていません')).toBeInTheDocument();
+  });
+
+  it('「連絡先を追加」ボタンで行が追加される', async () => {
+    const user = userEvent.setup();
+    render(<ContactsTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /連絡先を追加/ }));
+
+    // 「未入力」の行サマリーが表示される
+    expect(screen.getByText('未入力')).toBeInTheDocument();
+    expect(screen.queryByText('家族連絡先が登録されていません')).not.toBeInTheDocument();
+  });
+
+  it('複数回「連絡先を追加」で複数行追加できる', async () => {
+    const user = userEvent.setup();
+    render(<ContactsTabHost />);
+
+    const addBtn = screen.getByRole('button', { name: /連絡先を追加/ });
+    await user.click(addBtn);
+    await user.click(addBtn);
+    await user.click(addBtn);
+
+    expect(screen.getAllByText('未入力')).toHaveLength(3);
+  });
+
+  it('行のサマリーをクリックすると展開して入力欄が表示される', async () => {
+    const user = userEvent.setup();
+    render(<ContactsTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /連絡先を追加/ }));
+    // 展開前は氏名Inputが見えない（要素がconditionally render）
+    expect(screen.queryByLabelText(/氏名/)).not.toBeInTheDocument();
+
+    // サマリー行をクリック
+    await user.click(screen.getByText('未入力'));
+    // 展開後は氏名Inputが見える
+    expect(screen.getByLabelText(/氏名/)).toBeInTheDocument();
+  });
+
+  it('展開された行で氏名フィールドに入力できる', async () => {
+    const user = userEvent.setup();
+    render(<ContactsTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /連絡先を追加/ }));
+    await user.click(screen.getByText('未入力'));
+
+    const nameInput = screen.getByLabelText(/氏名/);
+    await user.type(nameInput, '田中花子');
+    expect(nameInput).toHaveValue('田中花子');
+  });
+
+  it('削除ボタンクリックで該当行が削除される', async () => {
+    const user = userEvent.setup();
+    render(<ContactsTabHost />);
+
+    await user.click(screen.getByRole('button', { name: /連絡先を追加/ }));
+    await user.click(screen.getByRole('button', { name: /連絡先を追加/ }));
+    expect(screen.getAllByText('未入力')).toHaveLength(2);
+
+    const deleteButtons = screen.getAllByRole('button', { name: '連絡先を削除' });
+    await user.click(deleteButtons[0]);
+
+    expect(screen.getAllByText('未入力')).toHaveLength(1);
+  });
+
+  it('errors props経由でエラーメッセージが表示される', async () => {
+    const user = userEvent.setup();
+    function ErrorHost() {
+      const [expandedContactId, setExpandedContactId] = useState<string | null>(null);
+      return (
+        <TabHost
+          arrayName="familyContacts"
+          defaultValues={{
+            familyContacts: [
+              {
+                emergencyContactFlag: false,
+                name: '',
+                relationship: '',
+                address: '',
+                phoneNumber: '',
+                birthDate: null,
+                postalCode: null,
+                faxNumber: null,
+                email: null,
+                registeredAddress: null,
+                mailingType: null,
+                notes: null,
+              },
+            ],
+          }}
+        >
+          {(h) => (
+            <ContactsTab
+              {...h}
+              familyContactFields={h.arrayFields ?? []}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              addFamilyContact={h.arrayAppend as any}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              removeFamilyContact={h.arrayRemove as any}
+              expandedContactId={expandedContactId}
+              setExpandedContactId={setExpandedContactId}
+              errors={
+                {
+                  familyContacts: [
+                    { name: { message: '氏名は必須です', type: 'required' } },
+                  ],
+                } as typeof h.errors
+              }
+              masterData={emptyMasterData}
+            />
+          )}
+        </TabHost>
+      );
+    }
+    render(<ErrorHost />);
+
+    await user.click(screen.getByText('未入力'));
+    expect(screen.getByText('氏名は必須です')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/plot-form/fee-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/fee-info-tab.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { FeeInfoTab } from '@/components/plot-form/FeeInfoTab';
+import { TabHost, emptyMasterData } from './test-helpers';
+
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-testid="mock-select" data-value={value}>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <div data-testid={`mock-select-item-${value}`}>{children}</div>
+  ),
+}));
+
+describe('FeeInfoTab', () => {
+  it('初期状態では使用料・管理料ともに「登録されていません」を表示する', () => {
+    render(
+      <TabHost>
+        {(h) => <FeeInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    expect(screen.getByText('使用料が登録されていません')).toBeInTheDocument();
+    expect(screen.getByText('管理料が登録されていません')).toBeInTheDocument();
+  });
+
+  it('「使用料を追加」ボタンクリックで使用料セクションが表示される', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <FeeInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    const addButton = screen.getByRole('button', { name: '使用料を追加' });
+    await user.click(addButton);
+
+    // 「登録されていません」メッセージが消える
+    expect(screen.queryByText('使用料が登録されていません')).not.toBeInTheDocument();
+    // 「使用料を削除」ボタンに変わる
+    expect(screen.getByRole('button', { name: '使用料を削除' })).toBeInTheDocument();
+    // 使用料の入力欄が表示される
+    expect(screen.getByPlaceholderText('36000')).toBeInTheDocument();
+  });
+
+  it('「管理料を追加」ボタンクリックで管理料セクションが表示される', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <FeeInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    const addButton = screen.getByRole('button', { name: '管理料を追加' });
+    await user.click(addButton);
+
+    expect(screen.queryByText('管理料が登録されていません')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '管理料を削除' })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('12000')).toBeInTheDocument();
+  });
+
+  it('使用料追加→削除のトグル動作が正しい', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <FeeInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    await user.click(screen.getByRole('button', { name: '使用料を追加' }));
+    await user.click(screen.getByRole('button', { name: '使用料を削除' }));
+
+    expect(screen.getByText('使用料が登録されていません')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '使用料を追加' })).toBeInTheDocument();
+  });
+
+  it('使用料の単価フィールドに入力できる', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <FeeInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    await user.click(screen.getByRole('button', { name: '使用料を追加' }));
+    const unitPriceInput = screen.getByPlaceholderText('10000');
+    await user.type(unitPriceInput, '50000');
+    expect(unitPriceInput).toHaveValue('50000');
+  });
+
+  it('viewMode=trueの場合、追加・削除ボタンが表示されない', () => {
+    render(
+      <TabHost>
+        {(h) => <FeeInfoTab {...h} masterData={emptyMasterData} viewMode={true} />}
+      </TabHost>
+    );
+
+    expect(screen.queryByRole('button', { name: '使用料を追加' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '管理料を追加' })).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/plot-form/plot-form.test.tsx
+++ b/src/__tests__/components/plot-form/plot-form.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { ViewModeField, ViewModeSelect, ViewModeTextarea } from '@/components/plot-form/ViewModeField';
 import { HistoryTab } from '@/components/plot-form/HistoryTab';
@@ -10,6 +11,14 @@ import {
   PhysicalPlotStatus,
   ContractStatus,
 } from '@komine/types';
+
+// toast はテスト中サイレントにする
+jest.mock('@/lib/toast', () => ({
+  showWarning: jest.fn(),
+  showSuccess: jest.fn(),
+  showError: jest.fn(),
+  showInfo: jest.fn(),
+}));
 
 // ===== Mocks =====
 
@@ -502,5 +511,152 @@ describe('PlotForm', () => {
     );
 
     expect(container.querySelector('form')).toBeInTheDocument();
+  });
+
+  // ===== バリデーション・プレビューフロー =====
+
+  it('新規モードで未入力のまま送信するとバリデーションエラーリストが表示される', async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn();
+    render(<PlotForm onSave={onSave} onCancel={jest.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '登録' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('入力エラーがあります')).toBeInTheDocument();
+    });
+
+    // 必須エラー（区画番号は必須です）がエラーリストに含まれる
+    expect(screen.getByText(/区画番号: 区画番号は必須です/)).toBeInTheDocument();
+    // onSave は呼ばれない
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('バリデーションエラーがあるタブにエラーバッジ（!）が表示される', async () => {
+    const user = userEvent.setup();
+    render(<PlotForm onSave={jest.fn()} onCancel={jest.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '登録' }));
+
+    await waitFor(() => {
+      // tabsWithErrors が反映されてエラーバッジ「!」が複数表示される
+      const badges = screen.getAllByText('!');
+      expect(badges.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('編集モードでは plotDetail から初期値が反映される', () => {
+    const detail = makePlotDetail();
+    render(<PlotForm plotDetail={detail} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+    // 区画番号が初期値として入力されている
+    const plotNumberInput = screen.getByDisplayValue('A-001');
+    expect(plotNumberInput).toBeInTheDocument();
+    // 契約者氏名が初期値として入力されている
+    expect(screen.getByDisplayValue('田中太郎')).toBeInTheDocument();
+  });
+
+  it('plotDetail が後から変わると reset でフォーム値が更新される', () => {
+    const detail1 = makePlotDetail({
+      physicalPlot: {
+        id: 'pp-1',
+        plotNumber: 'A-001',
+        areaName: '第1期',
+        areaSqm: 3.6,
+        status: PhysicalPlotStatus.SoldOut,
+        notes: null,
+      },
+    });
+    const { rerender } = render(
+      <PlotForm plotDetail={detail1} onSave={jest.fn()} onCancel={jest.fn()} />
+    );
+    expect(screen.getByDisplayValue('A-001')).toBeInTheDocument();
+
+    const detail2 = makePlotDetail({
+      physicalPlot: {
+        id: 'pp-2',
+        plotNumber: 'B-200',
+        areaName: '第2期',
+        areaSqm: 1.8,
+        status: PhysicalPlotStatus.SoldOut,
+        notes: null,
+      },
+    });
+    rerender(
+      <PlotForm plotDetail={detail2} onSave={jest.fn()} onCancel={jest.fn()} />
+    );
+
+    expect(screen.getByDisplayValue('B-200')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('A-001')).not.toBeInTheDocument();
+  });
+
+  it('編集モードで送信すると差分プレビュー（PreviewDialog）が表示される', async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn();
+    const detail = makePlotDetail();
+    render(<PlotForm plotDetail={detail} onSave={onSave} onCancel={jest.fn()} />);
+
+    // 区画番号を変更
+    const plotNumberInput = screen.getByDisplayValue('A-001');
+    await user.clear(plotNumberInput);
+    await user.type(plotNumberInput, 'A-002');
+
+    // 更新ボタンクリック
+    await user.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('更新内容の確認')).toBeInTheDocument();
+    });
+    expect(screen.getByText('以下の項目が変更されます')).toBeInTheDocument();
+    // この時点では onSave はまだ呼ばれない（確認ダイアログ表示中）
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('プレビューで「確認して更新」をクリックすると onSave が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn();
+    const detail = makePlotDetail();
+    render(<PlotForm plotDetail={detail} onSave={onSave} onCancel={jest.fn()} />);
+
+    const plotNumberInput = screen.getByDisplayValue('A-001');
+    await user.clear(plotNumberInput);
+    await user.type(plotNumberInput, 'A-002');
+
+    await user.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '確認して更新' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: '確認して更新' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+    // onSave に渡されたデータには変更後の値が含まれる
+    expect(onSave.mock.calls[0][0].physicalPlot.plotNumber).toBe('A-002');
+  });
+
+  it('プレビューで「戻る」をクリックするとダイアログが閉じて onSave は呼ばれない', async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn();
+    const detail = makePlotDetail();
+    render(<PlotForm plotDetail={detail} onSave={onSave} onCancel={jest.fn()} />);
+
+    const plotNumberInput = screen.getByDisplayValue('A-001');
+    await user.clear(plotNumberInput);
+    await user.type(plotNumberInput, 'A-002');
+    await user.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '戻る' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: '戻る' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('更新内容の確認')).not.toBeInTheDocument();
+    });
+    expect(onSave).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/components/plot-form/test-helpers.tsx
+++ b/src/__tests__/components/plot-form/test-helpers.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { useForm, useFieldArray, Resolver } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  plotFormSchema,
+  defaultPlotFormData,
+} from '@/lib/validations/plot-form';
+import type { PlotFormData } from '@/lib/validations/plot-form';
+import type { MasterData } from '@/components/plot-form/types';
+
+export const emptyMasterData: MasterData = {
+  calcTypes: [],
+  taxTypes: [],
+  billingTypes: [],
+  paymentMethods: [],
+  accountTypes: [],
+  sectionNames: [],
+  isLoading: false,
+};
+
+export interface FormHandles {
+  register: ReturnType<typeof useForm<PlotFormData>>['register'];
+  watch: ReturnType<typeof useForm<PlotFormData>>['watch'];
+  setValue: ReturnType<typeof useForm<PlotFormData>>['setValue'];
+  errors: ReturnType<typeof useForm<PlotFormData>>['formState']['errors'];
+  control: ReturnType<typeof useForm<PlotFormData>>['control'];
+}
+
+interface TabHostProps {
+  defaultValues?: Partial<PlotFormData>;
+  arrayName?: 'familyContacts' | 'buriedPersons' | 'constructionInfos';
+  children: (handles: FormHandles & {
+    arrayFields?: ReturnType<typeof useFieldArray>['fields'];
+    arrayAppend?: ReturnType<typeof useFieldArray>['append'];
+    arrayRemove?: ReturnType<typeof useFieldArray>['remove'];
+    handleSubmit: ReturnType<typeof useForm<PlotFormData>>['handleSubmit'];
+  }) => React.ReactNode;
+}
+
+/**
+ * Renders a tab inside a real react-hook-form context.
+ * Pass `arrayName` to also wire up useFieldArray for that path.
+ */
+export function TabHost({ defaultValues, arrayName, children }: TabHostProps) {
+  const merged = { ...defaultPlotFormData, ...defaultValues } as PlotFormData;
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+    control,
+    handleSubmit,
+  } = useForm<PlotFormData>({
+    resolver: zodResolver(plotFormSchema) as Resolver<PlotFormData>,
+    defaultValues: merged,
+  });
+
+  const arr = useFieldArray({
+    control,
+    name: arrayName ?? 'familyContacts',
+  });
+
+  return (
+    <form>
+      {children({
+        register,
+        watch,
+        setValue,
+        errors,
+        control,
+        handleSubmit,
+        arrayFields: arrayName ? arr.fields : undefined,
+        arrayAppend: arrayName ? arr.append : undefined,
+        arrayRemove: arrayName ? arr.remove : undefined,
+      })}
+    </form>
+  );
+}

--- a/src/__tests__/components/plot-form/work-billing-tab.test.tsx
+++ b/src/__tests__/components/plot-form/work-billing-tab.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { WorkBillingTab } from '@/components/plot-form/WorkBillingTab';
+import { TabHost, emptyMasterData } from './test-helpers';
+
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-testid="mock-select" data-value={value}>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <div data-testid={`mock-select-item-${value}`}>{children}</div>
+  ),
+}));
+
+describe('WorkBillingTab', () => {
+  it('勤務先情報・請求情報のセクションヘッダーを表示する', () => {
+    render(
+      <TabHost>
+        {(h) => <WorkBillingTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    expect(screen.getByText('勤務先情報')).toBeInTheDocument();
+    expect(screen.getByText('請求情報')).toBeInTheDocument();
+  });
+
+  it('初期状態では「追加」ボタンが2つ表示される', () => {
+    render(
+      <TabHost>
+        {(h) => <WorkBillingTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    expect(screen.getAllByRole('button', { name: '追加' })).toHaveLength(2);
+  });
+
+  it('勤務先情報の「追加」ボタンクリックで入力欄が表示される', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <WorkBillingTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    const addButtons = screen.getAllByRole('button', { name: '追加' });
+    await user.click(addButtons[0]);
+
+    expect(screen.getByPlaceholderText('会社名')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('カイシャメイ')).toBeInTheDocument();
+  });
+
+  it('請求情報の「追加」ボタンクリックで銀行関連入力欄が表示される', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <WorkBillingTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    const addButtons = screen.getAllByRole('button', { name: '追加' });
+    await user.click(addButtons[1]);
+
+    expect(screen.getByPlaceholderText('○○銀行')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('△△支店')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('1234567')).toBeInTheDocument();
+  });
+
+  it('勤務先名称フィールドに入力できる', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <WorkBillingTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    await user.click(screen.getAllByRole('button', { name: '追加' })[0]);
+    const companyInput = screen.getByPlaceholderText('会社名');
+    await user.type(companyInput, '株式会社テスト');
+    expect(companyInput).toHaveValue('株式会社テスト');
+  });
+
+  it('追加→削除トグルで入力欄が消える', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <WorkBillingTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    const addButtons = screen.getAllByRole('button', { name: '追加' });
+    await user.click(addButtons[0]);
+    expect(screen.getByPlaceholderText('会社名')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '削除' }));
+    expect(screen.queryByPlaceholderText('会社名')).not.toBeInTheDocument();
+  });
+
+  it('errors propsで請求情報エラーメッセージが表示される', async () => {
+    const user = userEvent.setup();
+    function ErrorHost() {
+      return (
+        <TabHost>
+          {(h) => (
+            <WorkBillingTab
+              {...h}
+              errors={
+                {
+                  billingInfo: { bankName: { message: '銀行名は必須です', type: 'required' } },
+                } as typeof h.errors
+              }
+              masterData={emptyMasterData}
+            />
+          )}
+        </TabHost>
+      );
+    }
+    render(<ErrorHost />);
+
+    // 請求情報セクションを開く
+    const addButtons = screen.getAllByRole('button', { name: '追加' });
+    await user.click(addButtons[1]);
+
+    expect(screen.getByText('銀行名は必須です')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

issue #117 対応。PlotForm関連の各タブと親フォームの主要挙動を網羅するユニットテストを追加。

- BasicInfoTab / FeeInfoTab / WorkBillingTab — 初期表示・入力反映・追加/削除トグル・viewModeを検証
- ContactsTab / BurialInfoTab / ConstructionInfoTab — useFieldArray の追加・削除・展開トグル・入力反映を検証
- plot-form/index.tsx — バリデーション失敗時のタブバッジ「!」、エラーリスト表示、PreviewDialog 表示・差分・onSave 呼び出し・戻るキャンセルを検証
- 共通ヘルパー `test-helpers.tsx`（TabHost）を新設して各タブを実 react-hook-form コンテキスト上で検証
- 既存テストの ViewModeField / HistoryTab はそのまま、PlotForm セクションを拡張

## Test plan

- [x] `npm test` で全316テスト pass（追加分 +48）
- [x] `npm run lint` で新規テストのエラー/警告なし
- [ ] 既存の挙動に影響しないことをCIで確認

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)