### PR TITLE
feat: 区画一覧に「埋葬者を含む」表示オプション (B9)

### DIFF
--- a/src/components/plot-list-table.tsx
+++ b/src/components/plot-list-table.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { StatusBadge, type StatusBadgeProps } from '@/components/ui/status-badge';
+import { Switch } from '@/components/ui/switch';
 import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 
@@ -89,6 +90,8 @@ export default function PlotListTable({
   // ローカルソート状態（クライアントサイド）
   const [sortKey, setSortKey] = useState<SortKey>('customerName');
   const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
+  // 埋葬者名を一覧に併記表示するかのトグル（旧画面「埋葬者を含む」相当）
+  const [showBuriedPersons, setShowBuriedPersons] = useState(false);
 
   // usePlotsフックを使用（サーバーサイド検索）
   const {
@@ -300,6 +303,20 @@ export default function PlotListTable({
               </Button>
             </div>
           </div>
+          {/* 表示オプション */}
+          <div className="mt-3 pt-3 border-t border-gin flex items-center gap-2">
+            <Switch
+              id="toggle-include-buried-persons"
+              checked={showBuriedPersons}
+              onCheckedChange={setShowBuriedPersons}
+            />
+            <label
+              htmlFor="toggle-include-buried-persons"
+              className="text-sm text-sumi cursor-pointer select-none"
+            >
+              埋葬者を含む
+            </label>
+          </div>
         </div>
       )}
 
@@ -453,6 +470,12 @@ export default function PlotListTable({
                           <div className="text-xs md:text-sm text-hai">
                             {plot.customerNameKana || ''}
                           </div>
+                          {showBuriedPersons && plot.buriedPersonNames.length > 0 && (
+                            <div className="mt-1 text-xs text-hai whitespace-normal max-w-[260px]">
+                              <span className="text-cha font-medium">埋葬者:</span>{' '}
+                              {plot.buriedPersonNames.join('、')}
+                            </div>
+                          )}
                           {/* モバイル専用: エリアと未集金額を補足表示 */}
                           <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-hai sm:hidden">
                             {plot.areaName && <span>{plot.areaName}</span>}


### PR DESCRIPTION
## Summary

- 旧画面 (01_区画一覧画面) の「埋葬者を含む」チェックボックスを再現
- toggle ON で氏名セル下に埋葬者名を `、` 連結で併記
- backend は `PlotListItem.buriedPersonNames` を既に返しているため frontend 単発

## Phase 5 / UI ギャップ分析

`UI_GAP_SCREEN_01_PLOT_LIST.md` の **B9** に該当。`query_result/UI_GAP_HANDOFF.md` の未完了リスト「B7〜B14」の第 1 弾。

## 実装メモ

- 既存の Switch component (`@/components/ui/switch`) を使用
- toggle のデフォルトは OFF (既存の表示挙動を維持)
- 埋葬者名のセルは `whitespace-normal max-w-[260px]` で長いリストの折り返しに対応
- `buriedPersonNames` 自体は既存の `usePlots` フックが返している (`packages/types/src/api/plots.ts:57`)

## 残作業 (本 PR スコープ外)

- B9 と同じ画面01 の B10 (年度別請求 status 列) / B11 (区分フィルタ) は別 PR
- `埋葬者を含む` の他に「件数を含む」も legacy にあるが、新システムは件数を常時表示しているので unnecessary

## Test plan

- [ ] toggle OFF: 一覧表示が既存と同じ (regression なし)
- [ ] toggle ON: 埋葬者が紐づく区画行に「埋葬者: ◯◯、△△」が表示される
- [ ] toggle ON: 埋葬者ゼロの区画行は埋葬者ブロックを描画しない
- [ ] toggle ON & 検索 / あいうえおタブ切替 / ソート: 埋葬者表示が維持される
- [ ] モバイル幅 (375px) でも toggle と埋葬者表示が崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)