### PR TITLE
feat: 続柄を RelationshipMaster select に置き換え (Closes #118)

### DIFF
--- a/src/__tests__/components/plot-form/test-helpers.tsx
+++ b/src/__tests__/components/plot-form/test-helpers.tsx
@@ -14,6 +14,7 @@ export const emptyMasterData: MasterData = {
   billingTypes: [],
   paymentMethods: [],
   sectionNames: [],
+  relationships: [],
   isLoading: false,
 };
 

--- a/src/components/plot-form/BurialInfoTab.tsx
+++ b/src/components/plot-form/BurialInfoTab.tsx
@@ -19,7 +19,9 @@ export function BurialInfoTab({
   buriedPersonFields,
   addBuriedPerson,
   removeBuriedPerson,
+  masterData,
 }: BurialInfoTabProps) {
+  const relationships = masterData?.relationships ?? [];
   const [expandedBurialId, setExpandedBurialId] = useState<string | null>(null);
 
   const collectiveBurial = watch('collectiveBurial');
@@ -223,16 +225,34 @@ export function BurialInfoTab({
                     )}
                   </div>
 
-                  {/* Relationship */}
+                  {/* Relationship — RelationshipMaster select with legacy fallback */}
                   <div>
-                    <Label htmlFor={`buriedPersons.${index}.relationship`}>続柄</Label>
-                    <Input
-                      id={`buriedPersons.${index}.relationship`}
-                      {...register(`buriedPersons.${index}.relationship`)}
-                      className={
-                        errors.buriedPersons?.[index]?.relationship ? 'border-beni' : ''
-                      }
-                    />
+                    {(() => {
+                      const currentValue = watch(`buriedPersons.${index}.relationship`) || '';
+                      const hasLegacyValue =
+                        currentValue && !relationships.some((r) => r.name === currentValue);
+                      return (
+                        <ViewModeSelect
+                          label="続柄"
+                          value={currentValue}
+                          onValueChange={(v) =>
+                            setValue(`buriedPersons.${index}.relationship`, v)
+                          }
+                          placeholder="選択..."
+                        >
+                          {relationships.map((r) => (
+                            <SelectItem key={r.id} value={r.name}>
+                              {r.name}
+                            </SelectItem>
+                          ))}
+                          {hasLegacyValue && (
+                            <SelectItem key="legacy" value={currentValue}>
+                              {currentValue}（既存値）
+                            </SelectItem>
+                          )}
+                        </ViewModeSelect>
+                      );
+                    })()}
                     {errors.buriedPersons?.[index]?.relationship && (
                       <p className="text-sm text-beni mt-1">
                         {errors.buriedPersons[index]?.relationship?.message}

--- a/src/components/plot-form/ContactsTab.tsx
+++ b/src/components/plot-form/ContactsTab.tsx
@@ -19,7 +19,9 @@ export function ContactsTab({
   removeFamilyContact,
   expandedContactId,
   setExpandedContactId,
+  masterData,
 }: ContactsTabProps) {
+  const relationships = masterData?.relationships ?? [];
   const addressTypeLabels: Record<AddressType, string> = {
     [AddressType.Home]: '自宅',
     [AddressType.Work]: '勤務先',
@@ -140,18 +142,33 @@ export function ContactsTab({
                   )}
                 </div>
 
-                {/* Relationship */}
+                {/* Relationship — RelationshipMaster select with legacy fallback */}
                 <div>
-                  <Label htmlFor={`familyContacts.${index}.relationship`}>
-                    続柄 <span className="text-beni">*</span>
-                  </Label>
-                  <Input
-                    id={`familyContacts.${index}.relationship`}
-                    {...register(`familyContacts.${index}.relationship`)}
-                    className={
-                      errors.familyContacts?.[index]?.relationship ? 'border-beni' : ''
-                    }
-                  />
+                  {(() => {
+                    const currentValue = watch(`familyContacts.${index}.relationship`) || '';
+                    const hasLegacyValue =
+                      currentValue && !relationships.some((r) => r.name === currentValue);
+                    return (
+                      <ViewModeSelect
+                        label="続柄"
+                        required
+                        value={currentValue}
+                        onValueChange={(v) => setValue(`familyContacts.${index}.relationship`, v)}
+                        placeholder="選択..."
+                      >
+                        {relationships.map((r) => (
+                          <SelectItem key={r.id} value={r.name}>
+                            {r.name}
+                          </SelectItem>
+                        ))}
+                        {hasLegacyValue && (
+                          <SelectItem key="legacy" value={currentValue}>
+                            {currentValue}（既存値）
+                          </SelectItem>
+                        )}
+                      </ViewModeSelect>
+                    );
+                  })()}
                   {errors.familyContacts?.[index]?.relationship && (
                     <p className="text-sm text-beni mt-1">
                       {errors.familyContacts[index]?.relationship?.message}

--- a/src/components/plot-form/index.tsx
+++ b/src/components/plot-form/index.tsx
@@ -32,6 +32,7 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     billingTypes,
     paymentMethods,
     sectionNames,
+    relationships,
     isLoading: isMasterLoading,
   } = useMasters();
 
@@ -41,6 +42,7 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     billingTypes,
     paymentMethods,
     sectionNames,
+    relationships,
     isLoading: isMasterLoading,
   };
 

--- a/src/components/plot-form/types.ts
+++ b/src/components/plot-form/types.ts
@@ -9,6 +9,7 @@ export interface MasterData {
   billingTypes: MasterItem[];
   paymentMethods: MasterItem[];
   sectionNames: SectionNameMasterItem[];
+  relationships: MasterItem[];
   isLoading: boolean;
 }
 

--- a/src/hooks/useMasters.ts
+++ b/src/hooks/useMasters.ts
@@ -149,6 +149,7 @@ export function useMasters(options?: { skipCache?: boolean }) {
   const recipientTypes = state.data?.recipientType || [];
   const constructionTypes = state.data?.constructionType || [];
   const sectionNames = state.data?.sectionName || [];
+  const relationships = state.data?.relationship || [];
 
   return {
     // 状態
@@ -166,6 +167,7 @@ export function useMasters(options?: { skipCache?: boolean }) {
     recipientTypes,
     constructionTypes,
     sectionNames,
+    relationships,
 
     // アクション
     refresh,

--- a/src/lib/api/masters.ts
+++ b/src/lib/api/masters.ts
@@ -36,6 +36,7 @@ export interface AllMastersData {
   recipientType: MasterItem[];
   constructionType: MasterItem[];
   sectionName: SectionNameMasterItem[];
+  relationship: MasterItem[];
 }
 
 // モックデータ
@@ -86,6 +87,20 @@ const mockMasterData: AllMastersData = {
     { id: 8, code: '3T-JURIN', name: '樹林', period: '第3期樹林部', description: null, sortOrder: 28, isActive: true },
     { id: 9, code: '4-RURIAN_TERRACE', name: 'るり庵テラス', period: '第4期', description: null, sortOrder: 30, isActive: true },
     { id: 10, code: '4-IKOI', name: '憩', period: '第4期', description: null, sortOrder: 37, isActive: true },
+  ],
+  relationship: [
+    { id: 1, code: 'SELF', name: '本人', description: null, sortOrder: 1, isActive: true },
+    { id: 2, code: 'SPOUSE', name: '配偶者', description: null, sortOrder: 2, isActive: true },
+    { id: 3, code: 'FATHER', name: '父', description: null, sortOrder: 3, isActive: true },
+    { id: 4, code: 'MOTHER', name: '母', description: null, sortOrder: 4, isActive: true },
+    { id: 5, code: 'SON', name: '長男', description: null, sortOrder: 5, isActive: true },
+    { id: 6, code: 'DAUGHTER', name: '長女', description: null, sortOrder: 6, isActive: true },
+    { id: 7, code: 'BROTHER', name: '兄弟', description: null, sortOrder: 7, isActive: true },
+    { id: 8, code: 'SISTER', name: '姉妹', description: null, sortOrder: 8, isActive: true },
+    { id: 9, code: 'GRANDFATHER', name: '祖父', description: null, sortOrder: 9, isActive: true },
+    { id: 10, code: 'GRANDMOTHER', name: '祖母', description: null, sortOrder: 10, isActive: true },
+    { id: 11, code: 'GRANDCHILD', name: '孫', description: null, sortOrder: 11, isActive: true },
+    { id: 12, code: 'OTHER', name: 'その他', description: null, sortOrder: 99, isActive: true },
   ],
 };
 
@@ -185,6 +200,16 @@ export async function getSectionNames(): Promise<ApiResponse<SectionNameMasterIt
   return apiGet<SectionNameMasterItem[]>('/masters/section-name');
 }
 
+/**
+ * 続柄マスタ取得
+ */
+export async function getRelationships(): Promise<ApiResponse<MasterItem[]>> {
+  if (shouldUseMockData()) {
+    return { success: true, data: mockMasterData.relationship };
+  }
+  return apiGet<MasterItem[]>('/masters/relationship');
+}
+
 // CRUD用の型定義
 export type MasterType =
   | 'cemetery-type'
@@ -194,7 +219,8 @@ export type MasterType =
   | 'billing-type'
   | 'recipient-type'
   | 'construction-type'
-  | 'section-name';
+  | 'section-name'
+  | 'relationship';
 
 export interface CreateMasterRequest {
   code?: string;


### PR DESCRIPTION
## Summary

`FamilyContact.relationship` と `BuriedPerson.relationship` を自由入力 `<Input>` から **RelationshipMaster 連動の `<Select>`** に置換。backend API は #109 / PR #114 で既に整備済み、frontend だけが追い付いていなかった部分（issue #118）。

データの正規化により、続柄ベースの集計・絞り込み・帳票出力が信頼できるようになる。

## 変更内容

| ファイル | 変更 |
|---|---|
| `lib/api/masters.ts` | `AllMastersData.relationship: MasterItem[]` 追加、`mockMasterData.relationship` に 12 件代表値、`getRelationships()` 関数、`MasterType` に `'relationship'` 追加 |
| `hooks/useMasters.ts` | `relationships` accessor 追加、hook 返却値に含める |
| `plot-form/types.ts` | `MasterData.relationships: MasterItem[]` 追加 |
| `plot-form/index.tsx` | useMasters から relationships を取得して MasterData に渡す |
| `plot-form/ContactsTab.tsx` | `familyContacts[i].relationship` を ViewModeSelect 化、必須は据え置き |
| `plot-form/BurialInfoTab.tsx` | `buriedPersons[i].relationship` を ViewModeSelect 化 |
| `__tests__/.../test-helpers.tsx` | `emptyMasterData` に `relationships: []` 追加（MasterData 型整合） |

## レガシー fallback

migration で取り込んだ既存データに「master に無い続柄」（例: `実母`、`次女`、レガシーの自由入力）が含まれる可能性がある。これを欠落させないため:

\`\`\`tsx
const hasLegacyValue = currentValue && !relationships.some(r => r.name === currentValue);
// → master items に加えて「{value}（既存値）」エントリを 1 件 select に挿入
\`\`\`

ユーザーは既存値を維持するか、master の値に置き換えるかを選べる。

## mock seed 値

backend に繋がない dev 環境用に 12 件: 本人 / 配偶者 / 父 / 母 / 長男 / 長女 / 兄弟 / 姉妹 / 祖父 / 祖母 / 孫 / その他。本番は backend の `/api/v1/masters/all` レスポンスを使うため、実値は backend 側 seed (issue #46) に依存する。

## Test plan

- [x] `npx tsc --noEmit` clean（対象ファイル）
- [x] `npx eslint` clean（対象ファイル）
- [x] `npm test` 308/308 pass（既存 test は relationship UI を assert していないので touch なし）
- [ ] 家族連絡先タブで続柄 select の挙動を目視確認（マスタ選択 + 既存値表示）
- [ ] 埋葬者タブで同上
- [ ] migration 済みの実データで「master に無い続柄」が既存値として保持されることを目視確認

## 関連

- Closes #118
- backend API: #109 / PR #114 (merged)
- 連動 issue: #46 (master データ seed の本番値確定、現在 mock で代用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)