### PR TITLE
feat: 区画詳細 FeeInfoTab で master 名表示 (C-2)

### DIFF
--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -21,6 +21,8 @@ import {
   DmSetting,
 } from '@komine/types';
 import { usePlotDetail } from '@/hooks/usePlots';
+import { useMasters } from '@/hooks/useMasters';
+import type { MasterItem, TaxTypeMasterItem } from '@/lib/api/masters';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -137,6 +139,32 @@ function formatDate(dateStr: string | null | undefined): string {
 function formatPrice(price: number | null | undefined): string {
   if (price == null) return '-';
   return `${price.toLocaleString()} 円`;
+}
+
+/**
+ * Master 名解決ヘルパー。
+ * legacy migration が int 文字列 ("1" "2" 等) を格納している区分系フィールドと、
+ * 新規入力で master code ("AREA" 等) を格納する場合の両方に対応するため、
+ * id 一致 → code 一致 → raw 値 の順に試す。
+ * master に無い既存値はそのまま表示して欠落を防ぐ。
+ */
+function resolveMasterName(
+  masters: ReadonlyArray<MasterItem | TaxTypeMasterItem>,
+  value: string | null | undefined,
+): string | null {
+  if (value == null || value === '') return null;
+  const byId = masters.find((m) => m.id.toString() === value);
+  if (byId) return byId.name;
+  const byCode = masters.find((m) => m.code === value);
+  if (byCode) return byCode.name;
+  return value;
+}
+
+interface FeeMasters {
+  calcTypes: MasterItem[];
+  taxTypes: TaxTypeMasterItem[];
+  billingTypes: MasterItem[];
+  paymentMethods: MasterItem[];
 }
 
 // ===== サブコンポーネント =====
@@ -306,36 +334,36 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
   );
 }
 
-function FeeInfoTab({ plot }: { plot: PlotDetailResponse }) {
+function FeeInfoTab({ plot, masters }: { plot: PlotDetailResponse; masters: FeeMasters }) {
   return (
     <div className="space-y-4">
       {/* 使用料 */}
       {plot.usageFee && (
         <Section title="使用料">
-          <InfoField label="計算タイプ" value={plot.usageFee.calculationType} />
-          <InfoField label="税区分" value={plot.usageFee.taxType} />
-          <InfoField label="請求タイプ" value={plot.usageFee.billingType} />
+          <InfoField label="計算タイプ" value={resolveMasterName(masters.calcTypes, plot.usageFee.calculationType)} />
+          <InfoField label="税区分" value={resolveMasterName(masters.taxTypes, plot.usageFee.taxType)} />
+          <InfoField label="請求タイプ" value={resolveMasterName(masters.billingTypes, plot.usageFee.billingType)} />
           <InfoField label="請求年数" value={plot.usageFee.billingYears?.toString()} />
           <InfoField label="面積" value={plot.usageFee.area} />
           <InfoField label="単価" value={plot.usageFee.unitPrice} />
           <InfoField label="使用料" value={plot.usageFee.usageFee} />
-          <InfoField label="送付方法" value={plot.usageFee.paymentMethod} />
+          <InfoField label="送付方法" value={resolveMasterName(masters.paymentMethods, plot.usageFee.paymentMethod)} />
         </Section>
       )}
 
       {/* 管理料 */}
       {plot.managementFee && (
         <Section title="管理料">
-          <InfoField label="計算タイプ" value={plot.managementFee.calculationType} />
-          <InfoField label="税区分" value={plot.managementFee.taxType} />
-          <InfoField label="請求タイプ" value={plot.managementFee.billingType} />
+          <InfoField label="計算タイプ" value={resolveMasterName(masters.calcTypes, plot.managementFee.calculationType)} />
+          <InfoField label="税区分" value={resolveMasterName(masters.taxTypes, plot.managementFee.taxType)} />
+          <InfoField label="請求タイプ" value={resolveMasterName(masters.billingTypes, plot.managementFee.billingType)} />
           <InfoField label="請求年数" value={plot.managementFee.billingYears?.toString()} />
           <InfoField label="面積" value={plot.managementFee.area} />
           <InfoField label="請求月" value={plot.managementFee.billingMonth?.toString()} />
           <InfoField label="管理料" value={plot.managementFee.managementFee} />
           <InfoField label="単価" value={plot.managementFee.unitPrice} />
           <InfoField label="終納請求年月" value={plot.managementFee.lastBillingMonth} />
-          <InfoField label="送付方法" value={plot.managementFee.paymentMethod} />
+          <InfoField label="送付方法" value={resolveMasterName(masters.paymentMethods, plot.managementFee.paymentMethod)} />
         </Section>
       )}
 
@@ -584,6 +612,8 @@ function ConstructionInfoTab({ plot }: { plot: PlotDetailResponse }) {
 export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRestore }: PlotDetailViewProps) {
   const { user } = useAuth();
   const { plot, isLoading, error, refresh } = usePlotDetail(plotId);
+  const { calcTypes, taxTypes, billingTypes, paymentMethods } = useMasters();
+  const feeMasters: FeeMasters = { calcTypes, taxTypes, billingTypes, paymentMethods };
 
   if (isLoading) {
     return (
@@ -847,7 +877,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
         </TabsContent>
 
         <TabsContent value="fee" className="mt-4 md:mt-6">
-          <FeeInfoTab plot={plot} />
+          <FeeInfoTab plot={plot} masters={feeMasters} />
         </TabsContent>
 
         <TabsContent value="contacts" className="mt-4 md:mt-6">


### PR DESCRIPTION
## Summary

詳細View の **使用料 / 管理料 section** で計算タイプ・税区分・請求タイプ・送付方法が **legacy コード値の生表示** だった (例: `1` `2` 等) のを **master の name** に置換 (例: `面積単価` `内税` `永代` `振込`)。データは migration ✅ / マスタ ✅ で UI lookup だけが欠落していたパターン（C カテゴリ）。

## 変更内容

| ファイル | 変更 |
|---|---|
| `plot-detail-view.tsx` | `resolveMasterName(masters, value)` helper + `FeeMasters` 型を追加。`PlotDetailView` で `useMasters` 経由で 4 master 取得し `FeeInfoTab` に渡す。`FeeInfoTab` 内 8 箇所 (使用料 4 + 管理料 4) で resolveMasterName 適用。 |

## resolveMasterName のフォールバック戦略

```ts
function resolveMasterName(masters, value):
  if value is empty → null (InfoField が "-" を出す)
  if masters.find(m.id.toString() === value) → m.name   // legacy int 文字列
  if masters.find(m.code === value) → m.name             // 新規 form の master code
  return value                                            // どちらも当たらないとき生値を温存
```

**Why 3 段階フォールバック:**
- `m_bochi.shiyouryou_keisan` 等は legacy で tinyint。step05 で `.toString()` され `UsageFee.calculation_type` に文字列保存 → "1" "2" などの **id-like 値**
- 新規入力 (Form の ViewModeSelect) は master code を入れる ("AREA" "FIXED" 等)
- 両方サポートしつつ、未マッピング値も欠落させない

## Out of scope (意図的に別 PR)

- **Form 側 (`FeeInfoTab` in plot-form)** — 既に master 連動 Select で動作中なので touch なし
- **Migration の根本修正** — step05 で legacy 値 → master code に変換する本質的修正は、まず legacy code (m_bochi の tinyint 値) と master code の対応表を業務側で確定する必要があり、本 PR スコープ外
- **同じパターンが必要な他フィールド** — direction_id / position_id / grave_kind / grave_kubun / religion / contractor 等は別 PR (issue #46 / #108 / #118)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] `npm test` 308/308 pass
- [ ] 実 plot で「`1` → `面積単価`」のような master 解決を目視確認
- [ ] master に無い既存値が生値で残ることを目視確認 (regression なし)

Refs: `query_result/UI_GAP_SCREEN_02_BASIC_INFO_1.md` (C カテゴリ — D 使用料 / E 管理料 section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)