### PR TITLE
feat: add Billing/Payment UI

### DIFF
--- a/src/app/(main)/billings/page.tsx
+++ b/src/app/(main)/billings/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import BillingManagement from '@/components/billing';
+
+export default function BillingsPage() {
+  return <BillingManagement />;
+}

--- a/src/app/(main)/payments/page.tsx
+++ b/src/app/(main)/payments/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import PaymentManagement from '@/components/payment';
+
+export default function PaymentsPage() {
+  return <PaymentManagement />;
+}

--- a/src/components/billing/billing-detail-dialog.tsx
+++ b/src/components/billing/billing-detail-dialog.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { BillingDetailResponse } from '@komine/types';
+import { getBillingById, BILLING_CATEGORY_LABELS, BILLING_RECORD_STATUS_LABELS } from '@/lib/api/billings';
+
+const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
+
+export interface BillingDetailDialogProps {
+  open: boolean;
+  billingId: string | null;
+  onClose: () => void;
+}
+
+export function BillingDetailDialog({ open, billingId, onClose }: BillingDetailDialogProps) {
+  const [data, setData] = useState<BillingDetailResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !billingId) {
+      setData(null);
+      setError(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    getBillingById(billingId)
+      .then((res) => {
+        if (res.success) setData(res.data);
+        else setError(res.error?.message ?? '取得に失敗しました');
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'エラーが発生しました'))
+      .finally(() => setLoading(false));
+  }, [open, billingId]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-elegant-lg shadow-elegant-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="bg-gradient-to-r from-ai-50 to-kinari px-6 py-4 border-b border-gin flex items-center justify-between">
+          <div>
+            <h3 className="font-mincho text-lg font-semibold text-sumi">請求詳細</h3>
+            <p className="text-sm text-hai mt-0.5">関連する入金履歴を含む</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-hai hover:text-sumi"
+            aria-label="閉じる"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-5 overflow-y-auto">
+          {loading && (
+            <div className="p-8 text-center text-hai">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-matsu mx-auto mb-3" />
+              読み込み中...
+            </div>
+          )}
+          {error && (
+            <div className="p-3 bg-beni-50 border border-beni-200 text-beni text-sm rounded-elegant">
+              {error}
+            </div>
+          )}
+          {data && <BillingDetailBody billing={data} />}
+        </div>
+
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gin bg-kinari">
+          <button
+            onClick={onClose}
+            className="border border-gin text-sumi hover:bg-white rounded-elegant px-4 py-2 text-sm font-medium"
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BillingDetailBody({ billing }: { billing: BillingDetailResponse }) {
+  const Row = ({ label, value }: { label: string; value: React.ReactNode }) => (
+    <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3 py-2 border-b border-gin last:border-b-0">
+      <div className="text-xs text-hai sm:w-32 flex-shrink-0">{label}</div>
+      <div className="text-sm text-sumi flex-1">{value || '-'}</div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h4 className="text-sm font-semibold text-sumi mb-2 font-mincho">基本情報</h4>
+        <div className="bg-kinari rounded-elegant-lg p-4">
+          <Row label="料金区分" value={BILLING_CATEGORY_LABELS[billing.category]} />
+          <Row
+            label="ステータス"
+            value={
+              <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-white border border-gin">
+                {BILLING_RECORD_STATUS_LABELS[billing.status]}
+              </span>
+            }
+          />
+          <Row label="区画" value={billing.plotNumber ? `${billing.plotNumber} (${billing.areaName ?? ''})` : '-'} />
+          <Row label="顧客" value={billing.customer?.name ?? '-'} />
+          <Row label="金額" value={<span className="tabular-nums">¥{billing.amount.toLocaleString('ja-JP')}</span>} />
+          <Row label="入金済" value={<span className="tabular-nums">¥{billing.paidAmount.toLocaleString('ja-JP')}</span>} />
+          <Row label="残額" value={<span className="tabular-nums">¥{(billing.amount - billing.paidAmount).toLocaleString('ja-JP')}</span>} />
+        </div>
+      </section>
+
+      <section>
+        <h4 className="text-sm font-semibold text-sumi mb-2 font-mincho">日付・期間</h4>
+        <div className="bg-kinari rounded-elegant-lg p-4">
+          <Row label="契約日" value={billing.contractDate} />
+          <Row label="請求日" value={billing.billingDate} />
+          <Row label="最終入金日" value={billing.lastPaymentDate} />
+          <Row label="使用開始年" value={billing.useStartYear} />
+          <Row label="使用終了年" value={billing.useEndYear} />
+          <Row label="対象月" value={billing.targetMonth} />
+          <Row label="請求年数" value={billing.billingYears} />
+          {billing.terminated && (
+            <Row label="解約日" value={billing.terminatedDate} />
+          )}
+        </div>
+      </section>
+
+      <section>
+        <h4 className="text-sm font-semibold text-sumi mb-2 font-mincho">入金履歴 ({billing.payments.length}件)</h4>
+        {billing.payments.length === 0 ? (
+          <div className="bg-kinari rounded-elegant-lg p-4 text-sm text-hai text-center">
+            入金履歴はありません
+          </div>
+        ) : (
+          <div className="bg-kinari rounded-elegant-lg overflow-hidden">
+            <table className="w-full">
+              <thead>
+                <tr className="bg-shiro border-b border-gin">
+                  <th className="px-3 py-2 text-left text-xs font-semibold text-sumi">入金日</th>
+                  <th className="px-3 py-2 text-right text-xs font-semibold text-sumi">入金額</th>
+                  <th className="px-3 py-2 text-left text-xs font-semibold text-sumi hidden sm:table-cell">担当者</th>
+                  <th className="px-3 py-2 text-left text-xs font-semibold text-sumi hidden md:table-cell">料金種別</th>
+                </tr>
+              </thead>
+              <tbody>
+                {billing.payments.map((p) => (
+                  <tr key={p.id} className="border-b border-gin last:border-b-0">
+                    <td className="px-3 py-2 text-sm text-sumi tabular-nums">{p.paymentDate ?? p.scheduledDate ?? '-'}</td>
+                    <td className="px-3 py-2 text-sm text-right text-sumi tabular-nums">{formatYen(p.paymentAmount)}</td>
+                    <td className="px-3 py-2 text-sm text-hai hidden sm:table-cell">{p.staffInCharge ?? '-'}</td>
+                    <td className="px-3 py-2 text-sm text-hai hidden md:table-cell">{p.feeType ?? '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {billing.notes && (
+        <section>
+          <h4 className="text-sm font-semibold text-sumi mb-2 font-mincho">備考</h4>
+          <div className="bg-kinari rounded-elegant-lg p-4 text-sm text-sumi whitespace-pre-wrap">
+            {billing.notes}
+          </div>
+        </section>
+      )}
+
+      <div className="text-xs text-hai pt-2 border-t border-gin">
+        作成: {new Date(billing.createdAt).toLocaleString('ja-JP')} / 更新: {new Date(billing.updatedAt).toLocaleString('ja-JP')}
+        {billing.legacySeikyuCd != null && (
+          <span className="ml-2">/ legacy seikyu_cd: {billing.legacySeikyuCd}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/billing/billing-form-dialog.tsx
+++ b/src/components/billing/billing-form-dialog.tsx
@@ -1,0 +1,394 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Billing,
+  BillingCategory,
+  BillingRecordStatus,
+  CreateBillingRequest,
+  UpdateBillingRequest,
+} from '@komine/types';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { BILLING_CATEGORY_LABELS, BILLING_RECORD_STATUS_LABELS } from '@/lib/api/billings';
+
+export interface BillingFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: CreateBillingRequest | UpdateBillingRequest) => Promise<void>;
+  /** 編集対象の請求。undefined なら新規作成 */
+  editing?: Billing | null;
+  /** 区画詳細から開いた場合のプリセット */
+  presetContractPlotId?: string;
+  presetCustomerId?: string;
+  isSubmitting?: boolean;
+}
+
+interface FormState {
+  contractPlotId: string;
+  customerId: string;
+  category: BillingCategory;
+  amount: string;
+  useStartYear: string;
+  useEndYear: string;
+  targetMonth: string;
+  billingYears: string;
+  contractDate: string;
+  billingDate: string;
+  applicationType: string;
+  billingType: string;
+  status: BillingRecordStatus;
+  terminated: boolean;
+  terminatedDate: string;
+  notes: string;
+}
+
+const emptyState = (preset?: { contractPlotId?: string; customerId?: string }): FormState => ({
+  contractPlotId: preset?.contractPlotId ?? '',
+  customerId: preset?.customerId ?? '',
+  category: BillingCategory.UsageFee,
+  amount: '0',
+  useStartYear: '',
+  useEndYear: '',
+  targetMonth: '',
+  billingYears: '',
+  contractDate: '',
+  billingDate: '',
+  applicationType: '',
+  billingType: '',
+  status: BillingRecordStatus.Pending,
+  terminated: false,
+  terminatedDate: '',
+  notes: '',
+});
+
+const fromBilling = (b: Billing): FormState => ({
+  contractPlotId: b.contractPlotId,
+  customerId: b.customerId,
+  category: b.category,
+  amount: String(b.amount),
+  useStartYear: b.useStartYear?.toString() ?? '',
+  useEndYear: b.useEndYear?.toString() ?? '',
+  targetMonth: b.targetMonth?.toString() ?? '',
+  billingYears: b.billingYears?.toString() ?? '',
+  contractDate: b.contractDate ?? '',
+  billingDate: b.billingDate ?? '',
+  applicationType: b.applicationType?.toString() ?? '',
+  billingType: b.billingType?.toString() ?? '',
+  status: b.status,
+  terminated: b.terminated,
+  terminatedDate: b.terminatedDate ?? '',
+  notes: b.notes ?? '',
+});
+
+const parseIntOrNull = (s: string): number | null => {
+  const t = s.trim();
+  if (!t) return null;
+  const n = parseInt(t, 10);
+  return Number.isFinite(n) ? n : null;
+};
+
+const dateOrNull = (s: string): string | null => (s.trim() ? s.trim() : null);
+
+export function BillingFormDialog({
+  open,
+  onClose,
+  onSubmit,
+  editing,
+  presetContractPlotId,
+  presetCustomerId,
+  isSubmitting = false,
+}: BillingFormDialogProps) {
+  const [state, setState] = useState<FormState>(() =>
+    editing
+      ? fromBilling(editing)
+      : emptyState({ contractPlotId: presetContractPlotId, customerId: presetCustomerId })
+  );
+  const [formError, setFormError] = useState<string>('');
+
+  useEffect(() => {
+    if (open) {
+      setState(
+        editing
+          ? fromBilling(editing)
+          : emptyState({ contractPlotId: presetContractPlotId, customerId: presetCustomerId })
+      );
+      setFormError('');
+    }
+  }, [open, editing, presetContractPlotId, presetCustomerId]);
+
+  if (!open) return null;
+
+  const isEdit = Boolean(editing);
+
+  const handleSubmit = async () => {
+    if (!isEdit && !state.contractPlotId.trim()) {
+      setFormError('契約区画 ID を入力してください');
+      return;
+    }
+    if (!isEdit && !state.customerId.trim()) {
+      setFormError('顧客 ID を入力してください');
+      return;
+    }
+    const amountNum = parseIntOrNull(state.amount);
+    if (amountNum === null || amountNum < 0) {
+      setFormError('金額は 0 円以上の整数で入力してください');
+      return;
+    }
+    setFormError('');
+
+    const common = {
+      category: state.category,
+      amount: amountNum,
+      useStartYear: parseIntOrNull(state.useStartYear),
+      useEndYear: parseIntOrNull(state.useEndYear),
+      targetMonth: parseIntOrNull(state.targetMonth),
+      billingYears: parseIntOrNull(state.billingYears),
+      contractDate: dateOrNull(state.contractDate),
+      billingDate: dateOrNull(state.billingDate),
+      applicationType: parseIntOrNull(state.applicationType),
+      billingType: parseIntOrNull(state.billingType),
+      status: state.status,
+      notes: state.notes.trim() ? state.notes.trim() : null,
+    };
+
+    const data: CreateBillingRequest | UpdateBillingRequest = isEdit
+      ? {
+          ...common,
+          terminated: state.terminated,
+          terminatedDate: dateOrNull(state.terminatedDate),
+        }
+      : {
+          contractPlotId: state.contractPlotId.trim(),
+          customerId: state.customerId.trim(),
+          ...common,
+        };
+
+    try {
+      await onSubmit(data);
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : '保存に失敗しました');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-elegant-lg shadow-elegant-xl w-full max-w-xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="bg-gradient-to-r from-matsu-50 to-kinari px-6 py-4 border-b border-gin">
+          <h3 className="font-mincho text-lg font-semibold text-sumi">
+            {isEdit ? '請求編集' : '請求登録'}
+          </h3>
+          <p className="text-sm text-hai mt-0.5">
+            {isEdit ? '請求情報を編集します' : '新しい請求を登録します'}
+          </p>
+        </div>
+
+        <div className="px-6 py-5 overflow-y-auto">
+          {formError && (
+            <div className="mb-4 p-3 bg-beni-50 border border-beni-200 text-beni text-sm rounded-elegant">
+              {formError}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            {!isEdit && (
+              <>
+                <div>
+                  <Label className="block mb-1.5 text-sm font-medium text-sumi">
+                    契約区画 ID <span className="text-beni">*</span>
+                  </Label>
+                  <Input
+                    value={state.contractPlotId}
+                    onChange={(e) => setState({ ...state, contractPlotId: e.target.value })}
+                    placeholder="UUID"
+                    disabled={Boolean(presetContractPlotId)}
+                    className="border-gin focus:ring-matsu focus:border-matsu font-mono text-xs"
+                  />
+                </div>
+                <div>
+                  <Label className="block mb-1.5 text-sm font-medium text-sumi">
+                    顧客 ID <span className="text-beni">*</span>
+                  </Label>
+                  <Input
+                    value={state.customerId}
+                    onChange={(e) => setState({ ...state, customerId: e.target.value })}
+                    placeholder="UUID"
+                    disabled={Boolean(presetCustomerId)}
+                    className="border-gin focus:ring-matsu focus:border-matsu font-mono text-xs"
+                  />
+                </div>
+              </>
+            )}
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">
+                  料金区分 <span className="text-beni">*</span>
+                </Label>
+                <select
+                  value={state.category}
+                  onChange={(e) =>
+                    setState({ ...state, category: e.target.value as BillingCategory })
+                  }
+                  className="w-full px-3 py-2 border border-gin rounded-elegant bg-white text-sumi focus:outline-none focus:ring-2 focus:ring-matsu"
+                >
+                  {(Object.values(BillingCategory) as BillingCategory[]).map((c) => (
+                    <option key={c} value={c}>
+                      {BILLING_CATEGORY_LABELS[c]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">
+                  金額（円） <span className="text-beni">*</span>
+                </Label>
+                <Input
+                  type="number"
+                  value={state.amount}
+                  onChange={(e) => setState({ ...state, amount: e.target.value })}
+                  className="border-gin focus:ring-matsu focus:border-matsu tabular-nums"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">契約日</Label>
+                <Input
+                  type="date"
+                  value={state.contractDate}
+                  onChange={(e) => setState({ ...state, contractDate: e.target.value })}
+                  className="border-gin focus:ring-matsu focus:border-matsu"
+                />
+              </div>
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">請求日</Label>
+                <Input
+                  type="date"
+                  value={state.billingDate}
+                  onChange={(e) => setState({ ...state, billingDate: e.target.value })}
+                  className="border-gin focus:ring-matsu focus:border-matsu"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">使用開始年</Label>
+                <Input
+                  type="number"
+                  value={state.useStartYear}
+                  onChange={(e) => setState({ ...state, useStartYear: e.target.value })}
+                  placeholder="2026"
+                  className="border-gin focus:ring-matsu focus:border-matsu tabular-nums"
+                />
+              </div>
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">使用終了年</Label>
+                <Input
+                  type="number"
+                  value={state.useEndYear}
+                  onChange={(e) => setState({ ...state, useEndYear: e.target.value })}
+                  placeholder="2030"
+                  className="border-gin focus:ring-matsu focus:border-matsu tabular-nums"
+                />
+              </div>
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">対象月</Label>
+                <Input
+                  type="number"
+                  value={state.targetMonth}
+                  onChange={(e) => setState({ ...state, targetMonth: e.target.value })}
+                  placeholder="1〜12"
+                  className="border-gin focus:ring-matsu focus:border-matsu tabular-nums"
+                />
+              </div>
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">請求年数</Label>
+                <Input
+                  type="number"
+                  value={state.billingYears}
+                  onChange={(e) => setState({ ...state, billingYears: e.target.value })}
+                  placeholder="一括分"
+                  className="border-gin focus:ring-matsu focus:border-matsu tabular-nums"
+                />
+              </div>
+            </div>
+
+            <div>
+              <Label className="block mb-1.5 text-sm font-medium text-sumi">ステータス</Label>
+              <select
+                value={state.status}
+                onChange={(e) =>
+                  setState({ ...state, status: e.target.value as BillingRecordStatus })
+                }
+                className="w-full px-3 py-2 border border-gin rounded-elegant bg-white text-sumi focus:outline-none focus:ring-2 focus:ring-matsu"
+              >
+                {(Object.values(BillingRecordStatus) as BillingRecordStatus[]).map((s) => (
+                  <option key={s} value={s}>
+                    {BILLING_RECORD_STATUS_LABELS[s]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {isEdit && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 items-end">
+                <div className="flex items-center gap-2">
+                  <input
+                    id="terminated"
+                    type="checkbox"
+                    checked={state.terminated}
+                    onChange={(e) => setState({ ...state, terminated: e.target.checked })}
+                    className="w-4 h-4 text-matsu border-gin rounded focus:ring-matsu"
+                  />
+                  <Label htmlFor="terminated" className="text-sm text-sumi">
+                    解約済み
+                  </Label>
+                </div>
+                <div>
+                  <Label className="block mb-1.5 text-sm font-medium text-sumi">解約日</Label>
+                  <Input
+                    type="date"
+                    value={state.terminatedDate}
+                    onChange={(e) => setState({ ...state, terminatedDate: e.target.value })}
+                    className="border-gin focus:ring-matsu focus:border-matsu"
+                  />
+                </div>
+              </div>
+            )}
+
+            <div>
+              <Label className="block mb-1.5 text-sm font-medium text-sumi">備考</Label>
+              <textarea
+                value={state.notes}
+                onChange={(e) => setState({ ...state, notes: e.target.value })}
+                rows={3}
+                className="w-full px-3 py-2 border border-gin rounded-elegant bg-white text-sumi focus:outline-none focus:ring-2 focus:ring-matsu"
+                placeholder="備考があれば記入"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gin bg-kinari">
+          <button
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="border border-gin text-sumi hover:bg-white rounded-elegant px-4 py-2 text-sm font-medium disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+            className="bg-matsu text-white hover:bg-matsu-dark rounded-elegant px-4 py-2 shadow-elegant-sm text-sm font-medium disabled:opacity-50"
+          >
+            {isSubmitting ? '保存中...' : isEdit ? '更新' : '登録'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/billing/billing-list-table.tsx
+++ b/src/components/billing/billing-list-table.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { Billing } from '@komine/types';
+import { BILLING_CATEGORY_LABELS, BILLING_RECORD_STATUS_LABELS } from '@/lib/api/billings';
+
+const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
+
+const statusBadgeClass = (status: Billing['status']): string => {
+  switch (status) {
+    case 'paid':
+      return 'bg-matsu-50 text-matsu-dark';
+    case 'partial_paid':
+    case 'billed':
+      return 'bg-ai-50 text-ai-dark';
+    case 'pending':
+      return 'bg-kohaku-50 text-kohaku-dark';
+    case 'overdue':
+      return 'bg-beni-50 text-beni-dark';
+    case 'terminated':
+    case 'written_off':
+      return 'bg-hai-50 text-hai';
+    default:
+      return 'bg-hai-50 text-hai';
+  }
+};
+
+export interface BillingListTableProps {
+  items: Billing[];
+  isLoading?: boolean;
+  onEdit?: (billing: Billing) => void;
+  onDelete?: (billing: Billing) => void;
+  onView?: (billing: Billing) => void;
+  /** 区画コンテキストで表示するときは true → 区画情報カラムを非表示 */
+  hidePlotColumns?: boolean;
+}
+
+export function BillingListTable({
+  items,
+  isLoading,
+  onEdit,
+  onDelete,
+  onView,
+  hidePlotColumns = false,
+}: BillingListTableProps) {
+  if (isLoading) {
+    return (
+      <div className="p-12 text-center text-hai">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-matsu mx-auto mb-4" />
+        <p className="text-sm">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="p-12 text-center text-hai">
+        <p className="text-sm">請求データがありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full">
+        <thead>
+          <tr className="bg-kinari border-b border-gin">
+            <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi">
+              料金区分
+            </th>
+            {!hidePlotColumns && (
+              <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi hidden md:table-cell">
+                区画
+              </th>
+            )}
+            <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi hidden sm:table-cell">
+              顧客
+            </th>
+            <th className="px-2 md:px-4 py-3 text-right text-sm font-semibold text-sumi">
+              金額
+            </th>
+            <th className="px-2 md:px-4 py-3 text-right text-sm font-semibold text-sumi hidden lg:table-cell">
+              入金済
+            </th>
+            <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi hidden md:table-cell">
+              請求日
+            </th>
+            <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi">
+              ステータス
+            </th>
+            {(onEdit || onDelete || onView) && (
+              <th className="px-2 md:px-4 py-3 text-center text-sm font-semibold text-sumi">
+                操作
+              </th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((b, i) => (
+            <tr
+              key={b.id}
+              className={`border-b border-gin hover:bg-kinari transition-colors ${
+                i % 2 === 0 ? 'bg-white' : 'bg-shiro'
+              } ${b.terminated ? 'opacity-60' : ''}`}
+            >
+              <td className="px-2 md:px-4 py-3 text-sm text-sumi">
+                {BILLING_CATEGORY_LABELS[b.category]}
+              </td>
+              {!hidePlotColumns && (
+                <td className="px-2 md:px-4 py-3 text-sm text-sumi hidden md:table-cell">
+                  {b.plotNumber ?? '-'}
+                  {b.areaName && (
+                    <span className="text-xs text-hai ml-1">({b.areaName})</span>
+                  )}
+                </td>
+              )}
+              <td className="px-2 md:px-4 py-3 text-sm text-sumi hidden sm:table-cell">
+                {b.customer?.name ?? '-'}
+              </td>
+              <td className="px-2 md:px-4 py-3 text-sm text-right text-sumi tabular-nums">
+                {formatYen(b.amount)}
+              </td>
+              <td className="px-2 md:px-4 py-3 text-sm text-right text-sumi hidden lg:table-cell tabular-nums">
+                {formatYen(b.paidAmount)}
+              </td>
+              <td className="px-2 md:px-4 py-3 text-sm text-hai hidden md:table-cell tabular-nums">
+                {b.billingDate ?? '-'}
+              </td>
+              <td className="px-2 md:px-4 py-3 text-sm">
+                <span
+                  className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${statusBadgeClass(
+                    b.status
+                  )}`}
+                >
+                  {BILLING_RECORD_STATUS_LABELS[b.status]}
+                </span>
+              </td>
+              {(onEdit || onDelete || onView) && (
+                <td className="px-2 md:px-4 py-3 text-center">
+                  <div className="flex items-center justify-center gap-2 flex-wrap">
+                    {onView && (
+                      <button
+                        onClick={() => onView(b)}
+                        className="border border-ai text-ai hover:bg-ai-50 rounded-elegant px-3 py-1 text-xs font-medium"
+                      >
+                        詳細
+                      </button>
+                    )}
+                    {onEdit && (
+                      <button
+                        onClick={() => onEdit(b)}
+                        className="border border-gin text-sumi hover:bg-kinari rounded-elegant px-3 py-1 text-xs font-medium"
+                      >
+                        編集
+                      </button>
+                    )}
+                    {onDelete && (
+                      <button
+                        onClick={() => onDelete(b)}
+                        className="border border-beni text-beni hover:bg-beni-50 rounded-elegant px-3 py-1 text-xs font-medium"
+                      >
+                        削除
+                      </button>
+                    )}
+                  </div>
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/billing/billing-management.tsx
+++ b/src/components/billing/billing-management.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Billing,
+  BillingCategory,
+  BillingRecordStatus,
+  CreateBillingRequest,
+  UpdateBillingRequest,
+  ListBillingsQuery,
+} from '@komine/types';
+import {
+  getBillings,
+  createBilling as apiCreate,
+  updateBilling as apiUpdate,
+  deleteBilling as apiDelete,
+  BILLING_CATEGORY_LABELS,
+  BILLING_RECORD_STATUS_LABELS,
+} from '@/lib/api/billings';
+import { showSuccess, showApiError, showError } from '@/lib/toast';
+import PageHeader from '@/components/page-header';
+import { StatCard } from '@/components/ui/stat-card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { BillingListTable } from './billing-list-table';
+import { BillingFormDialog } from './billing-form-dialog';
+import { BillingDetailDialog } from './billing-detail-dialog';
+
+const PAGE_SIZE = 50;
+
+const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
+
+export interface BillingManagementProps {
+  /** 区画コンテキストで埋め込む場合の絞り込み */
+  contractPlotId?: string;
+  /** 区画コンテキストでの請求作成時の顧客プリセット */
+  customerId?: string;
+  /** ページヘッダを表示するか（埋め込み時は false） */
+  showHeader?: boolean;
+}
+
+export default function BillingManagement({
+  contractPlotId,
+  customerId,
+  showHeader = true,
+}: BillingManagementProps) {
+  const [items, setItems] = useState<Billing[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [categoryFilter, setCategoryFilter] = useState<BillingCategory | 'all'>('all');
+  const [statusFilter, setStatusFilter] = useState<BillingRecordStatus | 'all'>('all');
+
+  const [showFormDialog, setShowFormDialog] = useState(false);
+  const [editing, setEditing] = useState<Billing | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const [detailId, setDetailId] = useState<string | null>(null);
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deletingTarget, setDeletingTarget] = useState<Billing | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const fetchList = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    const query: ListBillingsQuery = {
+      page,
+      limit: PAGE_SIZE,
+      contractPlotId,
+      category: categoryFilter === 'all' ? undefined : categoryFilter,
+      status: statusFilter === 'all' ? undefined : statusFilter,
+    };
+    try {
+      const res = await getBillings(query);
+      if (res.success) {
+        setItems(res.data.items);
+        setTotal(res.data.pagination.totalCount);
+      } else {
+        setError(res.error.message);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '読み込みに失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, contractPlotId, categoryFilter, statusFilter]);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  const stats = useMemo(() => {
+    const totalAmount = items.reduce((s, b) => s + b.amount, 0);
+    const paidAmount = items.reduce((s, b) => s + b.paidAmount, 0);
+    const unpaidAmount = totalAmount - paidAmount;
+    const overdueCount = items.filter((b) => b.status === 'overdue').length;
+    return { totalAmount, paidAmount, unpaidAmount, overdueCount };
+  }, [items]);
+
+  const handleSubmit = async (data: CreateBillingRequest | UpdateBillingRequest) => {
+    setIsSaving(true);
+    try {
+      if (editing) {
+        const res = await apiUpdate(editing.id, data as UpdateBillingRequest);
+        if (res.success) {
+          showSuccess('請求を更新しました');
+          setShowFormDialog(false);
+          await fetchList();
+        } else {
+          showApiError('請求の更新', res.error?.message, res.error?.details);
+        }
+      } else {
+        const res = await apiCreate(data as CreateBillingRequest);
+        if (res.success) {
+          showSuccess('請求を登録しました');
+          setShowFormDialog(false);
+          await fetchList();
+        } else {
+          showApiError('請求の登録', res.error?.message, res.error?.details);
+        }
+      }
+    } catch (e) {
+      showError(e instanceof Error ? e.message : 'エラーが発生しました');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deletingTarget) return;
+    setIsDeleting(true);
+    try {
+      const res = await apiDelete(deletingTarget.id);
+      if (res.success) {
+        showSuccess('請求を削除しました');
+        setShowDeleteConfirm(false);
+        setDeletingTarget(null);
+        await fetchList();
+      } else {
+        showApiError('請求の削除', res.error?.message, res.error?.details);
+      }
+    } catch (e) {
+      showError(e instanceof Error ? e.message : 'エラーが発生しました');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden bg-shiro">
+      {showHeader && (
+        <PageHeader
+          title="請求管理"
+          subtitle="請求情報の一覧・登録・編集・削除"
+          theme="matsu"
+          icon={
+            <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          }
+        />
+      )}
+
+      <div className="flex-1 overflow-auto">
+        <div className="flex items-center justify-end gap-2 px-3 md:px-6 py-3 border-b border-gin bg-kinari">
+          <button
+            onClick={() => {
+              setEditing(null);
+              setShowFormDialog(true);
+            }}
+            className="inline-flex items-center bg-matsu text-white hover:bg-matsu-dark rounded-elegant px-3 py-1.5 shadow-elegant-sm text-sm font-medium"
+          >
+            <svg className="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            新規登録
+          </button>
+        </div>
+
+        {showHeader && (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 px-3 md:px-6 py-4">
+            <StatCard label="請求総額" value={formatYen(stats.totalAmount)} theme="sumi" />
+            <StatCard label="入金済" value={formatYen(stats.paidAmount)} theme="matsu" />
+            <StatCard label="未入金" value={formatYen(stats.unpaidAmount)} theme="kohaku" />
+            <StatCard label="延滞件数" value={stats.overdueCount} theme="beni" />
+          </div>
+        )}
+
+        <div className="mx-3 md:mx-6 mb-4 bg-white border border-gin rounded-elegant-lg shadow-elegant-sm p-3 md:p-4">
+          <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-hai whitespace-nowrap">料金区分:</label>
+              <select
+                value={categoryFilter}
+                onChange={(e) => {
+                  setCategoryFilter(e.target.value as BillingCategory | 'all');
+                  setPage(1);
+                }}
+                className="px-3 py-2 border border-gin rounded-elegant text-sm text-sumi bg-white focus:outline-none focus:ring-2 focus:ring-matsu"
+              >
+                <option value="all">すべて</option>
+                {(Object.values(BillingCategory) as BillingCategory[]).map((c) => (
+                  <option key={c} value={c}>
+                    {BILLING_CATEGORY_LABELS[c]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-hai whitespace-nowrap">ステータス:</label>
+              <select
+                value={statusFilter}
+                onChange={(e) => {
+                  setStatusFilter(e.target.value as BillingRecordStatus | 'all');
+                  setPage(1);
+                }}
+                className="px-3 py-2 border border-gin rounded-elegant text-sm text-sumi bg-white focus:outline-none focus:ring-2 focus:ring-matsu"
+              >
+                <option value="all">すべて</option>
+                {(Object.values(BillingRecordStatus) as BillingRecordStatus[]).map((s) => (
+                  <option key={s} value={s}>
+                    {BILLING_RECORD_STATUS_LABELS[s]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <p className="text-sm text-hai sm:ml-auto">{total} 件</p>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mx-3 md:mx-6 mb-4 p-4 bg-beni-50 border border-beni-200 text-beni rounded-elegant-lg flex items-center justify-between">
+            <span>{error}</span>
+            <button
+              onClick={fetchList}
+              className="border border-beni text-beni hover:bg-beni-100 rounded-elegant px-3 py-1.5 text-sm font-medium ml-4"
+            >
+              再試行
+            </button>
+          </div>
+        )}
+
+        <div className="mx-3 md:mx-6 mb-6 bg-white border border-gin rounded-elegant-lg shadow-elegant-sm overflow-hidden">
+          <BillingListTable
+            items={items}
+            isLoading={isLoading}
+            hidePlotColumns={Boolean(contractPlotId)}
+            onView={(b) => setDetailId(b.id)}
+            onEdit={(b) => {
+              setEditing(b);
+              setShowFormDialog(true);
+            }}
+            onDelete={(b) => {
+              setDeletingTarget(b);
+              setShowDeleteConfirm(true);
+            }}
+          />
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between px-4 py-3 border-t border-gin bg-kinari">
+              <p className="text-sm text-hai">
+                {page} / {totalPages} ページ
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1}
+                  className="border border-gin text-sumi hover:bg-white rounded-elegant px-3 py-1 text-sm disabled:opacity-50"
+                >
+                  前へ
+                </button>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={page >= totalPages}
+                  className="border border-gin text-sumi hover:bg-white rounded-elegant px-3 py-1 text-sm disabled:opacity-50"
+                >
+                  次へ
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <BillingFormDialog
+        open={showFormDialog}
+        editing={editing}
+        presetContractPlotId={contractPlotId}
+        presetCustomerId={customerId}
+        onClose={() => setShowFormDialog(false)}
+        onSubmit={handleSubmit}
+        isSubmitting={isSaving}
+      />
+
+      <BillingDetailDialog
+        open={detailId !== null}
+        billingId={detailId}
+        onClose={() => setDetailId(null)}
+      />
+
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        onOpenChange={(o) => {
+          setShowDeleteConfirm(o);
+          if (!o) setDeletingTarget(null);
+        }}
+        title="請求の削除"
+        description={`この請求を削除しますか？紐付く入金は保持され、請求との紐付けは外れます。${
+          isDeleting ? '\n削除中...' : ''
+        }`}
+        confirmLabel="削除"
+        variant="destructive"
+        onConfirm={handleDelete}
+      />
+    </div>
+  );
+}

--- a/src/components/billing/index.ts
+++ b/src/components/billing/index.ts
@@ -1,0 +1,4 @@
+export { default } from './billing-management';
+export { BillingListTable } from './billing-list-table';
+export { BillingFormDialog } from './billing-form-dialog';
+export { BillingDetailDialog } from './billing-detail-dialog';

--- a/src/components/layout/GlobalSidebar.tsx
+++ b/src/components/layout/GlobalSidebar.tsx
@@ -26,6 +26,10 @@ function MenuIcon({ icon, className = 'w-5 h-5' }: { icon: NavItem['icon']; clas
       return <svg {...props}><path {...pathProps} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" /></svg>;
     case 'bank':
       return <svg {...props}><path {...pathProps} d="M3 21h18M3 10h18M5 6l7-3 7 3M4 10v11m4-11v11m4-11v11m4-11v11m4-11v11" /></svg>;
+    case 'invoice':
+      return <svg {...props}><path {...pathProps} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>;
+    case 'cash':
+      return <svg {...props}><path {...pathProps} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>;
   }
 }
 

--- a/src/components/payment/index.ts
+++ b/src/components/payment/index.ts
@@ -1,0 +1,3 @@
+export { default } from './payment-management';
+export { PaymentListTable } from './payment-list-table';
+export { PaymentFormDialog } from './payment-form-dialog';

--- a/src/components/payment/payment-form-dialog.tsx
+++ b/src/components/payment/payment-form-dialog.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Payment,
+  CreatePaymentRequest,
+  UpdatePaymentRequest,
+} from '@komine/types';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface PaymentFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: CreatePaymentRequest | UpdatePaymentRequest) => Promise<void>;
+  editing?: Payment | null;
+  /** 請求詳細から開いた場合のプリセット */
+  presetBillingId?: string;
+  presetContractPlotId?: string;
+  presetCustomerId?: string;
+  isSubmitting?: boolean;
+}
+
+interface FormState {
+  billingId: string;
+  customerId: string;
+  contractPlotId: string;
+  scheduledDate: string;
+  scheduledAmount: string;
+  paymentDate: string;
+  paymentAmount: string;
+  feeType: string;
+  applicationType: string;
+  billingType: string;
+  staffInCharge: string;
+  notes: string;
+}
+
+const emptyState = (preset?: {
+  billingId?: string;
+  contractPlotId?: string;
+  customerId?: string;
+}): FormState => ({
+  billingId: preset?.billingId ?? '',
+  customerId: preset?.customerId ?? '',
+  contractPlotId: preset?.contractPlotId ?? '',
+  scheduledDate: '',
+  scheduledAmount: '',
+  paymentDate: '',
+  paymentAmount: '0',
+  feeType: '',
+  applicationType: '',
+  billingType: '',
+  staffInCharge: '',
+  notes: '',
+});
+
+const fromPayment = (p: Payment): FormState => ({
+  billingId: p.billingId ?? '',
+  customerId: p.customerId ?? '',
+  contractPlotId: p.contractPlotId ?? '',
+  scheduledDate: p.scheduledDate ?? '',
+  scheduledAmount: p.scheduledAmount?.toString() ?? '',
+  paymentDate: p.paymentDate ?? '',
+  paymentAmount: String(p.paymentAmount),
+  feeType: p.feeType ?? '',
+  applicationType: p.applicationType?.toString() ?? '',
+  billingType: p.billingType?.toString() ?? '',
+  staffInCharge: p.staffInCharge ?? '',
+  notes: p.notes ?? '',
+});
+
+const parseIntOrNull = (s: string): number | null => {
+  const t = s.trim();
+  if (!t) return null;
+  const n = parseInt(t, 10);
+  return Number.isFinite(n) ? n : null;
+};
+
+const trimOrNull = (s: string): string | null => (s.trim() ? s.trim() : null);
+
+export function PaymentFormDialog({
+  open,
+  onClose,
+  onSubmit,
+  editing,
+  presetBillingId,
+  presetContractPlotId,
+  presetCustomerId,
+  isSubmitting = false,
+}: PaymentFormDialogProps) {
+  const [state, setState] = useState<FormState>(() =>
+    editing
+      ? fromPayment(editing)
+      : emptyState({
+          billingId: presetBillingId,
+          contractPlotId: presetContractPlotId,
+          customerId: presetCustomerId,
+        })
+  );
+  const [formError, setFormError] = useState<string>('');
+
+  useEffect(() => {
+    if (open) {
+      setState(
+        editing
+          ? fromPayment(editing)
+          : emptyState({
+              billingId: presetBillingId,
+              contractPlotId: presetContractPlotId,
+              customerId: presetCustomerId,
+            })
+      );
+      setFormError('');
+    }
+  }, [open, editing, presetBillingId, presetContractPlotId, presetCustomerId]);
+
+  if (!open) return null;
+
+  const isEdit = Boolean(editing);
+
+  const handleSubmit = async () => {
+    if (!state.billingId.trim() && !state.customerId.trim() && !state.contractPlotId.trim()) {
+      setFormError('請求 ID・顧客 ID・契約区画 ID のいずれかは必須です');
+      return;
+    }
+    const amountNum = parseIntOrNull(state.paymentAmount);
+    if (amountNum === null || amountNum < 0) {
+      setFormError('入金額は 0 円以上の整数で入力してください');
+      return;
+    }
+    setFormError('');
+
+    const common = {
+      billingId: trimOrNull(state.billingId),
+      customerId: trimOrNull(state.customerId),
+      contractPlotId: trimOrNull(state.contractPlotId),
+      scheduledDate: trimOrNull(state.scheduledDate),
+      scheduledAmount: parseIntOrNull(state.scheduledAmount),
+      paymentDate: trimOrNull(state.paymentDate),
+      feeType: trimOrNull(state.feeType),
+      applicationType: parseIntOrNull(state.applicationType),
+      billingType: parseIntOrNull(state.billingType),
+      staffInCharge: trimOrNull(state.staffInCharge),
+      notes: trimOrNull(state.notes),
+    };
+
+    const data: CreatePaymentRequest | UpdatePaymentRequest = {
+      ...common,
+      paymentAmount: amountNum,
+    };
+
+    try {
+      await onSubmit(data);
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : '保存に失敗しました');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-elegant-lg shadow-elegant-xl w-full max-w-xl max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="bg-gradient-to-r from-ai-50 to-kinari px-6 py-4 border-b border-gin">
+          <h3 className="font-mincho text-lg font-semibold text-sumi">
+            {isEdit ? '入金編集' : '入金登録'}
+          </h3>
+          <p className="text-sm text-hai mt-0.5">
+            {isEdit ? '入金情報を編集します' : '新しい入金を登録します'}
+          </p>
+        </div>
+
+        <div className="px-6 py-5 overflow-y-auto">
+          {formError && (
+            <div className="mb-4 p-3 bg-beni-50 border border-beni-200 text-beni text-sm rounded-elegant">
+              {formError}
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <div className="bg-kinari rounded-elegant p-3 text-xs text-hai">
+              請求紐付け <strong>または</strong> 顧客/区画紐付けのいずれかが必須です（両方可）。
+            </div>
+
+            <div>
+              <Label className="block mb-1.5 text-sm font-medium text-sumi">請求 ID</Label>
+              <Input
+                value={state.billingId}
+                onChange={(e) => setState({ ...state, billingId: e.target.value })}
+                placeholder="UUID（任意）"
+                disabled={Boolean(presetBillingId)}
+                className="border-gin focus:ring-matsu focus:border-matsu font-mono text-xs"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">顧客 ID</Label>
+                <Input
+                  value={state.customerId}
+                  onChange={(e) => setState({ ...state, customerId: e.target.value })}
+                  placeholder="UUID（任意）"
+                  disabled={Boolean(presetCustomerId)}
+                  className="border-gin focus:ring-matsu focus:border-matsu font-mono text-xs"
+                />
+              </div>
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">契約区画 ID</Label>
+                <Input
+                  value={state.contractPlotId}
+                  onChange={(e) => setState({ ...state, contractPlotId: e.target.value })}
+                  placeholder="UUID（任意）"
+                  disabled={Boolean(presetContractPlotId)}
+                  className="border-gin focus:ring-matsu focus:border-matsu font-mono text-xs"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">入金日</Label>
+                <Input
+                  type="date"
+                  value={state.paymentDate}
+                  onChange={(e) => setState({ ...state, paymentDate: e.target.value })}
+                  className="border-gin focus:ring-matsu focus:border-matsu"
+                />
+              </div>
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">
+                  入金額（円） <span className="text-beni">*</span>
+                </Label>
+                <Input
+                  type="number"
+                  value={state.paymentAmount}
+                  onChange={(e) => setState({ ...state, paymentAmount: e.target.value })}
+                  className="border-gin focus:ring-matsu focus:border-matsu tabular-nums"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">入金予定日</Label>
+                <Input
+                  type="date"
+                  value={state.scheduledDate}
+                  onChange={(e) => setState({ ...state, scheduledDate: e.target.value })}
+                  className="border-gin focus:ring-matsu focus:border-matsu"
+                />
+              </div>
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">入金予定額</Label>
+                <Input
+                  type="number"
+                  value={state.scheduledAmount}
+                  onChange={(e) => setState({ ...state, scheduledAmount: e.target.value })}
+                  className="border-gin focus:ring-matsu focus:border-matsu tabular-nums"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">料金種別</Label>
+                <Input
+                  value={state.feeType}
+                  onChange={(e) => setState({ ...state, feeType: e.target.value })}
+                  placeholder="自由記述"
+                  className="border-gin focus:ring-matsu focus:border-matsu"
+                />
+              </div>
+              <div>
+                <Label className="block mb-1.5 text-sm font-medium text-sumi">担当者</Label>
+                <Input
+                  value={state.staffInCharge}
+                  onChange={(e) => setState({ ...state, staffInCharge: e.target.value })}
+                  placeholder="氏名等"
+                  className="border-gin focus:ring-matsu focus:border-matsu"
+                />
+              </div>
+            </div>
+
+            <div>
+              <Label className="block mb-1.5 text-sm font-medium text-sumi">備考</Label>
+              <textarea
+                value={state.notes}
+                onChange={(e) => setState({ ...state, notes: e.target.value })}
+                rows={3}
+                className="w-full px-3 py-2 border border-gin rounded-elegant bg-white text-sumi focus:outline-none focus:ring-2 focus:ring-matsu"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gin bg-kinari">
+          <button
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="border border-gin text-sumi hover:bg-white rounded-elegant px-4 py-2 text-sm font-medium disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+            className="bg-matsu text-white hover:bg-matsu-dark rounded-elegant px-4 py-2 shadow-elegant-sm text-sm font-medium disabled:opacity-50"
+          >
+            {isSubmitting ? '保存中...' : isEdit ? '更新' : '登録'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/payment/payment-list-table.tsx
+++ b/src/components/payment/payment-list-table.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { Payment } from '@komine/types';
+import { BILLING_CATEGORY_LABELS } from '@/lib/api/billings';
+
+const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
+
+export interface PaymentListTableProps {
+  items: Payment[];
+  isLoading?: boolean;
+  onEdit?: (payment: Payment) => void;
+  onDelete?: (payment: Payment) => void;
+  /** 区画コンテキストでは plot 情報を非表示 */
+  hidePlotColumns?: boolean;
+}
+
+export function PaymentListTable({
+  items,
+  isLoading,
+  onEdit,
+  onDelete,
+  hidePlotColumns = false,
+}: PaymentListTableProps) {
+  if (isLoading) {
+    return (
+      <div className="p-12 text-center text-hai">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-matsu mx-auto mb-4" />
+        <p className="text-sm">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="p-12 text-center text-hai">
+        <p className="text-sm">入金データがありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full">
+        <thead>
+          <tr className="bg-kinari border-b border-gin">
+            <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi">入金日</th>
+            <th className="px-2 md:px-4 py-3 text-right text-sm font-semibold text-sumi">入金額</th>
+            <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi hidden md:table-cell">
+              紐付け
+            </th>
+            {!hidePlotColumns && (
+              <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi hidden lg:table-cell">
+                区画
+              </th>
+            )}
+            <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi hidden sm:table-cell">
+              顧客
+            </th>
+            <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi hidden lg:table-cell">
+              料金種別
+            </th>
+            <th className="px-2 md:px-4 py-3 text-left text-sm font-semibold text-sumi hidden lg:table-cell">
+              担当
+            </th>
+            {(onEdit || onDelete) && (
+              <th className="px-2 md:px-4 py-3 text-center text-sm font-semibold text-sumi">
+                操作
+              </th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((p, i) => (
+            <tr
+              key={p.id}
+              className={`border-b border-gin hover:bg-kinari transition-colors ${
+                i % 2 === 0 ? 'bg-white' : 'bg-shiro'
+              }`}
+            >
+              <td className="px-2 md:px-4 py-3 text-sm text-sumi tabular-nums">
+                {p.paymentDate ?? p.scheduledDate ?? '-'}
+                {p.scheduledDate && !p.paymentDate && (
+                  <span className="text-xs text-kohaku ml-1">予定</span>
+                )}
+              </td>
+              <td className="px-2 md:px-4 py-3 text-sm text-right text-sumi tabular-nums">
+                {formatYen(p.paymentAmount)}
+              </td>
+              <td className="px-2 md:px-4 py-3 text-sm hidden md:table-cell">
+                {p.billing ? (
+                  <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-matsu-50 text-matsu-dark">
+                    請求紐付 ({BILLING_CATEGORY_LABELS[p.billing.category]})
+                  </span>
+                ) : (
+                  <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-hai-50 text-hai">
+                    孤児入金
+                  </span>
+                )}
+              </td>
+              {!hidePlotColumns && (
+                <td className="px-2 md:px-4 py-3 text-sm text-sumi hidden lg:table-cell">
+                  {p.plotNumber ?? '-'}
+                </td>
+              )}
+              <td className="px-2 md:px-4 py-3 text-sm text-sumi hidden sm:table-cell">
+                {p.customer?.name ?? '-'}
+              </td>
+              <td className="px-2 md:px-4 py-3 text-sm text-hai hidden lg:table-cell">
+                {p.feeType ?? '-'}
+              </td>
+              <td className="px-2 md:px-4 py-3 text-sm text-hai hidden lg:table-cell">
+                {p.staffInCharge ?? '-'}
+              </td>
+              {(onEdit || onDelete) && (
+                <td className="px-2 md:px-4 py-3 text-center">
+                  <div className="flex items-center justify-center gap-2 flex-wrap">
+                    {onEdit && (
+                      <button
+                        onClick={() => onEdit(p)}
+                        className="border border-gin text-sumi hover:bg-kinari rounded-elegant px-3 py-1 text-xs font-medium"
+                      >
+                        編集
+                      </button>
+                    )}
+                    {onDelete && (
+                      <button
+                        onClick={() => onDelete(p)}
+                        className="border border-beni text-beni hover:bg-beni-50 rounded-elegant px-3 py-1 text-xs font-medium"
+                      >
+                        削除
+                      </button>
+                    )}
+                  </div>
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/payment/payment-management.tsx
+++ b/src/components/payment/payment-management.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Payment,
+  CreatePaymentRequest,
+  UpdatePaymentRequest,
+  ListPaymentsQuery,
+} from '@komine/types';
+import {
+  getPayments,
+  createPayment as apiCreate,
+  updatePayment as apiUpdate,
+  deletePayment as apiDelete,
+} from '@/lib/api/payments';
+import { showSuccess, showApiError, showError } from '@/lib/toast';
+import PageHeader from '@/components/page-header';
+import { StatCard } from '@/components/ui/stat-card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { PaymentListTable } from './payment-list-table';
+import { PaymentFormDialog } from './payment-form-dialog';
+
+const PAGE_SIZE = 50;
+
+const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
+
+export interface PaymentManagementProps {
+  contractPlotId?: string;
+  customerId?: string;
+  /** 特定請求の入金一覧表示時 */
+  billingId?: string;
+  showHeader?: boolean;
+}
+
+type OrphanFilter = 'all' | 'orphan' | 'linked';
+
+export default function PaymentManagement({
+  contractPlotId,
+  customerId,
+  billingId,
+  showHeader = true,
+}: PaymentManagementProps) {
+  const [items, setItems] = useState<Payment[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [orphanFilter, setOrphanFilter] = useState<OrphanFilter>('all');
+
+  const [showFormDialog, setShowFormDialog] = useState(false);
+  const [editing, setEditing] = useState<Payment | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deletingTarget, setDeletingTarget] = useState<Payment | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const fetchList = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    const query: ListPaymentsQuery = {
+      page,
+      limit: PAGE_SIZE,
+      contractPlotId,
+      customerId,
+      billingId,
+      orphan: orphanFilter === 'orphan' ? true : orphanFilter === 'linked' ? false : undefined,
+    };
+    try {
+      const res = await getPayments(query);
+      if (res.success) {
+        setItems(res.data.items);
+        setTotal(res.data.pagination.totalCount);
+      } else {
+        setError(res.error.message);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '読み込みに失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, contractPlotId, customerId, billingId, orphanFilter]);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  const stats = useMemo(() => {
+    const totalAmount = items.reduce((s, p) => s + p.paymentAmount, 0);
+    const orphanCount = items.filter((p) => !p.billingId).length;
+    return { totalAmount, orphanCount };
+  }, [items]);
+
+  const handleSubmit = async (data: CreatePaymentRequest | UpdatePaymentRequest) => {
+    setIsSaving(true);
+    try {
+      if (editing) {
+        const res = await apiUpdate(editing.id, data as UpdatePaymentRequest);
+        if (res.success) {
+          showSuccess('入金を更新しました');
+          setShowFormDialog(false);
+          await fetchList();
+        } else {
+          showApiError('入金の更新', res.error?.message, res.error?.details);
+        }
+      } else {
+        const res = await apiCreate(data as CreatePaymentRequest);
+        if (res.success) {
+          showSuccess('入金を登録しました');
+          setShowFormDialog(false);
+          await fetchList();
+        } else {
+          showApiError('入金の登録', res.error?.message, res.error?.details);
+        }
+      }
+    } catch (e) {
+      showError(e instanceof Error ? e.message : 'エラーが発生しました');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deletingTarget) return;
+    setIsDeleting(true);
+    try {
+      const res = await apiDelete(deletingTarget.id);
+      if (res.success) {
+        showSuccess('入金を削除しました');
+        setShowDeleteConfirm(false);
+        setDeletingTarget(null);
+        await fetchList();
+      } else {
+        showApiError('入金の削除', res.error?.message, res.error?.details);
+      }
+    } catch (e) {
+      showError(e instanceof Error ? e.message : 'エラーが発生しました');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden bg-shiro">
+      {showHeader && (
+        <PageHeader
+          title="入金管理"
+          subtitle="入金情報の一覧・登録・編集・削除"
+          theme="ai"
+          icon={
+            <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+            </svg>
+          }
+        />
+      )}
+
+      <div className="flex-1 overflow-auto">
+        <div className="flex items-center justify-end gap-2 px-3 md:px-6 py-3 border-b border-gin bg-kinari">
+          <button
+            onClick={() => {
+              setEditing(null);
+              setShowFormDialog(true);
+            }}
+            className="inline-flex items-center bg-matsu text-white hover:bg-matsu-dark rounded-elegant px-3 py-1.5 shadow-elegant-sm text-sm font-medium"
+          >
+            <svg className="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            新規登録
+          </button>
+        </div>
+
+        {showHeader && (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4 px-3 md:px-6 py-4">
+            <StatCard label="表示中の入金合計" value={formatYen(stats.totalAmount)} theme="matsu" />
+            <StatCard label="孤児入金" value={stats.orphanCount} theme="kohaku" />
+            <StatCard label="表示件数" value={total} theme="ai" />
+          </div>
+        )}
+
+        <div className="mx-3 md:mx-6 mb-4 bg-white border border-gin rounded-elegant-lg shadow-elegant-sm p-3 md:p-4">
+          <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-hai whitespace-nowrap">紐付け:</label>
+              <select
+                value={orphanFilter}
+                onChange={(e) => {
+                  setOrphanFilter(e.target.value as OrphanFilter);
+                  setPage(1);
+                }}
+                className="px-3 py-2 border border-gin rounded-elegant text-sm text-sumi bg-white focus:outline-none focus:ring-2 focus:ring-matsu"
+              >
+                <option value="all">すべて</option>
+                <option value="linked">請求紐付け</option>
+                <option value="orphan">孤児入金</option>
+              </select>
+            </div>
+            <p className="text-sm text-hai sm:ml-auto">{total} 件</p>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mx-3 md:mx-6 mb-4 p-4 bg-beni-50 border border-beni-200 text-beni rounded-elegant-lg flex items-center justify-between">
+            <span>{error}</span>
+            <button
+              onClick={fetchList}
+              className="border border-beni text-beni hover:bg-beni-100 rounded-elegant px-3 py-1.5 text-sm font-medium ml-4"
+            >
+              再試行
+            </button>
+          </div>
+        )}
+
+        <div className="mx-3 md:mx-6 mb-6 bg-white border border-gin rounded-elegant-lg shadow-elegant-sm overflow-hidden">
+          <PaymentListTable
+            items={items}
+            isLoading={isLoading}
+            hidePlotColumns={Boolean(contractPlotId)}
+            onEdit={(p) => {
+              setEditing(p);
+              setShowFormDialog(true);
+            }}
+            onDelete={(p) => {
+              setDeletingTarget(p);
+              setShowDeleteConfirm(true);
+            }}
+          />
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between px-4 py-3 border-t border-gin bg-kinari">
+              <p className="text-sm text-hai">
+                {page} / {totalPages} ページ
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1}
+                  className="border border-gin text-sumi hover:bg-white rounded-elegant px-3 py-1 text-sm disabled:opacity-50"
+                >
+                  前へ
+                </button>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={page >= totalPages}
+                  className="border border-gin text-sumi hover:bg-white rounded-elegant px-3 py-1 text-sm disabled:opacity-50"
+                >
+                  次へ
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <PaymentFormDialog
+        open={showFormDialog}
+        editing={editing}
+        presetBillingId={billingId}
+        presetContractPlotId={contractPlotId}
+        presetCustomerId={customerId}
+        onClose={() => setShowFormDialog(false)}
+        onSubmit={handleSubmit}
+        isSubmitting={isSaving}
+      />
+
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        onOpenChange={(o) => {
+          setShowDeleteConfirm(o);
+          if (!o) setDeletingTarget(null);
+        }}
+        title="入金の削除"
+        description={`この入金を削除しますか？${
+          deletingTarget?.billingId ? '紐付く請求の入金集計が再計算されます。' : ''
+        }${isDeleting ? '\n削除中...' : ''}`}
+        confirmLabel="削除"
+        variant="destructive"
+        onConfirm={handleDelete}
+      />
+    </div>
+  );
+}

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -34,6 +34,8 @@ import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { HistoryTab } from '@/components/plot-form/HistoryTab';
 import { useAuth } from '@/contexts/auth-context';
+import BillingManagement from '@/components/billing';
+import PaymentManagement from '@/components/payment';
 
 // ===== 型定義 =====
 
@@ -741,7 +743,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete }: Plo
             // (overflow時に中央寄せだと左端が見切れてスクロール不可になるため)
             'flex w-full justify-start overflow-x-auto overflow-y-hidden snap-x snap-mandatory scrollbar-thin h-auto gap-1',
             // sm以上: グリッドレイアウトに戻す
-            'sm:grid sm:grid-cols-3 lg:grid-cols-6 sm:overflow-visible sm:snap-none'
+            'sm:grid sm:grid-cols-4 lg:grid-cols-8 sm:overflow-visible sm:snap-none'
           )}
         >
           <TabsTrigger value="basic" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
@@ -758,6 +760,12 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete }: Plo
           </TabsTrigger>
           <TabsTrigger value="construction" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             工事情報
+          </TabsTrigger>
+          <TabsTrigger value="billing" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
+            請求
+          </TabsTrigger>
+          <TabsTrigger value="payment" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
+            入金
           </TabsTrigger>
           <TabsTrigger value="history" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             履歴情報
@@ -782,6 +790,32 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete }: Plo
 
         <TabsContent value="construction" className="mt-4 md:mt-6">
           <ConstructionInfoTab plot={plot} />
+        </TabsContent>
+
+        <TabsContent value="billing" className="mt-4 md:mt-6">
+          <div className="bg-white border border-gin rounded-elegant-lg overflow-hidden">
+            <BillingManagement
+              contractPlotId={plot.id}
+              customerId={
+                plot.roles.find((r) => r.role === ContractRole.Contractor)?.customer.id ??
+                plot.roles[0]?.customer.id
+              }
+              showHeader={false}
+            />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="payment" className="mt-4 md:mt-6">
+          <div className="bg-white border border-gin rounded-elegant-lg overflow-hidden">
+            <PaymentManagement
+              contractPlotId={plot.id}
+              customerId={
+                plot.roles.find((r) => r.role === ContractRole.Contractor)?.customer.id ??
+                plot.roles[0]?.customer.id
+              }
+              showHeader={false}
+            />
+          </div>
         </TabsContent>
 
         <TabsContent value="history" className="mt-4 md:mt-6">

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -3,7 +3,7 @@ import { UserRole } from '@/types/plot-detail';
 export interface NavItem {
   label: string;
   path: string;
-  icon: 'search' | 'archive' | 'grid' | 'file-text' | 'users' | 'settings' | 'upload' | 'bank';
+  icon: 'search' | 'archive' | 'grid' | 'file-text' | 'users' | 'settings' | 'upload' | 'bank' | 'invoice' | 'cash';
   requiredRoles: UserRole[];
 }
 
@@ -20,6 +20,8 @@ export const NAV_GROUPS: NavGroup[] = [
       { label: '合祀管理', path: '/collective-burials', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'archive' },
       { label: '区画残数管理', path: '/plot-availability', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'grid' },
       { label: '書類管理', path: '/documents', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'file-text' },
+      { label: '請求管理', path: '/billings', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'invoice' },
+      { label: '入金管理', path: '/payments', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'cash' },
       { label: 'ゆうちょ連携', path: '/yucho', requiredRoles: ['operator', 'manager', 'admin'], icon: 'bank' },
     ],
   },

--- a/src/lib/api/billings.ts
+++ b/src/lib/api/billings.ts
@@ -1,0 +1,86 @@
+/**
+ * 請求 (Billing) API
+ *
+ * バックエンド `/api/v1/billings` への CRUD クライアント。
+ * 型は @komine/types から直接利用する。
+ */
+
+import {
+  Billing,
+  BillingDetailResponse,
+  BillingsListResponse,
+  CreateBillingRequest,
+  UpdateBillingRequest,
+  ListBillingsQuery,
+  DeleteBillingResponse,
+  BillingCategory,
+  BillingRecordStatus,
+} from '@komine/types';
+import { apiDelete, apiGet, apiPost, apiPut } from './client';
+import { ApiResponse } from './types';
+
+const BASE = '/billings';
+
+const queryToParams = (
+  q?: ListBillingsQuery
+): Record<string, string | number | undefined> | undefined => {
+  if (!q) return undefined;
+  return {
+    page: q.page,
+    limit: q.limit,
+    contractPlotId: q.contractPlotId,
+    customerId: q.customerId,
+    category: q.category,
+    status: q.status,
+    billingDateFrom: q.billingDateFrom,
+    billingDateTo: q.billingDateTo,
+    sortBy: q.sortBy,
+    sortOrder: q.sortOrder,
+  };
+};
+
+export function getBillings(
+  query?: ListBillingsQuery
+): Promise<ApiResponse<BillingsListResponse>> {
+  return apiGet<BillingsListResponse>(BASE, queryToParams(query));
+}
+
+export function getBillingById(id: string): Promise<ApiResponse<BillingDetailResponse>> {
+  return apiGet<BillingDetailResponse>(`${BASE}/${id}`);
+}
+
+export function createBilling(data: CreateBillingRequest): Promise<ApiResponse<Billing>> {
+  return apiPost<Billing>(BASE, data);
+}
+
+export function updateBilling(
+  id: string,
+  data: UpdateBillingRequest
+): Promise<ApiResponse<Billing>> {
+  return apiPut<Billing>(`${BASE}/${id}`, data);
+}
+
+export function deleteBilling(id: string): Promise<ApiResponse<DeleteBillingResponse>> {
+  return apiDelete<DeleteBillingResponse>(`${BASE}/${id}`);
+}
+
+// ===== ラベル定義（UI 表示用） =====
+
+export const BILLING_CATEGORY_LABELS: Record<BillingCategory, string> = {
+  usage_fee: '使用料',
+  management_fee: '管理料',
+  collective_fee: '合祀料金',
+  construction_fee: '工事料金',
+  gravestone_fee: '墓石代',
+  other: 'その他',
+};
+
+export const BILLING_RECORD_STATUS_LABELS: Record<BillingRecordStatus, string> = {
+  pending: '請求前',
+  billed: '請求済',
+  partial_paid: '一部入金',
+  paid: '全額入金',
+  overdue: '延滞',
+  terminated: '解約済',
+  written_off: '貸倒',
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -173,6 +173,26 @@ export type {
   YuchoExportParams,
 } from './yucho';
 
+// 請求 (Billing) APIのエクスポート
+export {
+  getBillings,
+  getBillingById,
+  createBilling,
+  updateBilling,
+  deleteBilling,
+  BILLING_CATEGORY_LABELS,
+  BILLING_RECORD_STATUS_LABELS,
+} from './billings';
+
+// 入金 (Payment) APIのエクスポート
+export {
+  getPayments,
+  getPaymentById,
+  createPayment,
+  updatePayment,
+  deletePayment,
+} from './payments';
+
 // 区画在庫管理APIのエクスポート
 export {
   getInventorySummary,

--- a/src/lib/api/payments.ts
+++ b/src/lib/api/payments.ts
@@ -1,0 +1,63 @@
+/**
+ * 入金 (Payment) API
+ *
+ * バックエンド `/api/v1/payments` への CRUD クライアント。
+ * billing_id は nullable（孤児入金に対応）。
+ */
+
+import {
+  Payment,
+  PaymentDetailResponse,
+  PaymentsListResponse,
+  CreatePaymentRequest,
+  UpdatePaymentRequest,
+  ListPaymentsQuery,
+  DeletePaymentResponse,
+} from '@komine/types';
+import { apiDelete, apiGet, apiPost, apiPut } from './client';
+import { ApiResponse } from './types';
+
+const BASE = '/payments';
+
+const queryToParams = (
+  q?: ListPaymentsQuery
+): Record<string, string | number | undefined> | undefined => {
+  if (!q) return undefined;
+  return {
+    page: q.page,
+    limit: q.limit,
+    billingId: q.billingId,
+    customerId: q.customerId,
+    contractPlotId: q.contractPlotId,
+    paymentDateFrom: q.paymentDateFrom,
+    paymentDateTo: q.paymentDateTo,
+    orphan: q.orphan === undefined ? undefined : String(q.orphan),
+    sortBy: q.sortBy,
+    sortOrder: q.sortOrder,
+  };
+};
+
+export function getPayments(
+  query?: ListPaymentsQuery
+): Promise<ApiResponse<PaymentsListResponse>> {
+  return apiGet<PaymentsListResponse>(BASE, queryToParams(query));
+}
+
+export function getPaymentById(id: string): Promise<ApiResponse<PaymentDetailResponse>> {
+  return apiGet<PaymentDetailResponse>(`${BASE}/${id}`);
+}
+
+export function createPayment(data: CreatePaymentRequest): Promise<ApiResponse<Payment>> {
+  return apiPost<Payment>(BASE, data);
+}
+
+export function updatePayment(
+  id: string,
+  data: UpdatePaymentRequest
+): Promise<ApiResponse<Payment>> {
+  return apiPut<Payment>(`${BASE}/${id}`, data);
+}
+
+export function deletePayment(id: string): Promise<ApiResponse<DeletePaymentResponse>> {
+  return apiDelete<DeletePaymentResponse>(`${BASE}/${id}`);
+}

--- a/src/lib/validations/billing-form.ts
+++ b/src/lib/validations/billing-form.ts
@@ -1,0 +1,63 @@
+/**
+ * 請求 (Billing) フォームバリデーション
+ *
+ * バックエンド `src/validations/billingValidation.ts` と整合。
+ */
+
+import { z } from 'zod';
+import { BillingCategory, BillingRecordStatus } from '@komine/types';
+
+const dateString = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, '日付は YYYY-MM-DD 形式で入力してください')
+  .optional()
+  .or(z.literal(''));
+
+const optionalInt = (min?: number, max?: number) =>
+  z
+    .union([z.number().int(), z.literal('').transform(() => undefined), z.literal('').optional()])
+    .optional()
+    .nullable()
+    .refine((v) => v === undefined || v === null || v === '' || (typeof v === 'number' && (min === undefined || v >= min) && (max === undefined || v <= max)), {
+      message: `数値の範囲外です${min !== undefined ? ` (最小: ${min})` : ''}${max !== undefined ? ` (最大: ${max})` : ''}`,
+    });
+
+export const billingFormSchema = z.object({
+  contractPlotId: z.string().uuid('契約区画 ID を選択してください'),
+  customerId: z.string().uuid('顧客 ID を選択してください'),
+  category: z.nativeEnum(BillingCategory),
+  amount: z.number().int().nonnegative('金額は 0 円以上で入力してください'),
+  useStartYear: optionalInt(1900, 2999),
+  useEndYear: optionalInt(1900, 2999),
+  targetMonth: optionalInt(1, 12),
+  billingYears: optionalInt(1, 100),
+  contractDate: dateString,
+  billingDate: dateString,
+  applicationType: optionalInt(),
+  billingType: optionalInt(),
+  status: z.nativeEnum(BillingRecordStatus).optional(),
+  terminated: z.boolean().optional(),
+  terminatedDate: dateString,
+  notes: z.string().max(2000, '備考は 2000 文字以内で入力してください').optional().nullable().or(z.literal('')),
+});
+
+export type BillingFormValues = z.infer<typeof billingFormSchema>;
+
+export const DEFAULT_BILLING_FORM_VALUES: BillingFormValues = {
+  contractPlotId: '',
+  customerId: '',
+  category: BillingCategory.UsageFee,
+  amount: 0,
+  useStartYear: null,
+  useEndYear: null,
+  targetMonth: null,
+  billingYears: null,
+  contractDate: '',
+  billingDate: '',
+  applicationType: null,
+  billingType: null,
+  status: BillingRecordStatus.Pending,
+  terminated: false,
+  terminatedDate: '',
+  notes: '',
+};

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './plot-form';
+export * from './billing-form';
+export * from './payment-form';

--- a/src/lib/validations/payment-form.ts
+++ b/src/lib/validations/payment-form.ts
@@ -1,0 +1,56 @@
+/**
+ * 入金 (Payment) フォームバリデーション
+ *
+ * バックエンド `src/validations/paymentValidation.ts` と整合。
+ * billingId / customerId / contractPlotId のいずれかは必須（孤児入金対応）。
+ */
+
+import { z } from 'zod';
+
+const dateString = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, '日付は YYYY-MM-DD 形式で入力してください')
+  .optional()
+  .or(z.literal(''));
+
+const optionalUuid = z.string().uuid().optional().nullable().or(z.literal(''));
+
+export const paymentFormSchema = z
+  .object({
+    billingId: optionalUuid,
+    customerId: optionalUuid,
+    contractPlotId: optionalUuid,
+    scheduledDate: dateString,
+    scheduledAmount: z.number().int().nonnegative('入金予定額は 0 円以上で入力してください').optional().nullable(),
+    paymentDate: dateString,
+    paymentAmount: z.number().int().nonnegative('入金額は 0 円以上で入力してください'),
+    feeType: z.string().max(50, '料金種別は 50 文字以内で入力してください').optional().nullable().or(z.literal('')),
+    applicationType: z.number().int().optional().nullable(),
+    billingType: z.number().int().optional().nullable(),
+    staffInCharge: z.string().max(100, '担当者は 100 文字以内で入力してください').optional().nullable().or(z.literal('')),
+    notes: z.string().max(2000, '備考は 2000 文字以内で入力してください').optional().nullable().or(z.literal('')),
+  })
+  .refine(
+    (v) => Boolean(v.billingId) || Boolean(v.customerId) || Boolean(v.contractPlotId),
+    {
+      message: '請求・顧客・区画のいずれかは紐付けてください',
+      path: ['billingId'],
+    }
+  );
+
+export type PaymentFormValues = z.infer<typeof paymentFormSchema>;
+
+export const DEFAULT_PAYMENT_FORM_VALUES: PaymentFormValues = {
+  billingId: '',
+  customerId: '',
+  contractPlotId: '',
+  scheduledDate: '',
+  scheduledAmount: null,
+  paymentDate: '',
+  paymentAmount: 0,
+  feeType: '',
+  applicationType: null,
+  billingType: null,
+  staffInCharge: '',
+  notes: '',
+};


### PR DESCRIPTION
## Summary

backend `/api/v1/billings` `/api/v1/payments` (komine-crm-backend PR #113) を消費するフロントエンド UI 一式。横断ページ + 区画詳細タブの両方から CRUD 可能。

## ⚠️ 依存

`@komine/types` の Billing/Payment 型追加 (https://github.com/zaitsu82/komine-types/pull/12) が **先にマージ・反映**されている必要あり。

## 追加内容

### API クライアント
- \`src/lib/api/billings.ts\` — CRUD + ラベル定義 (BILLING_CATEGORY_LABELS / BILLING_RECORD_STATUS_LABELS)
- \`src/lib/api/payments.ts\` — CRUD

### Zod バリデーション
- \`src/lib/validations/{billing,payment}-form.ts\`

### 共通コンポーネント (区画詳細タブから再利用可)
- \`src/components/billing/\`
  - \`billing-management.tsx\` — オーケストレータ（フィルタ + 一覧 + ダイアログ）
  - \`billing-list-table.tsx\` — 表示用テーブル（hidePlotColumns 対応）
  - \`billing-form-dialog.tsx\` — 登録/編集ダイアログ
  - \`billing-detail-dialog.tsx\` — 詳細表示（紐付く入金一覧含む）
- \`src/components/payment/\`
  - \`payment-management.tsx\` / \`payment-list-table.tsx\` / \`payment-form-dialog.tsx\`

### ルート
- \`/billings\` — 横断請求一覧（料金区分・ステータスフィルタ + ページネーション）
- \`/payments\` — 横断入金一覧（紐付けフィルタ：すべて/請求紐付け/孤児入金）

### 区画詳細にタブ追加
- \`/plots/[id]\` の Tabs に「請求」「入金」を追加（\`lg:grid-cols-8\` に拡張）
- contractPlotId プリセット + 契約者 customerId 自動投入

### サイドバー導線
- 「業務」グループに「請求管理」「入金管理」追加
- icon \`invoice\` / \`cash\` を新規定義

## 既知の制限（後続改善候補）

- フォームの contractPlotId / customerId / billingId は **UUID テキスト入力**（プロト的）
- 区画詳細タブから開く場合はプリセットで disabled
- 将来オートコンプリート化（区画番号・顧客名から検索）を検討

## Test plan

- [ ] types PR (#12) マージ後、ローカルで \`npm install\` → \`npm run dev\`
- [ ] \`/billings\` で一覧表示・カテゴリ/ステータスフィルタ
- [ ] \`/billings\` で新規登録（既存 ContractPlot/Customer の UUID を入力）
- [ ] 一覧から「詳細」→ 紐付く入金一覧が表示される
- [ ] 一覧から「編集」→ 値が編集できる
- [ ] 一覧から「削除」→ 削除確認ダイアログ → ソフト削除
- [ ] \`/payments\` で一覧 / 紐付けフィルタ
- [ ] \`/payments\` で新規登録（請求紐付け・孤児入金両方）
- [ ] 編集/削除
- [ ] \`/plots/[id]\` の「請求」「入金」タブで一覧表示・新規登録（プリセットが効く）
- [ ] サイドバーから両画面に遷移できる
- [ ] モバイル幅 (375px) で破綻しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)