### PR TITLE
feat(plot-form): add parallel applicant section to BasicInfoTab (B2)

### DIFF
--- a/src/__tests__/components/plot-form/basic-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/basic-info-tab.test.tsx
@@ -28,7 +28,7 @@ jest.mock('@/components/ui/select', () => ({
 }));
 
 describe('BasicInfoTab', () => {
-  it('物理区画情報・契約区画情報・販売契約情報・契約者情報の4セクションを表示する', () => {
+  it('物理区画情報・契約区画情報・販売契約情報・契約者情報・申込者情報の5セクションを表示する', () => {
     render(
       <TabHost>
         {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
@@ -39,6 +39,77 @@ describe('BasicInfoTab', () => {
     expect(screen.getByText('契約区画情報')).toBeInTheDocument();
     expect(screen.getByText('販売契約情報')).toBeInTheDocument();
     expect(screen.getByText('契約者情報')).toBeInTheDocument();
+    expect(screen.getByText(/申込者情報/)).toBeInTheDocument();
+  });
+
+  it('デフォルトでは申込者 section は折りたたまれていて「申込者を追加」ボタンがある', () => {
+    render(
+      <TabHost>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    expect(screen.getByRole('button', { name: '申込者を追加' })).toBeInTheDocument();
+    // 入力フィールドは未表示
+    expect(screen.queryByPlaceholderText('山田 花子')).not.toBeInTheDocument();
+  });
+
+  it('「申込者を追加」を押すと氏名・カナ等の入力フィールドが現れる', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    await user.click(screen.getByRole('button', { name: '申込者を追加' }));
+
+    expect(screen.getByPlaceholderText('山田 花子')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('ヤマダ ハナコ')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '申込者を削除' })).toBeInTheDocument();
+  });
+
+  it('「申込者を削除」を押すと申込者フィールドが消え、再度「追加」ボタンが表示される', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost defaultValues={{
+        applicant: {
+          name: '山田花子',
+          nameKana: 'ヤマダハナコ',
+          birthDate: null,
+          gender: null,
+          postalCode: null,
+          address: null,
+          addressLine2: null,
+          registeredPostalCode: null,
+          registeredAddress: null,
+          phoneNumber: null,
+          faxNumber: null,
+          email: null,
+          notes: null,
+        },
+      }}>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    expect(screen.getByPlaceholderText('山田 花子')).toHaveValue('山田花子');
+
+    await user.click(screen.getByRole('button', { name: '申込者を削除' }));
+
+    expect(screen.queryByPlaceholderText('山田 花子')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '申込者を追加' })).toBeInTheDocument();
+  });
+
+  it('viewMode の場合、追加・削除ボタンは表示されず、未入力時は「契約者と同一」テキストが出る', () => {
+    render(
+      <TabHost>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} viewMode={true} />}
+      </TabHost>
+    );
+
+    expect(screen.queryByRole('button', { name: '申込者を追加' })).not.toBeInTheDocument();
+    expect(screen.getByText('申込者は契約者と同一です。')).toBeInTheDocument();
   });
 
   it('必須項目に*マークが表示される', () => {

--- a/src/components/plot-form/BasicInfoTab.tsx
+++ b/src/components/plot-form/BasicInfoTab.tsx
@@ -6,7 +6,9 @@ import { ViewModeField, ViewModeSelect } from './ViewModeField';
 import { SelectItem } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { useMemo } from 'react';
-import { Gender, ContractRole, PaymentStatus } from '@komine/types';
+import { Button } from '@/components/ui/button';
+import { Gender, PaymentStatus } from '@komine/types';
+import { defaultApplicant } from '@/lib/validations/plot-form';
 
 export function BasicInfoTab({
   register,
@@ -357,19 +359,173 @@ export function BasicInfoTab({
             placeholder="example@example.com"
           />
 
-          <ViewModeSelect
-            label="役割"
-            value={watch('customer.role') || ''}
-            onValueChange={(v) => setValue('customer.role', v as ContractRole)}
-            viewMode={viewMode}
-            placeholder="選択..."
-          >
-            <SelectItem value={ContractRole.Contractor}>契約者</SelectItem>
-            <SelectItem value={ContractRole.Applicant}>申込者</SelectItem>
-          </ViewModeSelect>
         </div>
       </div>
 
+      {/* Section 5: 申込者情報（任意 — 契約者と異なる場合のみ入力） */}
+      <ApplicantSection
+        register={register}
+        watch={watch}
+        setValue={setValue}
+        errors={errors}
+        viewMode={viewMode}
+      />
+
+    </div>
+  );
+}
+
+function ApplicantSection({
+  register,
+  watch,
+  setValue,
+  errors,
+  viewMode,
+}: Pick<PlotTabBaseProps, 'register' | 'watch' | 'setValue' | 'errors' | 'viewMode'>) {
+  const applicant = watch('applicant');
+  const hasApplicant = applicant !== null && applicant !== undefined;
+
+  const handleAdd = () => setValue('applicant', { ...defaultApplicant });
+  const handleRemove = () => setValue('applicant', null);
+
+  return (
+    <div className="border rounded-lg p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-sumi">
+          申込者情報
+          <span className="ml-2 text-xs font-normal text-hai">（契約者と異なる場合のみ入力）</span>
+        </h3>
+        {!viewMode && (
+          hasApplicant ? (
+            <Button type="button" variant="outline" size="sm" onClick={handleRemove}>
+              申込者を削除
+            </Button>
+          ) : (
+            <Button type="button" variant="outline" size="sm" onClick={handleAdd}>
+              申込者を追加
+            </Button>
+          )
+        )}
+      </div>
+
+      {!hasApplicant ? (
+        <p className="text-sm text-hai">
+          {viewMode
+            ? '申込者は契約者と同一です。'
+            : '契約者と異なる申込者がいる場合は「申込者を追加」をクリック。'}
+        </p>
+      ) : (
+        <div className="grid grid-cols-3 gap-4">
+          <ViewModeField
+            label="氏名"
+            viewMode={viewMode}
+            required
+            register={register('applicant.name')}
+            error={errors.applicant?.name?.message}
+            placeholder="山田 花子"
+          />
+
+          <ViewModeField
+            label="氏名カナ"
+            viewMode={viewMode}
+            required
+            register={register('applicant.nameKana')}
+            error={errors.applicant?.nameKana?.message}
+            placeholder="ヤマダ ハナコ"
+          />
+
+          <ViewModeField
+            label="生年月日"
+            viewMode={viewMode}
+            type="date"
+            register={register('applicant.birthDate')}
+            error={errors.applicant?.birthDate?.message}
+          />
+
+          <ViewModeSelect
+            label="性別"
+            value={watch('applicant.gender') || ''}
+            onValueChange={(v) => setValue('applicant.gender', v as Gender)}
+            viewMode={viewMode}
+            placeholder="選択..."
+          >
+            <SelectItem value={Gender.Male}>男性</SelectItem>
+            <SelectItem value={Gender.Female}>女性</SelectItem>
+            <SelectItem value={Gender.NotAnswered}>未回答</SelectItem>
+          </ViewModeSelect>
+
+          <ViewModeField
+            label="郵便番号"
+            viewMode={viewMode}
+            register={register('applicant.postalCode')}
+            error={errors.applicant?.postalCode?.message}
+            placeholder="1234567（ハイフンなし7桁）"
+          />
+
+          <div className="col-span-3">
+            <ViewModeField
+              label="住所"
+              viewMode={viewMode}
+              register={register('applicant.address')}
+              error={errors.applicant?.address?.message}
+              placeholder="東京都渋谷区..."
+            />
+          </div>
+
+          <div className="col-span-3">
+            <ViewModeField
+              label="住所2"
+              viewMode={viewMode}
+              register={register('applicant.addressLine2')}
+              error={errors.applicant?.addressLine2?.message}
+              placeholder="マンション名・部屋番号等"
+            />
+          </div>
+
+          <ViewModeField
+            label="本籍郵便番号"
+            viewMode={viewMode}
+            register={register('applicant.registeredPostalCode')}
+            error={errors.applicant?.registeredPostalCode?.message}
+            placeholder="1234567（ハイフンなし7桁）"
+          />
+
+          <div className="col-span-3">
+            <ViewModeField
+              label="本籍地"
+              viewMode={viewMode}
+              register={register('applicant.registeredAddress')}
+              error={errors.applicant?.registeredAddress?.message}
+              placeholder="東京都..."
+            />
+          </div>
+
+          <ViewModeField
+            label="電話番号"
+            viewMode={viewMode}
+            register={register('applicant.phoneNumber')}
+            error={errors.applicant?.phoneNumber?.message}
+            placeholder="09012345678"
+          />
+
+          <ViewModeField
+            label="FAX"
+            viewMode={viewMode}
+            register={register('applicant.faxNumber')}
+            error={errors.applicant?.faxNumber?.message}
+            placeholder="0312345678"
+          />
+
+          <ViewModeField
+            label="メール"
+            viewMode={viewMode}
+            type="email"
+            register={register('applicant.email')}
+            error={errors.applicant?.email?.message}
+            placeholder="example@example.com"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/plot-form/previewHelper.ts
+++ b/src/components/plot-form/previewHelper.ts
@@ -29,11 +29,6 @@ const formatGender = (v: unknown) => {
   if (v === 'OTHER') return 'その他';
   return '';
 };
-const formatRole = (v: unknown) => {
-  if (v === 'APPLICANT') return '申込者';
-  if (v === 'CONTRACTOR') return '契約者';
-  return String(v ?? '');
-};
 const formatPaymentStatus = (v: unknown) => {
   const map: Record<string, string> = {
     Unpaid: '未払い', PartialPaid: '一部支払い済み', Paid: '支払い済み',
@@ -91,8 +86,25 @@ const sectionConfigs: SectionConfig[] = [
       { key: 'customer.phoneNumber', label: '電話番号' },
       { key: 'customer.faxNumber', label: 'FAX' },
       { key: 'customer.email', label: 'メール' },
-      { key: 'customer.role', label: '役割', format: formatRole },
       { key: 'customer.notes', label: '備考' },
+    ],
+  },
+  {
+    title: '申込者情報',
+    fields: [
+      { key: 'applicant.name', label: '氏名' },
+      { key: 'applicant.nameKana', label: '氏名カナ' },
+      { key: 'applicant.birthDate', label: '生年月日', format: formatDate },
+      { key: 'applicant.gender', label: '性別', format: formatGender },
+      { key: 'applicant.postalCode', label: '郵便番号' },
+      { key: 'applicant.address', label: '住所' },
+      { key: 'applicant.addressLine2', label: '住所2' },
+      { key: 'applicant.registeredPostalCode', label: '本籍郵便番号' },
+      { key: 'applicant.registeredAddress', label: '本籍地' },
+      { key: 'applicant.phoneNumber', label: '電話番号' },
+      { key: 'applicant.faxNumber', label: 'FAX' },
+      { key: 'applicant.email', label: 'メール' },
+      { key: 'applicant.notes', label: '備考' },
     ],
   },
   {

--- a/src/lib/validations/plot-form.ts
+++ b/src/lib/validations/plot-form.ts
@@ -23,6 +23,7 @@ export {
   contractPlotSchema,
   saleContractSchema,
   customerSchema,
+  applicantSchema,
   workInfoSchema,
   usageFeeSchema,
   managementFeeSchema,
@@ -41,6 +42,7 @@ export type {
   ContractPlotFormData,
   SaleContractFormData,
   CustomerSectionFormData,
+  ApplicantSectionFormData,
   WorkInfoFormData,
   UsageFeeFormData,
   ManagementFeeFormData,
@@ -58,6 +60,7 @@ import type {
   ContractPlotFormData,
   SaleContractFormData,
   CustomerSectionFormData,
+  ApplicantSectionFormData,
   PlotFormData,
   PlotUpdateFormData,
 } from '@komine/types/validations';
@@ -114,11 +117,28 @@ export const defaultCustomer: CustomerSectionFormData = {
   role: ContractRole.Contractor,
 };
 
+export const defaultApplicant: ApplicantSectionFormData = {
+  name: '',
+  nameKana: '',
+  birthDate: null,
+  gender: null,
+  postalCode: null,
+  address: null,
+  addressLine2: null,
+  registeredPostalCode: null,
+  registeredAddress: null,
+  phoneNumber: null,
+  faxNumber: null,
+  email: null,
+  notes: null,
+};
+
 export const defaultPlotFormData: PlotFormData = {
   physicalPlot: defaultPhysicalPlot,
   contractPlot: defaultContractPlot,
   saleContract: defaultSaleContract,
   customer: defaultCustomer,
+  applicant: null,
   workInfo: null,
   usageFee: null,
   managementFee: null,
@@ -181,6 +201,23 @@ export function plotFormDataToCreateRequest(formData: PlotFormData): CreatePlotR
       notes: formData.customer.notes || undefined,
       role: formData.customer.role,
     },
+    applicant: formData.applicant && formData.applicant.name
+      ? {
+        name: formData.applicant.name,
+        nameKana: formData.applicant.nameKana,
+        birthDate: formData.applicant.birthDate || undefined,
+        gender: formData.applicant.gender || undefined,
+        postalCode: formData.applicant.postalCode || undefined,
+        address: formData.applicant.address || undefined,
+        addressLine2: formData.applicant.addressLine2 || undefined,
+        registeredPostalCode: formData.applicant.registeredPostalCode || undefined,
+        registeredAddress: formData.applicant.registeredAddress || undefined,
+        phoneNumber: formData.applicant.phoneNumber || undefined,
+        faxNumber: formData.applicant.faxNumber || undefined,
+        email: formData.applicant.email || undefined,
+        notes: formData.applicant.notes || undefined,
+      }
+      : undefined,
     workInfo: formData.workInfo
       ? {
         companyName: formData.workInfo.companyName,
@@ -370,6 +407,29 @@ export function plotFormDataToUpdateRequest(formData: PlotUpdateFormData): Updat
     };
   }
 
+  // 申込者: 名前ありで送信、name 空 or applicant=null → null（既存解除）、undefined → 変更なし
+  if (formData.applicant !== undefined) {
+    if (formData.applicant && formData.applicant.name) {
+      request.applicant = {
+        name: formData.applicant.name,
+        nameKana: formData.applicant.nameKana,
+        birthDate: formData.applicant.birthDate || undefined,
+        gender: formData.applicant.gender || undefined,
+        postalCode: formData.applicant.postalCode || undefined,
+        address: formData.applicant.address || undefined,
+        addressLine2: formData.applicant.addressLine2 || undefined,
+        registeredPostalCode: formData.applicant.registeredPostalCode || undefined,
+        registeredAddress: formData.applicant.registeredAddress || undefined,
+        phoneNumber: formData.applicant.phoneNumber || undefined,
+        faxNumber: formData.applicant.faxNumber || undefined,
+        email: formData.applicant.email || undefined,
+        notes: formData.applicant.notes || undefined,
+      };
+    } else {
+      request.applicant = null;
+    }
+  }
+
   // オプショナルセクション
   request.workInfo = formData.workInfo;
   request.usageFee = formData.usageFee;
@@ -479,6 +539,12 @@ export function plotDetailToFormData(detail: PlotDetailResponse): PlotFormData {
   // Primary contractor を取得（最初の Contractor ロール、なければ最初のロール）
   const primaryRole = detail.roles.find((r) => r.role === ContractRole.Contractor) || detail.roles[0];
   const customer = primaryRole?.customer;
+  // 申込者（契約者と別人の場合のみ採用。同一人物のときは contractor 1 件として扱う）
+  const applicantRole = detail.roles.find((r) => r.role === ContractRole.Applicant);
+  const applicantCustomer =
+    applicantRole && applicantRole.customer.id !== primaryRole?.customer.id
+      ? applicantRole.customer
+      : null;
 
   return {
     physicalPlot: {
@@ -527,6 +593,23 @@ export function plotDetailToFormData(detail: PlotDetailResponse): PlotFormData {
       notes: customer?.notes || null,
       role: primaryRole?.role || ContractRole.Contractor,
     },
+    applicant: applicantCustomer
+      ? {
+        name: applicantCustomer.name,
+        nameKana: applicantCustomer.nameKana || '',
+        birthDate: toDateOnly(applicantCustomer.birthDate) || null,
+        gender: applicantCustomer.gender || null,
+        postalCode: applicantCustomer.postalCode || null,
+        address: applicantCustomer.address || null,
+        addressLine2: applicantCustomer.addressLine2 || null,
+        registeredPostalCode: applicantCustomer.registeredPostalCode || null,
+        registeredAddress: applicantCustomer.registeredAddress || null,
+        phoneNumber: applicantCustomer.phoneNumber || null,
+        faxNumber: applicantCustomer.faxNumber || null,
+        email: applicantCustomer.email || null,
+        notes: applicantCustomer.notes || null,
+      }
+      : null,
     workInfo: customer?.workInfo
       ? {
         companyName: customer.workInfo.companyName || '',


### PR DESCRIPTION
## Summary

- `BasicInfoTab` に「申込者情報」section を追加（任意・契約者と異なる場合のみ入力）
- 「申込者を追加」/「申込者を削除」ボタンで `null ↔ 入力フィールド` を切替
- 旧 `customer.role` select は section で固定されたため削除
- `plotDetailToFormData`: `applicantRole` (別 Customer ID) を `applicant` フィールドに展開
- `plotFormDataToCreateRequest`: 名前ありで `applicant` 送信
- `plotFormDataToUpdateRequest`: 入力あり→upsert、空・null→`null`（解除）、undefined→変更なし
- 確認プレビューにも「申込者情報」section を追加
- 関連テスト 4 件追加（追加ボタン・展開・削除・viewMode）

## Why

旧画面（`02_基本情報①画面.JPG`）は「申込者」と「契約者」を並列に両方表示する。
B1 (#... マージ済) で詳細View 側は両方表示できたが、Form 側は片肺だった。
本 PR で Form 側も並列入力できるようにし、B2 fullstack 改修を完了する。

UI gap 分析 [B2-PR](.../UI_GAP_SCREEN_02_BASIC_INFO_1.md) に対応。

## UI 挙動

- 申込者が未入力（デフォルト）: 「申込者情報」section に追加ボタンのみ表示
- 「申込者を追加」: 氏名・カナ・住所・電話番号等のフィールドが展開
- 編集時に旧 applicant role が存在する場合: 自動展開して既存値を表示
- viewMode（プレビュー）: 入力フィールドではなく値だけ表示。未入力なら「契約者と同一です」

## Dependencies

- depends-on: https://github.com/zaitsu82/komine-types/pull/23 (types PR)
- depends-on: https://github.com/zaitsu82/komine-crm-backend/pull/143 (backend PR)

## Test plan

- [x] frontend unit tests pass (`npm test` — 330 tests pass, 4 new)
- [x] frontend lint clean (`npm run lint` — 0 errors)
- [x] frontend src typecheck clean
- [ ] /plots/new と /plots/[id]/edit でブラウザ動作確認（backend マージ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)