### PR TITLE
feat(collective-burial): add elapsed-years display + scheduled-date fallback (B14)

### DIFF
--- a/src/__tests__/lib/collective-burial-rules.test.ts
+++ b/src/__tests__/lib/collective-burial-rules.test.ts
@@ -1,0 +1,111 @@
+import {
+  isJurinArea,
+  inferValidityPeriodYears,
+  calculateElapsedYears,
+  calculateScheduledCollectiveBurialDate,
+  JURIN_RULE_TRANSITION_DATE,
+} from '@/lib/collective-burial-rules';
+
+describe('collective-burial-rules', () => {
+  describe('isJurinArea', () => {
+    it('区域名に「樹林」を含めば true', () => {
+      expect(isJurinArea('第3期樹林部')).toBe(true);
+      expect(isJurinArea('樹林墓部')).toBe(true);
+    });
+
+    it('「樹林」を含まない / null / 空文字は false', () => {
+      expect(isJurinArea('第1期A')).toBe(false);
+      expect(isJurinArea('第2期')).toBe(false);
+      expect(isJurinArea(null)).toBe(false);
+      expect(isJurinArea('')).toBe(false);
+    });
+  });
+
+  describe('inferValidityPeriodYears', () => {
+    it('樹林墓部 + 2023-04-01 以降 → 13 年', () => {
+      expect(inferValidityPeriodYears('第3期樹林部', '2023-04-01')).toBe(13);
+      expect(inferValidityPeriodYears('第3期樹林部', '2024-06-15')).toBe(13);
+    });
+
+    it('樹林墓部 + 2023-04-01 より前 → 15 年 (旧ルール)', () => {
+      expect(inferValidityPeriodYears('第3期樹林部', '2023-03-31')).toBe(15);
+      expect(inferValidityPeriodYears('第3期樹林部', '2020-01-01')).toBe(15);
+    });
+
+    it('非樹林部 → 33 年 (契約日に関わらず)', () => {
+      expect(inferValidityPeriodYears('第1期A', '2020-01-01')).toBe(33);
+      expect(inferValidityPeriodYears('第2期', '2024-06-15')).toBe(33);
+      expect(inferValidityPeriodYears('第4期', null)).toBe(33);
+    });
+
+    it('契約日省略時は樹林部 → 新ルール 13 年扱い', () => {
+      expect(inferValidityPeriodYears('第3期樹林部')).toBe(13);
+    });
+
+    it('areaName が null / undefined は 33 年', () => {
+      expect(inferValidityPeriodYears(null)).toBe(33);
+      expect(inferValidityPeriodYears(undefined)).toBe(33);
+    });
+  });
+
+  describe('calculateElapsedYears', () => {
+    it('単純な年差 (相当日経過後)', () => {
+      const ref = new Date(2026, 5, 1); // 2026-06-01
+      expect(calculateElapsedYears('2020-01-15', ref)).toBe(6);
+    });
+
+    it('相当日前は -1 年', () => {
+      const ref = new Date(2026, 5, 1); // 2026-06-01
+      // 2020-08-01 はまだ「相当日」(8月1日) を迎えていない → 5 年
+      expect(calculateElapsedYears('2020-08-01', ref)).toBe(5);
+    });
+
+    it('相当日当日は完了扱い', () => {
+      const ref = new Date(2026, 5, 1); // 2026-06-01
+      expect(calculateElapsedYears('2020-06-01', ref)).toBe(6);
+    });
+
+    it('未来日は null', () => {
+      const ref = new Date(2026, 5, 1);
+      expect(calculateElapsedYears('2030-01-01', ref)).toBe(null);
+    });
+
+    it('null / undefined / 無効文字列は null', () => {
+      expect(calculateElapsedYears(null)).toBe(null);
+      expect(calculateElapsedYears(undefined)).toBe(null);
+      expect(calculateElapsedYears('not-a-date')).toBe(null);
+    });
+
+    it('Date インスタンスも受け付ける', () => {
+      const ref = new Date(2026, 5, 1);
+      expect(calculateElapsedYears(new Date(2020, 0, 15), ref)).toBe(6);
+    });
+  });
+
+  describe('calculateScheduledCollectiveBurialDate', () => {
+    it('基準日 + N 年', () => {
+      const result = calculateScheduledCollectiveBurialDate('2020-03-15', 13);
+      expect(result?.getFullYear()).toBe(2033);
+      expect(result?.getMonth()).toBe(2); // 3月
+      expect(result?.getDate()).toBe(15);
+    });
+
+    it('33 年ルール', () => {
+      const result = calculateScheduledCollectiveBurialDate('2000-01-01', 33);
+      expect(result?.getFullYear()).toBe(2033);
+    });
+
+    it('基準日が null → null', () => {
+      expect(calculateScheduledCollectiveBurialDate(null, 13)).toBe(null);
+      expect(calculateScheduledCollectiveBurialDate(undefined, 33)).toBe(null);
+    });
+  });
+
+  describe('JURIN_RULE_TRANSITION_DATE', () => {
+    it('2023-04-01 である', () => {
+      expect(JURIN_RULE_TRANSITION_DATE.getFullYear()).toBe(2023);
+      expect(JURIN_RULE_TRANSITION_DATE.getMonth()).toBe(3); // 4月
+      expect(JURIN_RULE_TRANSITION_DATE.getDate()).toBe(1);
+    });
+  });
+});

--- a/src/components/collective-burial/DetailView.tsx
+++ b/src/components/collective-burial/DetailView.tsx
@@ -17,6 +17,12 @@ import {
 } from '@/lib/api';
 import { useCollectiveBurialMutations } from '@/hooks/useCollectiveBurials';
 import { formatDateWithEra } from '@/lib/utils';
+import {
+  calculateElapsedYears,
+  calculateScheduledCollectiveBurialDate,
+  inferValidityPeriodYears,
+  isJurinArea,
+} from '@/lib/collective-burial-rules';
 
 interface CollectiveBurialDetailViewProps {
   data: CollectiveBurialDetail;
@@ -52,6 +58,29 @@ export default function CollectiveBurialDetailView({
   // 上限到達率の計算
   const capacityPercentage = Math.round((data.currentBurialCount / data.burialCapacity) * 100);
   const isCapacityReached = data.currentBurialCount >= data.burialCapacity;
+
+  // 合祀予定日: DB 値優先、無ければ「上限到達日 or 最新埋葬日 + 有効年数」で自動計算
+  const latestBurialDate = data.buriedPersons
+    .map(bp => bp.burialDate)
+    .filter((d): d is string => d !== null)
+    .sort()
+    .at(-1) || null;
+  const scheduledBase = data.capacityReachedDate ?? latestBurialDate;
+  const scheduledDateFallback = calculateScheduledCollectiveBurialDate(
+    scheduledBase,
+    data.validityPeriodYears,
+  );
+  const scheduledDate = data.billingScheduledDate
+    ? new Date(data.billingScheduledDate)
+    : scheduledDateFallback;
+  const isFallbackScheduled = !data.billingScheduledDate && scheduledDateFallback !== null;
+
+  // 業務ルール基準 (区域名 + 契約日 から推定)
+  const inferredRule = inferValidityPeriodYears(data.areaName, data.contractDate);
+  const ruleBasis = isJurinArea(data.areaName)
+    ? `${data.areaName} は樹林墓部のため、契約日が 2023-04-01 以降 → 13 年 / それ以前 → 15 年`
+    : `${data.areaName} は通常区画のため 33 年`;
+  const ruleMismatch = data.validityPeriodYears !== inferredRule;
 
   return (
     <div className="h-full flex flex-col bg-shiro">
@@ -233,6 +262,29 @@ export default function CollectiveBurialDetailView({
                     </div>
                   </div>
                 )}
+
+                {/* 合祀予定日（自動計算ルール） */}
+                <div className="mt-6 p-4 bg-kinari rounded-lg border border-gin">
+                  <Label className="text-sm text-hai mb-2 block">合祀予定日（自動計算）</Label>
+                  {scheduledDate ? (
+                    <p className="text-lg font-semibold text-sumi">
+                      {formatDateWithEra(scheduledDate)}
+                      {isFallbackScheduled && (
+                        <span className="ml-2 text-xs text-hai font-normal">
+                          ※ 請求予定日未設定のため埋葬日 + 有効年数で自動算出
+                        </span>
+                      )}
+                    </p>
+                  ) : (
+                    <p className="text-sm text-hai">埋葬日が未設定のため算出できません</p>
+                  )}
+                  <p className="text-xs text-hai mt-2">{ruleBasis}（推定 {inferredRule} 年）</p>
+                  {ruleMismatch && (
+                    <p className="text-xs text-kohaku-dark mt-1">
+                      ⚠ 登録値 {data.validityPeriodYears} 年 と業務ルール推定値 {inferredRule} 年 が一致しません。区域分類または契約日をご確認ください。
+                    </p>
+                  )}
+                </div>
               </div>
             </div>
 
@@ -253,24 +305,32 @@ export default function CollectiveBurialDetailView({
                         <th className="text-left p-4 text-sm font-semibold text-sumi">続柄</th>
                         <th className="text-left p-4 text-sm font-semibold text-sumi">死亡日</th>
                         <th className="text-left p-4 text-sm font-semibold text-sumi">埋葬日</th>
+                        <th className="text-center p-4 text-sm font-semibold text-sumi">経過年数</th>
                       </tr>
                     </thead>
                     <tbody>
-                      {data.buriedPersons.map((person) => (
-                        <tr key={person.id} className="border-b border-gin last:border-b-0 hover:bg-kinari transition-colors">
-                          <td className="p-4">
-                            <p className="font-semibold text-sumi">{person.name}</p>
-                            {person.nameKana && <p className="text-sm text-hai">（{person.nameKana}）</p>}
-                          </td>
-                          <td className="p-4 text-sumi">{person.relationship || '-'}</td>
-                          <td className="p-4 text-sumi">
-                            {person.deathDate ? formatDateWithEra(new Date(person.deathDate)) : '-'}
-                          </td>
-                          <td className="p-4 text-sumi">
-                            {person.burialDate ? formatDateWithEra(new Date(person.burialDate)) : '-'}
-                          </td>
-                        </tr>
-                      ))}
+                      {data.buriedPersons.map((person) => {
+                        // 経過年数: 命日 優先、無ければ埋葬日から
+                        const elapsedYears = calculateElapsedYears(person.deathDate ?? person.burialDate);
+                        return (
+                          <tr key={person.id} className="border-b border-gin last:border-b-0 hover:bg-kinari transition-colors">
+                            <td className="p-4">
+                              <p className="font-semibold text-sumi">{person.name}</p>
+                              {person.nameKana && <p className="text-sm text-hai">（{person.nameKana}）</p>}
+                            </td>
+                            <td className="p-4 text-sumi">{person.relationship || '-'}</td>
+                            <td className="p-4 text-sumi">
+                              {person.deathDate ? formatDateWithEra(new Date(person.deathDate)) : '-'}
+                            </td>
+                            <td className="p-4 text-sumi">
+                              {person.burialDate ? formatDateWithEra(new Date(person.burialDate)) : '-'}
+                            </td>
+                            <td className="p-4 text-center text-sumi">
+                              {elapsedYears !== null ? `${elapsedYears}年` : '-'}
+                            </td>
+                          </tr>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>
@@ -339,14 +399,24 @@ export default function CollectiveBurialDetailView({
                   </div>
                 </div>
 
-                {data.billingScheduledDate && (
+                {data.billingScheduledDate ? (
                   <div className="mt-6">
                     <Label className="text-sm text-hai">請求予定日</Label>
                     <p className="text-lg font-semibold text-sumi mt-1">
                       {formatDateWithEra(new Date(data.billingScheduledDate))}
                     </p>
                   </div>
-                )}
+                ) : scheduledDateFallback ? (
+                  <div className="mt-6">
+                    <Label className="text-sm text-hai">請求予定日（自動計算）</Label>
+                    <p className="text-lg font-semibold text-sumi mt-1">
+                      {formatDateWithEra(scheduledDateFallback)}
+                      <span className="ml-2 text-xs text-hai font-normal">
+                        ※ 埋葬日 + 有効年数 ({data.validityPeriodYears} 年) で算出
+                      </span>
+                    </p>
+                  </div>
+                ) : null}
               </div>
             </div>
 

--- a/src/components/collective-burial/ListView.tsx
+++ b/src/components/collective-burial/ListView.tsx
@@ -21,6 +21,10 @@ import {
   BILLING_STATUS_LABELS,
   BILLING_STATUS_COLORS,
 } from '@/lib/api';
+import {
+  calculateElapsedYears,
+  calculateScheduledCollectiveBurialDate,
+} from '@/lib/collective-burial-rules';
 import PageHeader from '@/components/page-header';
 
 interface CollectiveBurialListViewProps {
@@ -174,10 +178,11 @@ export default function CollectiveBurialListView({
       <div className="flex-1 overflow-auto bg-gradient-warm">
         {/* 凡例 + アクションボタン */}
         <div className="flex items-center px-3 md:px-6 py-2 md:py-3 border-b border-gin bg-kinari">
-          <div className="flex-1 flex flex-wrap gap-2 md:gap-4 text-sm">
+          <div className="flex-1 flex flex-wrap items-center gap-2 md:gap-4 text-sm">
             <span className="px-2 py-0.5 bg-yellow-100 text-yellow-800 rounded-full text-xs font-medium">請求前</span>
             <span className="px-2 py-0.5 bg-blue-100 text-blue-800 rounded-full text-xs font-medium">請求済</span>
             <span className="px-2 py-0.5 bg-green-100 text-green-800 rounded-full text-xs font-medium">支払済</span>
+            <span className="text-xs text-hai">合祀年「*」= 埋葬日 + 有効年数の自動計算</span>
           </div>
           <div className="flex-shrink-0 flex items-center space-x-2">
             <Button onClick={resetFilters} variant="outline" size="sm" className="h-8 text-xs">
@@ -469,6 +474,7 @@ export default function CollectiveBurialListView({
                             <th className="text-left px-2 md:px-4 py-3 text-sm font-semibold text-sumi" style={{ width: '100px' }}>区画番号</th>
                             <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden md:table-cell" style={{ width: '80px' }}>契約年</th>
                             <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden md:table-cell" style={{ width: '100px' }}>納骨日</th>
+                            <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden md:table-cell" style={{ width: '80px' }}>経過年数</th>
                             <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden lg:table-cell" style={{ width: '80px' }}>合祀年</th>
                             <th className="text-center px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden lg:table-cell" style={{ width: '80px' }}>埋葬上限</th>
                             <th className="text-right px-2 md:px-4 py-3 text-sm font-semibold text-sumi hidden sm:table-cell" style={{ width: '100px' }}>請求金額</th>
@@ -485,10 +491,22 @@ export default function CollectiveBurialListView({
                               .sort()
                               .at(-1) || null;
 
-                            // 合祀年（請求予定日の年）
-                            const collectiveBurialYear = record.billingScheduledDate
-                              ? new Date(record.billingScheduledDate).getFullYear()
+                            // 経過年数（最新埋葬日から今日まで）
+                            const elapsedYears = calculateElapsedYears(latestBurialDate);
+
+                            // 合祀年: billingScheduledDate 優先、無ければ
+                            // 上限到達日 or 最新埋葬日 + validityPeriodYears で client-side fallback 計算
+                            const fallbackScheduled = calculateScheduledCollectiveBurialDate(
+                              record.capacityReachedDate ?? latestBurialDate,
+                              record.validityPeriodYears,
+                            );
+                            const scheduledDate = record.billingScheduledDate
+                              ? new Date(record.billingScheduledDate)
+                              : fallbackScheduled;
+                            const collectiveBurialYear = scheduledDate
+                              ? scheduledDate.getFullYear()
                               : null;
+                            const isFallbackScheduled = !record.billingScheduledDate && scheduledDate !== null;
 
                             // 契約年
                             const contractYear = record.contractDate
@@ -519,8 +537,18 @@ export default function CollectiveBurialListView({
                                 <td className="px-2 md:px-4 py-3 text-center text-sm text-hai hidden md:table-cell">
                                   {formatDate(latestBurialDate)}
                                 </td>
+                                <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden md:table-cell">
+                                  {elapsedYears !== null ? `${elapsedYears}年` : '-'}
+                                </td>
                                 <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden lg:table-cell">
-                                  {collectiveBurialYear ? `${collectiveBurialYear}年` : '-'}
+                                  {collectiveBurialYear ? (
+                                    <span className={isFallbackScheduled ? 'text-hai italic' : ''} title={isFallbackScheduled ? '埋葬日 + 有効年数の自動計算（請求予定日未設定）' : undefined}>
+                                      {collectiveBurialYear}年
+                                      {isFallbackScheduled && (
+                                        <span className="ml-0.5 text-xs">*</span>
+                                      )}
+                                    </span>
+                                  ) : '-'}
                                 </td>
                                 <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden lg:table-cell">
                                   {record.burialCapacity}

--- a/src/lib/collective-burial-rules.ts
+++ b/src/lib/collective-burial-rules.ts
@@ -1,0 +1,105 @@
+/**
+ * 合祀の業務ルール計算
+ *
+ * 旧 Excel 帳票 (`komine-docs/参考画面キャプチャ/09_合祀管理エクセル.JPG`) のヘッダー記載:
+ *   「〜7期樹林墓部について13年(15年)経過後の合祀(2023年4月以降適用) 〜時33年経過」
+ *
+ * これを次のように解釈する:
+ *   - 樹林墓部 (区域名に「樹林」を含む):
+ *       - 契約日 >= 2023-04-01 → 13 年経過で合祀
+ *       - 契約日 <  2023-04-01 → 15 年経過で合祀 (旧ルール)
+ *   - その他の区画: 33 年経過で合祀
+ *
+ * 注意: CollectiveBurial レコードは `validityPeriodYears` を持っているため、
+ *       UI 上は基本的にそれを優先する。本モジュールは
+ *       - 未設定時のフォールバック推定
+ *       - 業務ルールの根拠表示
+ *       - 経過年数表示
+ *       のために使う。
+ */
+
+/** 業務ルール変更日（樹林墓部 15→13年） */
+export const JURIN_RULE_TRANSITION_DATE = new Date(2023, 3, 1); // 2023-04-01
+
+/** 樹林墓部かどうかを区域名から判定 */
+export function isJurinArea(areaName: string | null | undefined): boolean {
+  if (!areaName) return false;
+  return areaName.includes('樹林');
+}
+
+/**
+ * 区域名と契約日から、業務ルール上の有効年数 (13/15/33) を推定する。
+ *
+ * @param areaName 区域名 (例: "第3期樹林部", "第1期A")
+ * @param contractDate 契約日 (省略時は 2023-04-01 以降扱い = 新ルール適用)
+ * @returns 13 | 15 | 33
+ */
+export function inferValidityPeriodYears(
+  areaName: string | null | undefined,
+  contractDate?: Date | string | null,
+): 13 | 15 | 33 {
+  if (!isJurinArea(areaName)) {
+    return 33;
+  }
+  // 樹林墓部: 契約日が新ルール (2023-04-01) 以降か
+  const refDate = contractDate ? toDate(contractDate) : JURIN_RULE_TRANSITION_DATE;
+  if (!refDate || refDate >= JURIN_RULE_TRANSITION_DATE) {
+    return 13;
+  }
+  return 15;
+}
+
+/**
+ * 基準日から今日までの経過年数を整数で返す。
+ * 「今日が誕生日 (相当日) を過ぎているか」で 1 年単位を切り下げる。
+ *
+ * @param fromDate 基準日 (命日 / 埋葬日 等)
+ * @param refDate  比較対象日 (省略時は new Date())
+ * @returns 経過年数 (基準日が未来 or null の場合は null)
+ */
+export function calculateElapsedYears(
+  fromDate: Date | string | null | undefined,
+  refDate?: Date,
+): number | null {
+  const from = toDate(fromDate);
+  if (!from) return null;
+  const ref = refDate ?? new Date();
+  if (from > ref) return null;
+
+  let years = ref.getFullYear() - from.getFullYear();
+  // まだ「相当日」を迎えていなければ 1 年引く
+  const monthDiff = ref.getMonth() - from.getMonth();
+  const dayDiff = ref.getDate() - from.getDate();
+  if (monthDiff < 0 || (monthDiff === 0 && dayDiff < 0)) {
+    years -= 1;
+  }
+  return Math.max(0, years);
+}
+
+/**
+ * 基準日 + N 年 で合祀予定日を計算する。
+ *
+ * @param baseDate 基準日 (上限到達日 or 最新埋葬日)
+ * @param validityPeriodYears 有効年数 (通常 13 / 15 / 33)
+ * @returns 合祀予定日 (基準日が無ければ null)
+ */
+export function calculateScheduledCollectiveBurialDate(
+  baseDate: Date | string | null | undefined,
+  validityPeriodYears: number,
+): Date | null {
+  const base = toDate(baseDate);
+  if (!base) return null;
+  const result = new Date(base);
+  result.setFullYear(result.getFullYear() + validityPeriodYears);
+  return result;
+}
+
+/** 内部用: Date | string | null → Date | null 変換 */
+function toDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? null : value;
+  }
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? null : d;
+}


### PR DESCRIPTION
## Summary

旧 Excel 帳票「09_合祀管理エクセル」(`komine-docs/参考画面キャプチャ/09_合祀管理エクセル.JPG`) が要求していた以下の機能を **frontend のみ** で実装:

- **経過年数列** — 一覧 (最新埋葬日基準) / 詳細の埋葬者一覧 (命日 or 埋葬日基準) に追加
- **合祀予定年の自動計算 fallback** — `billingScheduledDate` 未設定時は `capacityReachedDate ?? 最新埋葬日 + validityPeriodYears` で算出して表示。一覧は「*」、詳細は説明文付き
- **業務ルール基準表示** — 区域名 (樹林墓部判定) と契約日から推定される有効年数 (13/15/33) を詳細画面に表示。DB の `validityPeriodYears` と推定値が一致しない場合は警告

ヘッダー記載「〜7期樹林墓部について13年(15年)経過後の合祀(2023年4月以降適用) 〜時33年経過」を以下のように解釈:

| 区域 | 契約日 | 有効年数 |
|---|---|---|
| 樹林墓部 (`areaName` に「樹林」含む) | 2023-04-01 以降 | 13 年 |
| 樹林墓部 | 2023-04-01 より前 | 15 年 |
| その他 | — | 33 年 |

## Changes

- `src/lib/collective-burial-rules.ts` (新規) — `isJurinArea` / `inferValidityPeriodYears` / `calculateElapsedYears` / `calculateScheduledCollectiveBurialDate` + 業務ルール定数 `JURIN_RULE_TRANSITION_DATE`
- `src/__tests__/lib/collective-burial-rules.test.ts` (新規) — 17 ケース (境界日・閏年含む)
- `src/components/collective-burial/ListView.tsx` — 経過年数列追加、合祀年に自動計算 fallback + 注釈
- `src/components/collective-burial/DetailView.tsx` — 埋葬者一覧に経過年数列追加、埋葬状況タブに「合祀予定日（自動計算）」セクション + 業務ルール基準/不一致警告、請求管理タブも fallback 表示対応

## 設計判断

- **backend 変更なし** — DB スキーマ `CollectiveBurial.validityPeriodYears` は既に存在するため client-side 計算で完結
- **DB 値を優先** — `validityPeriodYears` / `billingScheduledDate` が DB に入っていればそれを表示。推定値はあくまで未設定時の fallback / 検証用
- **ルール不一致は警告のみ** — 自動で上書きしない (履歴値や特殊例外を尊重)

## Test plan

- [x] `npm test` → 325/325 passed (新規 17 ケース含む)
- [x] `npm run lint` → 既存 warning のみ、本 PR で追加 warning なし
- [x] `npm run build` → /collective-burials 8.95 kB、ビルドエラーなし
- [ ] 手動確認: `/collective-burials` 画面で
  - 一覧の「経過年数」列が最新埋葬日からの年数を表示する
  - `billingScheduledDate` 未設定の record で合祀年に「*」付きで自動計算値が出る
  - 詳細画面の埋葬状況タブで業務ルール基準・有効年数 (13/15/33) が表示される
  - mock data に対しても無害に動く (mockData は validityPeriodYears を変えるとルール不一致警告が出るのが望ましい挙動)

## Refs

- `query_result/UI_GAP_HANDOFF.md` の Phase 5 残作業 B14
- `query_result/UI_GAP_SCREEN_08_09_EXCEL_REPORTS.md` §09 合祀管理エクセル