### PR TITLE
fix: 区画詳細に申込者 section を並列表示

### DIFF
--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -198,9 +198,38 @@ function Section({
 
 // ===== タブコンポーネント =====
 
+type PlotRole = PlotDetailResponse['roles'][number];
+
+function CustomerInfoSection({ role, title }: { role: PlotRole; title: string }) {
+  const customer = role.customer;
+  return (
+    <Section title={title}>
+      <InfoField label="氏名" value={customer.name} />
+      <InfoField label="ふりがな" value={customer.nameKana} />
+      <InfoField label="性別" value={customer.gender ? GENDER_LABELS[customer.gender as Gender] : null} />
+      <InfoField label="生年月日" value={formatDate(customer.birthDate)} />
+      <InfoField label="電話番号" value={customer.phoneNumber} />
+      <InfoField label="FAX" value={customer.faxNumber} />
+      <InfoField label="メール" value={customer.email} />
+      <InfoField label="郵便番号" value={customer.postalCode} />
+      <InfoField label="住所" value={customer.address} />
+      <InfoField label="住所2" value={customer.addressLine2} />
+      <InfoField label="本籍地" value={customer.registeredAddress} />
+      <InfoField label="役割開始日" value={formatDate(role.roleStartDate)} />
+      <InfoField label="役割終了日" value={formatDate(role.roleEndDate)} />
+      <InfoField label="備考" value={customer.notes} />
+    </Section>
+  );
+}
+
 function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
-  const primaryRole = plot.roles.find(r => r.role === ContractRole.Contractor) || plot.roles[0];
-  const customer = primaryRole?.customer;
+  const contractorRole = plot.roles.find(r => r.role === ContractRole.Contractor);
+  const applicantRole = plot.roles.find(r => r.role === ContractRole.Applicant);
+  const primaryRole = contractorRole ?? plot.roles[0];
+  const primaryCustomer = primaryRole?.customer;
+
+  const showApplicantSection =
+    !!applicantRole && (!primaryRole || applicantRole.customer.id !== primaryRole.customer.id);
 
   return (
     <div className="space-y-4">
@@ -231,36 +260,23 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
         <InfoField label="契約備考" value={plot.contractNotes} />
       </Section>
 
-      {/* 顧客情報（主たる契約者） */}
-      {customer && (
-        <Section title="契約者情報">
-          <InfoField label="氏名" value={customer.name} />
-          <InfoField label="ふりがな" value={customer.nameKana} />
-          <InfoField label="性別" value={customer.gender ? GENDER_LABELS[customer.gender as Gender] : null} />
-          <InfoField label="生年月日" value={formatDate(customer.birthDate)} />
-          <InfoField label="電話番号" value={customer.phoneNumber} />
-          <InfoField label="FAX" value={customer.faxNumber} />
-          <InfoField label="メール" value={customer.email} />
-          <InfoField label="郵便番号" value={customer.postalCode} />
-          <InfoField label="住所" value={customer.address} />
-          <InfoField label="住所2" value={customer.addressLine2} />
-          <InfoField label="本籍地" value={customer.registeredAddress} />
-          <InfoField label="役割" value={primaryRole?.role ? CONTRACT_ROLE_LABELS[primaryRole.role as ContractRole] : null} />
-          <InfoField label="備考" value={customer.notes} />
-        </Section>
-      )}
+      {/* 契約者情報 */}
+      {primaryRole && <CustomerInfoSection role={primaryRole} title="契約者情報" />}
 
-      {/* 勤務先情報 */}
-      {customer?.workInfo && (
+      {/* 申込者情報（契約者と別人の場合のみ表示） */}
+      {showApplicantSection && <CustomerInfoSection role={applicantRole} title="申込者情報" />}
+
+      {/* 勤務先情報（契約者） */}
+      {primaryCustomer?.workInfo && (
         <Section title="勤務先情報">
-          <InfoField label="勤務先名称" value={customer.workInfo.companyName} />
-          <InfoField label="勤務先かな" value={customer.workInfo.companyNameKana} />
-          <InfoField label="勤務先郵便番号" value={customer.workInfo.workPostalCode} />
-          <InfoField label="勤務先住所" value={customer.workInfo.workAddress} />
-          <InfoField label="勤務先電話番号" value={customer.workInfo.workPhoneNumber} />
-          <InfoField label="DM設定" value={customer.workInfo.dmSetting ? DM_SETTING_LABELS[customer.workInfo.dmSetting as DmSetting] : null} />
-          <InfoField label="宛先区分" value={customer.workInfo.addressType ? ADDRESS_TYPE_LABELS[customer.workInfo.addressType as AddressType] : null} />
-          <InfoField label="備考" value={customer.workInfo.notes} />
+          <InfoField label="勤務先名称" value={primaryCustomer.workInfo.companyName} />
+          <InfoField label="勤務先かな" value={primaryCustomer.workInfo.companyNameKana} />
+          <InfoField label="勤務先郵便番号" value={primaryCustomer.workInfo.workPostalCode} />
+          <InfoField label="勤務先住所" value={primaryCustomer.workInfo.workAddress} />
+          <InfoField label="勤務先電話番号" value={primaryCustomer.workInfo.workPhoneNumber} />
+          <InfoField label="DM設定" value={primaryCustomer.workInfo.dmSetting ? DM_SETTING_LABELS[primaryCustomer.workInfo.dmSetting as DmSetting] : null} />
+          <InfoField label="宛先区分" value={primaryCustomer.workInfo.addressType ? ADDRESS_TYPE_LABELS[primaryCustomer.workInfo.addressType as AddressType] : null} />
+          <InfoField label="備考" value={primaryCustomer.workInfo.notes} />
         </Section>
       )}
 


### PR DESCRIPTION
## Summary

- 区画詳細の「基本情報」タブで、契約者と並列に **申込者 section** を表示するように修正
- 旧画面では申込者と契約者を並列表示していたが、新システムは `BasicInfoTab` で `primaryRole` を 1 件だけ取得するため、申込者≠契約者ケース（全契約の 35.5%）で申込者情報が UI から完全に欠落していた
- 申込者と契約者が同一 customer の場合は申込者 section を表示しない（重複回避）
- 顧客情報の描画ロジックを `CustomerInfoSection` helper に切り出し

## 背景

`query_result/UI_GAP_SCREEN_02_BASIC_INFO_1.md` の「一番ヤバい発見」で特定された B1 項目。データ自体は migration 済（`SaleContractRole.role=applicant` で別 Customer レコード作成済）だが、`plot-detail-view.tsx:202` で contractor role のみ pickup しているため UI に出ていなかった。

## 主要変更

| Before | After |
|---|---|
| `primaryRole = roles.find(r=>r.role===Contractor) \|\| roles[0]` で 1 人だけ取得 | contractor / applicant の 2 role を個別に取得し、それぞれ section 描画 |
| 「契約者情報」内に "役割" InfoField | section title で役割を示すため "役割" InfoField を削除（重複防止） |
| `customer.workInfo` を直接参照 | `primaryCustomer.workInfo`（契約者の workInfo）に統一 |

## Test plan

- [x] `npx tsc --noEmit` で対象ファイルに型エラーなし（既存 test mock の pre-existing エラーは main にも同数あり）
- [x] `npx eslint src/components/plot-detail-view.tsx` clean
- [x] 申込者≠契約者の区画詳細を開き、契約者 section と申込者 section が並列表示されることを目視確認
- [x] 申込者＝契約者の区画詳細で、申込者 section が表示されないことを目視確認
- [x] 勤務先情報が契約者のものだけ表示されることを目視確認

## Out of scope

- Form 側 (`BasicInfoTab.tsx` in plot-form/) の並列 section 化 → 別 PR (B2) で対応予定
- 受付番号 / 平成書番号 マッピング (A1)、墓石 section 追加 (B3) 等は別 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)