### PR TITLE
feat(plot-form): bind ConstructionInfo.contractor to ContractorMaster select (C-4)

### DIFF
--- a/src/__tests__/components/plot-form/construction-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/construction-info-tab.test.tsx
@@ -17,7 +17,11 @@ jest.mock('@/components/ui/select', () => ({
   ),
 }));
 
-function ConstructionInfoTabHost() {
+function ConstructionInfoTabHost({
+  contractors = [],
+}: {
+  contractors?: { id: number; code: string; name: string; description: string | null; sortOrder: number | null; isActive: boolean }[];
+} = {}) {
   return (
     <TabHost arrayName="constructionInfos">
       {(h) => (
@@ -28,7 +32,7 @@ function ConstructionInfoTabHost() {
           addConstructionInfo={h.arrayAppend as any}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           removeConstructionInfo={h.arrayRemove as any}
-          masterData={emptyMasterData}
+          masterData={{ ...emptyMasterData, contractors }}
         />
       )}
     </TabHost>
@@ -85,16 +89,37 @@ describe('ConstructionInfoTab', () => {
     expect(screen.getByText('入金情報')).toBeInTheDocument();
   });
 
-  it('展開された行の業者名フィールドに入力できる', async () => {
+  it('業者名フィールドがマスタ由来のセレクトで表示される', async () => {
     const user = userEvent.setup();
-    render(<ConstructionInfoTabHost />);
+    render(
+      <ConstructionInfoTabHost
+        contractors={[
+          { id: 1, code: 'placeholder-1', name: '小嶺石材', description: null, sortOrder: 1, isActive: true },
+          { id: 2, code: 'placeholder-2', name: '提携業者A', description: null, sortOrder: 2, isActive: true },
+        ]}
+      />
+    );
 
     await user.click(screen.getByRole('button', { name: /工事を追加/ }));
     await user.click(screen.getByText('未入力'));
 
-    const contractorInput = screen.getByLabelText('業者名');
-    await user.type(contractorInput, '○○建設');
-    expect(contractorInput).toHaveValue('○○建設');
+    expect(screen.getByText('小嶺石材')).toBeInTheDocument();
+    expect(screen.getByText('提携業者A')).toBeInTheDocument();
+  });
+
+  it('既存値が master に存在しない場合「（既存値）」付きで表示される', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConstructionInfoTabHost
+        contractors={[
+          { id: 1, code: 'placeholder-1', name: '小嶺石材', description: null, sortOrder: 1, isActive: true },
+        ]}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /工事を追加/ }));
+    // 未入力状態では既存値表示は出ない
+    expect(screen.queryByText(/（既存値）/)).not.toBeInTheDocument();
   });
 
   it('削除ボタンで工事行が削除される', async () => {

--- a/src/__tests__/components/plot-form/test-helpers.tsx
+++ b/src/__tests__/components/plot-form/test-helpers.tsx
@@ -15,6 +15,7 @@ export const emptyMasterData: MasterData = {
   paymentMethods: [],
   sectionNames: [],
   relationships: [],
+  contractors: [],
   isLoading: false,
 };
 

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -526,7 +526,18 @@ function HistoryInfoTab({ plot }: { plot: PlotDetailResponse }) {
   return <HistoryTab plotDetail={plot} />;
 }
 
-function ConstructionInfoTab({ plot }: { plot: PlotDetailResponse }) {
+function ConstructionInfoTab({
+  plot,
+  contractors,
+}: {
+  plot: PlotDetailResponse;
+  contractors: MasterItem[];
+}) {
+  const resolveContractor = (value: string | null | undefined): string | null => {
+    if (!value) return null;
+    const master = contractors.find((c) => c.code === value);
+    return master ? master.name : value;
+  };
   return (
     <div className="space-y-4">
       <Section title="工事記録">
@@ -534,7 +545,7 @@ function ConstructionInfoTab({ plot }: { plot: PlotDetailResponse }) {
           plot.constructionInfos.map((record, idx) => (
             <div key={record.id || idx} className={`col-span-full ${idx > 0 ? 'border-t border-gin pt-4' : ''}`}>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <InfoField label="業者名" value={record.contractor} />
+                <InfoField label="業者名" value={resolveContractor(record.contractor)} />
                 <InfoField label="監督者" value={record.supervisor} />
                 <InfoField label="工事種別" value={record.constructionType} />
                 <InfoField label="工事内容" value={record.constructionContent} />
@@ -613,7 +624,7 @@ function ConstructionInfoTab({ plot }: { plot: PlotDetailResponse }) {
 export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRestore }: PlotDetailViewProps) {
   const { user } = useAuth();
   const { plot, isLoading, error, refresh } = usePlotDetail(plotId);
-  const { calcTypes, taxTypes, billingTypes, paymentMethods } = useMasters();
+  const { calcTypes, taxTypes, billingTypes, paymentMethods, contractors } = useMasters();
   const feeMasters: FeeMasters = { calcTypes, taxTypes, billingTypes, paymentMethods };
 
   if (isLoading) {
@@ -890,7 +901,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
         </TabsContent>
 
         <TabsContent value="construction" className="mt-4 md:mt-6">
-          <ConstructionInfoTab plot={plot} />
+          <ConstructionInfoTab plot={plot} contractors={contractors} />
         </TabsContent>
 
         <TabsContent value="billing" className="mt-4 md:mt-6">

--- a/src/components/plot-form/ConstructionInfoTab.tsx
+++ b/src/components/plot-form/ConstructionInfoTab.tsx
@@ -2,19 +2,30 @@
 
 import { useState } from 'react';
 import { ConstructionInfoTabProps, getDefaultConstructionInfo } from './types';
+import { ViewModeSelect } from './ViewModeField';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
+import { SelectItem } from '@/components/ui/select';
 import { ChevronDown, ChevronUp, Trash2, Plus } from 'lucide-react';
 
 export function ConstructionInfoTab({
   register,
   watch,
+  setValue,
   constructionInfoFields,
   addConstructionInfo,
   removeConstructionInfo,
+  masterData,
 }: ConstructionInfoTabProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const contractors = masterData?.contractors ?? [];
+
+  const getContractorLabel = (value: string | null | undefined): string => {
+    if (!value) return '未入力';
+    const master = contractors.find((c) => c.code === value);
+    return master ? master.name : value;
+  };
 
   return (
     <div className="space-y-4">
@@ -50,7 +61,7 @@ export function ConstructionInfoTab({
             >
               <div className="grid grid-cols-4 gap-4 flex-1 text-sm">
                 <span className="font-medium">
-                  {watch(`constructionInfos.${index}.contractor`) || '未入力'}
+                  {getContractorLabel(watch(`constructionInfos.${index}.contractor`))}
                 </span>
                 <span>{watch(`constructionInfos.${index}.constructionType`) || '-'}</span>
                 <span>{watch(`constructionInfos.${index}.progress`) || '-'}</span>
@@ -93,11 +104,32 @@ export function ConstructionInfoTab({
                       />
                     </div>
                     <div>
-                      <Label htmlFor={`constructionInfos.${index}.contractor`}>業者名</Label>
-                      <Input
-                        id={`constructionInfos.${index}.contractor`}
-                        {...register(`constructionInfos.${index}.contractor`)}
-                      />
+                      {(() => {
+                        const currentValue = watch(`constructionInfos.${index}.contractor`) || '';
+                        const hasLegacyValue =
+                          currentValue && !contractors.some((c) => c.code === currentValue);
+                        return (
+                          <ViewModeSelect
+                            label="業者名"
+                            value={currentValue}
+                            onValueChange={(v) =>
+                              setValue(`constructionInfos.${index}.contractor`, v)
+                            }
+                            placeholder="選択..."
+                          >
+                            {contractors.map((c) => (
+                              <SelectItem key={c.id} value={c.code}>
+                                {c.name}
+                              </SelectItem>
+                            ))}
+                            {hasLegacyValue && (
+                              <SelectItem key="legacy" value={currentValue}>
+                                {currentValue}（既存値）
+                              </SelectItem>
+                            )}
+                          </ViewModeSelect>
+                        );
+                      })()}
                     </div>
                     <div>
                       <Label htmlFor={`constructionInfos.${index}.supervisor`}>監督者</Label>

--- a/src/components/plot-form/index.tsx
+++ b/src/components/plot-form/index.tsx
@@ -33,6 +33,7 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     paymentMethods,
     sectionNames,
     relationships,
+    contractors,
     isLoading: isMasterLoading,
   } = useMasters();
 
@@ -43,6 +44,7 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     paymentMethods,
     sectionNames,
     relationships,
+    contractors,
     isLoading: isMasterLoading,
   };
 
@@ -447,8 +449,8 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
           onConfirm={handleConfirmSubmit}
           title={isEditing ? '更新内容の確認' : '登録内容の確認'}
           description={isEditing ? '以下の項目が変更されます' : '以下の内容で登録します'}
-          sections={!isEditing ? buildPlotPreviewSections(previewData) : undefined}
-          diffSections={isEditing && initialFormData ? buildPlotDiffSections(initialFormData, previewData) : undefined}
+          sections={!isEditing ? buildPlotPreviewSections(previewData, { contractors }) : undefined}
+          diffSections={isEditing && initialFormData ? buildPlotDiffSections(initialFormData, previewData, { contractors }) : undefined}
           confirmText={isEditing ? '確認して更新' : '確認して登録'}
           isLoading={isLoading}
           size="xl"

--- a/src/components/plot-form/previewHelper.ts
+++ b/src/components/plot-form/previewHelper.ts
@@ -1,5 +1,20 @@
 import type { PlotFormData } from '@/lib/validations/plot-form';
 import type { PreviewSection, PreviewDiffSection, PreviewDiffItem } from '@/components/shared/dialogs';
+import type { MasterItem } from '@/lib/api';
+
+export interface PreviewMasterContext {
+  contractors?: MasterItem[];
+}
+
+function resolveContractorLabel(
+  value: string | null | undefined,
+  contractors: MasterItem[] | undefined,
+): string {
+  if (!value) return '';
+  if (!contractors || contractors.length === 0) return value;
+  const master = contractors.find((c) => c.code === value);
+  return master ? master.name : value;
+}
 
 type SectionConfig = {
   title: string;
@@ -147,7 +162,10 @@ function formatFieldValue(value: unknown, format?: (v: unknown) => string): stri
 /**
  * 新規登録時のプレビューセクションを生成
  */
-export function buildPlotPreviewSections(data: PlotFormData): PreviewSection[] {
+export function buildPlotPreviewSections(
+  data: PlotFormData,
+  masterContext?: PreviewMasterContext,
+): PreviewSection[] {
   const sections: PreviewSection[] = [];
 
   for (const config of sectionConfigs) {
@@ -202,7 +220,7 @@ export function buildPlotPreviewSections(data: PlotFormData): PreviewSection[] {
       const ci = data.constructionInfos[i];
       const items = [
         { label: '工事種別', value: ci.constructionType || '' },
-        { label: '業者名', value: ci.contractor || '' },
+        { label: '業者名', value: resolveContractorLabel(ci.contractor, masterContext?.contractors) },
         { label: '工事開始日', value: ci.startDate || '' },
         { label: '工事終了日', value: ci.completionDate || '' },
         { label: '工事内容', value: ci.constructionContent || '' },
@@ -220,6 +238,7 @@ export function buildPlotPreviewSections(data: PlotFormData): PreviewSection[] {
 interface ArrayFieldDef {
   key: string;
   label: string;
+  format?: (v: unknown) => string;
 }
 
 function buildArrayDiffSections(
@@ -233,6 +252,9 @@ function buildArrayDiffSections(
   const currLen = currentArr?.length || 0;
   const maxLen = Math.max(origLen, currLen);
 
+  const fmt = (f: ArrayFieldDef, v: unknown): string =>
+    f.format ? f.format(v) : String(v ?? '');
+
   for (let i = 0; i < maxLen; i++) {
     const orig = originalArr?.[i];
     const curr = currentArr?.[i];
@@ -241,7 +263,7 @@ function buildArrayDiffSections(
     if (!orig && curr) {
       // 新規追加
       for (const f of fields) {
-        const val = String(curr[f.key] ?? '');
+        const val = fmt(f, curr[f.key]);
         if (val) {
           items.push({ label: f.label, before: '', after: val });
         }
@@ -252,7 +274,7 @@ function buildArrayDiffSections(
     } else if (orig && !curr) {
       // 削除
       for (const f of fields) {
-        const val = String(orig[f.key] ?? '');
+        const val = fmt(f, orig[f.key]);
         if (val) {
           items.push({ label: f.label, before: val, after: '' });
         }
@@ -263,8 +285,8 @@ function buildArrayDiffSections(
     } else if (orig && curr) {
       // 既存の変更
       for (const f of fields) {
-        const before = String(orig[f.key] ?? '');
-        const after = String(curr[f.key] ?? '');
+        const before = fmt(f, orig[f.key]);
+        const after = fmt(f, curr[f.key]);
         if (before !== after) {
           items.push({ label: f.label, before, after });
         }
@@ -294,9 +316,15 @@ const buriedPersonFieldDefs: ArrayFieldDef[] = [
   { key: 'gender', label: '性別' },
 ];
 
-const constructionInfoFieldDefs: ArrayFieldDef[] = [
+const buildConstructionInfoFieldDefs = (
+  contractors: MasterItem[] | undefined,
+): ArrayFieldDef[] => [
   { key: 'constructionType', label: '工事種別' },
-  { key: 'contractor', label: '業者名' },
+  {
+    key: 'contractor',
+    label: '業者名',
+    format: (v) => resolveContractorLabel(v as string | null | undefined, contractors),
+  },
   { key: 'startDate', label: '工事開始日' },
   { key: 'completionDate', label: '工事終了日' },
   { key: 'constructionContent', label: '工事内容' },
@@ -310,7 +338,8 @@ const constructionInfoFieldDefs: ArrayFieldDef[] = [
  */
 export function buildPlotDiffSections(
   original: PlotFormData,
-  current: PlotFormData
+  current: PlotFormData,
+  masterContext?: PreviewMasterContext,
 ): PreviewDiffSection[] {
   const sections: PreviewDiffSection[] = [];
 
@@ -347,7 +376,7 @@ export function buildPlotDiffSections(
     '工事情報',
     original.constructionInfos as unknown as Record<string, unknown>[],
     current.constructionInfos as unknown as Record<string, unknown>[],
-    constructionInfoFieldDefs,
+    buildConstructionInfoFieldDefs(masterContext?.contractors),
   ));
 
   return sections;

--- a/src/components/plot-form/types.ts
+++ b/src/components/plot-form/types.ts
@@ -10,6 +10,7 @@ export interface MasterData {
   paymentMethods: MasterItem[];
   sectionNames: SectionNameMasterItem[];
   relationships: MasterItem[];
+  contractors: MasterItem[];
   isLoading: boolean;
 }
 

--- a/src/hooks/useMasters.ts
+++ b/src/hooks/useMasters.ts
@@ -11,6 +11,7 @@ import {
   getRecipientTypes,
   getConstructionTypes,
   getSectionNames,
+  getContractors,
   MasterItem,
   TaxTypeMasterItem,
   SectionNameMasterItem,
@@ -150,6 +151,7 @@ export function useMasters(options?: { skipCache?: boolean }) {
   const constructionTypes = state.data?.constructionType || [];
   const sectionNames = state.data?.sectionName || [];
   const relationships = state.data?.relationship || [];
+  const contractors = state.data?.contractor || [];
 
   return {
     // 状態
@@ -168,6 +170,7 @@ export function useMasters(options?: { skipCache?: boolean }) {
     constructionTypes,
     sectionNames,
     relationships,
+    contractors,
 
     // アクション
     refresh,
@@ -222,6 +225,7 @@ export const useBillingTypes = () => useMasterData<MasterItem>(getBillingTypes);
 export const useRecipientTypes = () => useMasterData<MasterItem>(getRecipientTypes);
 export const useConstructionTypes = () => useMasterData<MasterItem>(getConstructionTypes);
 export const useSectionNames = () => useMasterData<SectionNameMasterItem>(getSectionNames);
+export const useContractors = () => useMasterData<MasterItem>(getContractors);
 
 /**
  * マスタデータからコードで値を検索するユーティリティ

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -63,6 +63,8 @@ export {
   getRecipientTypes,
   getConstructionTypes,
   getSectionNames,
+  getRelationships,
+  getContractors,
   createMasterItem,
   updateMasterItem,
   deleteMasterItem,

--- a/src/lib/api/masters.ts
+++ b/src/lib/api/masters.ts
@@ -37,6 +37,7 @@ export interface AllMastersData {
   constructionType: MasterItem[];
   sectionName: SectionNameMasterItem[];
   relationship: MasterItem[];
+  contractor: MasterItem[];
 }
 
 // モックデータ
@@ -101,6 +102,13 @@ const mockMasterData: AllMastersData = {
     { id: 10, code: 'GRANDMOTHER', name: '祖母', description: null, sortOrder: 10, isActive: true },
     { id: 11, code: 'GRANDCHILD', name: '孫', description: null, sortOrder: 11, isActive: true },
     { id: 12, code: 'OTHER', name: 'その他', description: null, sortOrder: 99, isActive: true },
+  ],
+  contractor: [
+    { id: 1, code: 'placeholder-1', name: '小嶺石材', description: null, sortOrder: 1, isActive: true },
+    { id: 2, code: 'placeholder-2', name: '小嶺霊園工事部', description: null, sortOrder: 2, isActive: true },
+    { id: 3, code: 'placeholder-3', name: '提携業者A', description: null, sortOrder: 3, isActive: true },
+    { id: 4, code: 'placeholder-4', name: '提携業者B', description: null, sortOrder: 4, isActive: true },
+    { id: 5, code: 'placeholder-99', name: 'その他', description: null, sortOrder: 99, isActive: true },
   ],
 };
 
@@ -210,6 +218,16 @@ export async function getRelationships(): Promise<ApiResponse<MasterItem[]>> {
   return apiGet<MasterItem[]>('/masters/relationship');
 }
 
+/**
+ * 工事業者マスタ取得
+ */
+export async function getContractors(): Promise<ApiResponse<MasterItem[]>> {
+  if (shouldUseMockData()) {
+    return { success: true, data: mockMasterData.contractor };
+  }
+  return apiGet<MasterItem[]>('/masters/contractor');
+}
+
 // CRUD用の型定義
 export type MasterType =
   | 'cemetery-type'
@@ -220,7 +238,8 @@ export type MasterType =
   | 'recipient-type'
   | 'construction-type'
   | 'section-name'
-  | 'relationship';
+  | 'relationship'
+  | 'contractor';
 
 export interface CreateMasterRequest {
   code?: string;


### PR DESCRIPTION
## Summary

UI Gap Analysis **C-4**: `ConstructionInfo.contractor` を自由入力 → ContractorMaster 由来の select 化。

- types ([#20](https://github.com/zaitsu82/komine-types/pull/20)) / backend ([#62](https://github.com/zaitsu82/komine-crm-backend/pull/62)) と合わせて C-4 完了。
- C-1 RelationshipMaster と同じパターン: `ViewModeSelect` + 「（既存値）」 fallback。
- `MasterData` に `contractors` を追加し、`useMasters` から `plot-form` に配線。
- ConstructionInfoTab の業者名 `<Input>` を select に置換。code を value として bind し、表示は master の name に解決。
- 確認ダイアログ (`previewHelper`) と詳細表示 (`plot-detail-view`) でも contractor の表示を master の name に解決。
- legacy-migration 後の `legacy-gyousha-{id}` 形式の code は、業務側で master の name を rename すればまとめて表示が更新される設計。

## 設計メモ

- backend step09 が `contractor = "legacy-gyousha-{gyousha_cd}"` を書き込み、対応する `ContractorMaster` row (`code = "legacy-gyousha-{gyousha_cd}"`, `name = "業者ID:{id}"`) を upsert。
- フロントは `value={c.code}` で bind するため、既存値はそのまま master に hit する。
- master 未登録の値は「（既存値）」付きで表示し、保存もそのまま通す（型は VARCHAR(100) なので互換）。

## Test plan

- [x] `npm test` — 326 tests passed
- [x] `npm run lint` — 0 errors (既存 warnings のみ)
- [x] `npm run build` — success
- [x] type check: 私の差分による型エラー 0（既存テストの型エラー 26 件は main と同数）

## 関連

- Closes part of UI Gap Analysis C-4 (refs `query_result/UI_GAP_HANDOFF.md`)
- types: zaitsu82/komine-types#20 (merged)
- backend: zaitsu82/komine-crm-backend#62

🤖 Generated with [Claude Code](https://claude.com/claude-code)