### PR TITLE
feat: 区画詳細の墓石 section に未表示 6 項目を追加

### DIFF
--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -454,15 +454,21 @@ function BurialInfoTab({ plot }: { plot: PlotDetailResponse }) {
       )}
 
       {/* 墓石情報 */}
-      {plot.gravestoneInfo && (
+      {(plot.gravestoneInfo || plot.graveKind != null || plot.graveKubun != null) && (
         <Section title="墓石情報">
-          <InfoField label="墓石基礎" value={plot.gravestoneInfo.gravestoneBase} />
-          <InfoField label="外柵位置" value={plot.gravestoneInfo.enclosurePosition} />
-          <InfoField label="石材店" value={plot.gravestoneInfo.gravestoneDealer} />
-          <InfoField label="墓石種類" value={plot.gravestoneInfo.gravestoneType} />
-          <InfoField label="周辺面積" value={plot.gravestoneInfo.surroundingArea} />
-          <InfoField label="建立期限" value={formatDate(plot.gravestoneInfo.establishmentDeadline)} />
-          <InfoField label="建立日" value={formatDate(plot.gravestoneInfo.establishmentDate)} />
+          <InfoField label="墓石形状" value={plot.graveKind?.toString()} />
+          <InfoField label="基地タイプ" value={plot.graveKubun?.toString()} />
+          <InfoField label="墓石基礎" value={plot.gravestoneInfo?.gravestoneBase} />
+          <InfoField label="外柵位置" value={plot.gravestoneInfo?.enclosurePosition} />
+          <InfoField label="石材店" value={plot.gravestoneInfo?.gravestoneDealer} />
+          <InfoField label="墓石種類" value={plot.gravestoneInfo?.gravestoneType} />
+          <InfoField label="周辺面積" value={plot.gravestoneInfo?.surroundingArea} />
+          <InfoField label="墓石代" value={formatPrice(plot.gravestoneInfo?.gravestoneCost)} />
+          <InfoField label="方位" value={plot.gravestoneInfo?.directionId?.toString()} />
+          <InfoField label="位置" value={plot.gravestoneInfo?.positionId?.toString()} />
+          <InfoField label="墓誌" value={plot.gravestoneInfo?.gravestoneInscription} />
+          <InfoField label="建立期限" value={formatDate(plot.gravestoneInfo?.establishmentDeadline)} />
+          <InfoField label="建立日" value={formatDate(plot.gravestoneInfo?.establishmentDate)} />
         </Section>
       )}
     </div>


### PR DESCRIPTION
## Summary

`plot-detail-view.tsx` の **墓石情報 section** に migration 済だが UI に出ていなかった 6 項目を追加。データは旧システム → 新システムへ移行済（step05 / step08）だが、`InfoField` の行が無いため画面に出ず、業務担当者から見ると「墓石情報が抜けてる」と認識されていた。

## 追加項目

| 旧画面ラベル | データソース | 型 |
|---|---|---|
| 墓石形状 | `ContractPlot.graveKind` | integer 〔master TBD〕 |
| 基地タイプ | `ContractPlot.graveKubun` | integer 〔master TBD〕 |
| 墓石代 | `GravestoneInfo.gravestoneCost` | 円（formatPrice） |
| 方位 | `GravestoneInfo.directionId` | integer 〔master TBD〕 |
| 位置 | `GravestoneInfo.positionId` | integer 〔master TBD〕 |
| 墓誌 | `GravestoneInfo.gravestoneInscription` | string |

`graveKind` / `graveKubun` は `ContractPlot` 上にあり `GravestoneInfo` には載らないため、section の表示ガードを拡張: `gravestoneInfo` が null でも `graveKind` / `graveKubun` のどちらかが入っていれば section を出す。

## 表示順

墓石形状 → 基地タイプ → 墓石基礎 → 外柵位置 → 石材店 → 墓石種類 → 周辺面積 → 墓石代 → 方位 → 位置 → 墓誌 → 建立期限 → 建立日

## Out of scope（意図的に別 PR）

- **マスタ join (C カテゴリ)** — `direction_id` / `position_id` / `graveKind` / `graveKubun` は整数のコード値。本 PR では raw value を表示（例: 方位「1」）。マスタ join 実装は別 PR（backend #46 / #118 と統合進行）。
- **宗派 (B5)** — schema 自体に列が無い。schema 追加 + migration + UI の fullstack 別 PR。
- **Form 側編集** — マスタ join 前に integer をそのまま入力させても UX が悪いため、master dropdown 追加 PR と一緒にまとめる予定。

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] `npm test` 308/308 pass
- [x] `gravestoneInfo === null` でも `graveKind` / `graveKubun` が値持つときに section が描画されることをロジック確認
- [ ] 6 項目すべてが表示されることを目視確認（墓石 section 持つ実 plot で）
- [ ] `gravestoneInfo` null / `graveKind` null / `graveKubun` null 全部の場合は section 自体が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)