### PR TITLE
feat(plot-list): add grave classification filter selects (B11)

### DIFF
--- a/src/components/plot-registry.tsx
+++ b/src/components/plot-registry.tsx
@@ -12,8 +12,10 @@ import { PlotListItem, PaymentStatus, PhysicalPlotStatus } from '@komine/types';
 import {
   getPlots,
   getPlotDisplayStatus,
+  getGraveClassifications,
 } from '@/lib/api/plots';
 import type { PlotSearchParams } from '@/lib/api/plots';
+import type { GraveClassificationsResponse } from '@komine/types';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { cn, truncateAddressToCity } from '@/lib/utils';
@@ -160,6 +162,14 @@ export default function PlotRegistry({
   const [filterStatus, setFilterStatus] = useState<PhysicalPlotStatus | undefined>(undefined);
   const [filterPaymentStatus, setFilterPaymentStatus] = useState<PaymentStatus | undefined>(undefined);
   const [filterAreaName, setFilterAreaName] = useState('');
+  const [filterGraveKind, setFilterGraveKind] = useState<number | undefined>(undefined);
+  const [filterGraveKubun, setFilterGraveKubun] = useState<number | undefined>(undefined);
+  const [filterGraveType, setFilterGraveType] = useState<number | undefined>(undefined);
+  const [graveClassifications, setGraveClassifications] = useState<GraveClassificationsResponse>({
+    graveKinds: [],
+    graveKubuns: [],
+    graveTypes: [],
+  });
   const [showBuriedPersons, setShowBuriedPersons] = useState(false);
   const [isFilterExpanded, setIsFilterExpanded] = useState(false);
   const [isAiueoExpanded, setIsAiueoExpanded] = useState(false);
@@ -170,6 +180,20 @@ export default function PlotRegistry({
 
   useEffect(() => {
     setSearchHistory(loadSearchHistory());
+  }, []);
+
+  // 区画区分 distinct 値（マスタ化されるまでの暫定 select 候補）
+  useEffect(() => {
+    let cancelled = false;
+    getGraveClassifications().then((res) => {
+      if (cancelled) return;
+      if (res.success) {
+        setGraveClassifications(res.data);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // サーバーサイドページネーション
@@ -208,6 +232,15 @@ export default function PlotRegistry({
       if (filterAreaName.trim()) {
         params.areaName = filterAreaName.trim();
       }
+      if (filterGraveKind !== undefined) {
+        params.graveKind = filterGraveKind;
+      }
+      if (filterGraveKubun !== undefined) {
+        params.graveKubun = filterGraveKubun;
+      }
+      if (filterGraveType !== undefined) {
+        params.graveType = filterGraveType;
+      }
 
       // サーバー対応ソートキーのみ送信
       const serverSortKey = SERVER_SORT_MAP[sortKey];
@@ -229,7 +262,7 @@ export default function PlotRegistry({
     } finally {
       setIsLoading(false);
     }
-  }, [currentPage, itemsPerPage, searchQuery, activeTab, sortKey, sortOrder, filterStatus, filterPaymentStatus, filterAreaName]);
+  }, [currentPage, itemsPerPage, searchQuery, activeTab, sortKey, sortOrder, filterStatus, filterPaymentStatus, filterAreaName, filterGraveKind, filterGraveKubun, filterGraveType]);
 
   useEffect(() => {
     fetchPlots();
@@ -292,7 +325,13 @@ export default function PlotRegistry({
   };
 
   // フィルタ変更ハンドラ
-  const hasActiveFilters = filterStatus !== undefined || filterPaymentStatus !== undefined || filterAreaName.trim() !== '';
+  const hasActiveFilters =
+    filterStatus !== undefined ||
+    filterPaymentStatus !== undefined ||
+    filterAreaName.trim() !== '' ||
+    filterGraveKind !== undefined ||
+    filterGraveKubun !== undefined ||
+    filterGraveType !== undefined;
 
   const handleFilterStatusChange = (value: string) => {
     setFilterStatus(value === 'all' ? undefined : value as PhysicalPlotStatus);
@@ -309,10 +348,28 @@ export default function PlotRegistry({
     setCurrentPage(1);
   };
 
+  const handleFilterGraveKindChange = (value: string) => {
+    setFilterGraveKind(value === 'all' ? undefined : Number(value));
+    setCurrentPage(1);
+  };
+
+  const handleFilterGraveKubunChange = (value: string) => {
+    setFilterGraveKubun(value === 'all' ? undefined : Number(value));
+    setCurrentPage(1);
+  };
+
+  const handleFilterGraveTypeChange = (value: string) => {
+    setFilterGraveType(value === 'all' ? undefined : Number(value));
+    setCurrentPage(1);
+  };
+
   const handleClearFilters = () => {
     setFilterStatus(undefined);
     setFilterPaymentStatus(undefined);
     setFilterAreaName('');
+    setFilterGraveKind(undefined);
+    setFilterGraveKubun(undefined);
+    setFilterGraveType(undefined);
     setCurrentPage(1);
   };
 
@@ -502,7 +559,14 @@ export default function PlotRegistry({
             フィルター
             {hasActiveFilters && (
               <span className="inline-flex items-center justify-center w-4 h-4 bg-ai text-white text-[10px] font-bold rounded-full">
-                {[filterStatus, filterPaymentStatus, filterAreaName.trim() || undefined].filter(Boolean).length}
+                {[
+                  filterStatus,
+                  filterPaymentStatus,
+                  filterAreaName.trim() || undefined,
+                  filterGraveKind,
+                  filterGraveKubun,
+                  filterGraveType,
+                ].filter((v) => v !== undefined && v !== '').length}
               </span>
             )}
             {isFilterExpanded ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
@@ -590,6 +654,57 @@ export default function PlotRegistry({
                 onChange={(e) => handleFilterAreaNameChange(e.target.value)}
                 className="w-full sm:w-28 h-9 text-sm"
               />
+            </div>
+            <div className="flex items-center gap-1 sm:gap-2">
+              <span className="text-xs sm:text-sm text-hai whitespace-nowrap">形状:</span>
+              <Select
+                value={filterGraveKind === undefined ? 'all' : String(filterGraveKind)}
+                onValueChange={handleFilterGraveKindChange}
+              >
+                <SelectTrigger className="w-full sm:w-20 h-9 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">全て</SelectItem>
+                  {graveClassifications.graveKinds.map((v) => (
+                    <SelectItem key={v} value={String(v)}>{v}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-1 sm:gap-2">
+              <span className="text-xs sm:text-sm text-hai whitespace-nowrap">基地:</span>
+              <Select
+                value={filterGraveKubun === undefined ? 'all' : String(filterGraveKubun)}
+                onValueChange={handleFilterGraveKubunChange}
+              >
+                <SelectTrigger className="w-full sm:w-20 h-9 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">全て</SelectItem>
+                  {graveClassifications.graveKubuns.map((v) => (
+                    <SelectItem key={v} value={String(v)}>{v}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-1 sm:gap-2">
+              <span className="text-xs sm:text-sm text-hai whitespace-nowrap">区分:</span>
+              <Select
+                value={filterGraveType === undefined ? 'all' : String(filterGraveType)}
+                onValueChange={handleFilterGraveTypeChange}
+              >
+                <SelectTrigger className="w-full sm:w-20 h-9 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">全て</SelectItem>
+                  {graveClassifications.graveTypes.map((v) => (
+                    <SelectItem key={v} value={String(v)}>{v}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <label className="md:hidden items-center gap-1.5 text-xs sm:text-sm text-hai cursor-pointer col-span-2 select-none flex">
               <input

--- a/src/lib/api/plots.ts
+++ b/src/lib/api/plots.ts
@@ -18,6 +18,7 @@ import {
   BulkUpdatePlotsResponse,
   RestoreContractRequest,
   RestoreContractResponse,
+  GraveClassificationsResponse,
 } from '@komine/types';
 import { apiGet, apiPost, apiPut, apiDelete, shouldUseMockData } from './client';
 import { ApiResponse } from './types';
@@ -51,6 +52,9 @@ export interface PlotSearchParams {
   sortBy?: string;
   sortOrder?: 'asc' | 'desc';
   nameKanaPrefix?: string;
+  graveKind?: number;
+  graveKubun?: number;
+  graveType?: number;
 }
 
 /**
@@ -422,6 +426,9 @@ export async function getPlots(
     sortBy: params.sortBy,
     sortOrder: params.sortOrder,
     nameKanaPrefix: params.nameKanaPrefix,
+    graveKind: params.graveKind,
+    graveKubun: params.graveKubun,
+    graveType: params.graveType,
   });
 
   if (!response.success) {
@@ -464,6 +471,22 @@ export async function getAllPlots(
   }
 
   return { success: true, data: allItems };
+}
+
+/**
+ * 区画区分 distinct 値取得（フィルタ select 用）
+ * master 化されるまでの暫定 API
+ */
+export async function getGraveClassifications(): Promise<
+  ApiResponse<GraveClassificationsResponse>
+> {
+  if (shouldUseMockData()) {
+    return {
+      success: true,
+      data: { graveKinds: [], graveKubuns: [], graveTypes: [] },
+    };
+  }
+  return apiGet<GraveClassificationsResponse>('/plots/grave-classifications');
 }
 
 /**


### PR DESCRIPTION
## Summary
- 区画一覧画面のフィルタ折り畳みエリアに「形状 / 基地 / 区分」3 つの select を追加
- 起動時に `GET /plots/grave-classifications` を呼び、distinct な数値群を選択肢として展開
- 「フィルタ解除」で 3 種も同時クリア。active 件数バッジに反映

## Context
画面01「区画一覧（台帳問合せ）」の **B11**（区分フィルタ）の frontend 側。
- 関連 PR: types#21（`GraveClassificationsResponse`）、backend#137（API endpoint）
- 参考: `query_result/UI_GAP_SCREEN_01_PLOT_LIST.md` 「区分（全て）」フィルタ
- grave_kind/kubun/type は ContractPlot に Int で保持済み（レガシー由来 tinyint）。master 化までは raw 数値 select として暫定対応。master 化された時点で label が自動的に名称に切り替えやすい構造

## Test plan
- [ ] types#21 + backend#137 merge 後に frontend CI re-run で全 green
- [ ] 画面01 で 3 select が表示・絞り込み動作する
- [ ] master 値が無い空 DB ケースで「全て」のみ表示される
- [ ] iPhone SE 375px でフィルタが破綻しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)