### PR TITLE
feat(plot-list): add 請求状況 summary column (B10)

### DIFF
--- a/src/__tests__/components/billing-summary-badges.test.tsx
+++ b/src/__tests__/components/billing-summary-badges.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BillingRecordStatus } from '@komine/types';
+import { BillingSummaryBadges } from '@/components/plot-list-table';
+
+/**
+ * B10: 区画一覧「請求状況」サマリ列のバッジ表示テスト
+ */
+describe('BillingSummaryBadges', () => {
+  it('Billing が無い場合は「—」を表示する', () => {
+    render(
+      <BillingSummaryBadges
+        summary={{
+          hasBilling: false,
+          latestYear: null,
+          latestYearStatus: null,
+          unpaidYearCount: 0,
+        }}
+      />
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByText(/未納/)).not.toBeInTheDocument();
+  });
+
+  it('完納（未納0年）は最新年度バッジのみ・未納バッジは出さない', () => {
+    render(
+      <BillingSummaryBadges
+        summary={{
+          hasBilling: true,
+          latestYear: 2024,
+          latestYearStatus: BillingRecordStatus.Paid,
+          unpaidYearCount: 0,
+        }}
+      />
+    );
+    expect(screen.getByText(/2024年/)).toBeInTheDocument();
+    expect(screen.getByText(/完納/)).toBeInTheDocument();
+    expect(screen.queryByText(/未納/)).not.toBeInTheDocument();
+  });
+
+  it('延滞かつ未納2年は 最新年度バッジ ＋ 未納2年バッジ', () => {
+    render(
+      <BillingSummaryBadges
+        summary={{
+          hasBilling: true,
+          latestYear: 2024,
+          latestYearStatus: BillingRecordStatus.Overdue,
+          unpaidYearCount: 2,
+        }}
+      />
+    );
+    expect(screen.getByText(/2024年/)).toBeInTheDocument();
+    expect(screen.getByText(/延滞/)).toBeInTheDocument();
+    expect(screen.getByText('未納2年')).toBeInTheDocument();
+  });
+
+  it('年度が null でも未納件数があれば未納バッジは出す（年度バッジは出さない）', () => {
+    render(
+      <BillingSummaryBadges
+        summary={{
+          hasBilling: true,
+          latestYear: null,
+          latestYearStatus: null,
+          unpaidYearCount: 1,
+        }}
+      />
+    );
+    expect(screen.getByText('未納1年')).toBeInTheDocument();
+    expect(screen.queryByText(/年 /)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/plot-list-table.tsx
+++ b/src/components/plot-list-table.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useMemo, useState, type KeyboardEvent } from 'react';
-import { PlotListItem, PaymentStatus } from '@komine/types';
+import { PlotListItem, PaymentStatus, BillingRecordStatus } from '@komine/types';
 import { usePlots } from '@/hooks/usePlots';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -65,6 +65,56 @@ const PAYMENT_STATUS_VARIANTS: Record<PaymentStatus, StatusBadgeProps['variant']
   [PaymentStatus.Overdue]: 'overdue',
   [PaymentStatus.Refunded]: 'refunded',
 };
+
+// ===== 請求状況サマリ（B10: 年度別請求 status の集約列）=====
+
+const BILLING_STATUS_LABELS: Record<BillingRecordStatus, string> = {
+  [BillingRecordStatus.Pending]: '請求前',
+  [BillingRecordStatus.Billed]: '請求済',
+  [BillingRecordStatus.PartialPaid]: '一部入金',
+  [BillingRecordStatus.Paid]: '完納',
+  [BillingRecordStatus.Overdue]: '延滞',
+  [BillingRecordStatus.Terminated]: '解約',
+  [BillingRecordStatus.WrittenOff]: '貸倒',
+};
+
+const BILLING_STATUS_VARIANTS: Record<BillingRecordStatus, StatusBadgeProps['variant']> = {
+  [BillingRecordStatus.Pending]: 'neutral',
+  [BillingRecordStatus.Billed]: 'unpaid',
+  [BillingRecordStatus.PartialPaid]: 'partial',
+  [BillingRecordStatus.Paid]: 'paid',
+  [BillingRecordStatus.Overdue]: 'overdue',
+  [BillingRecordStatus.Terminated]: 'cancelled',
+  [BillingRecordStatus.WrittenOff]: 'cancelled',
+};
+
+/**
+ * 請求状況サマリのバッジ群。
+ * 最新年度の status バッジ ＋ 未納年数バッジを表示する。Billing が無ければ「—」。
+ */
+export function BillingSummaryBadges({ summary }: { summary: PlotListItem['billingSummary'] }) {
+  if (!summary?.hasBilling) {
+    return <span className="text-sm text-hai">—</span>;
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {summary.latestYear !== null && summary.latestYearStatus && (
+        <StatusBadge
+          variant={BILLING_STATUS_VARIANTS[summary.latestYearStatus]}
+          size="sm"
+          withSymbol
+        >
+          {summary.latestYear}年 {BILLING_STATUS_LABELS[summary.latestYearStatus]}
+        </StatusBadge>
+      )}
+      {summary.unpaidYearCount > 0 && (
+        <StatusBadge variant="overdue" size="sm" withSymbol>
+          未納{summary.unpaidYearCount}年
+        </StatusBadge>
+      )}
+    </div>
+  );
+}
 
 // ===== ヘルパー関数 =====
 
@@ -417,6 +467,9 @@ export default function PlotListTable({
                     {renderSortIndicator('paymentStatus')}
                   </div>
                 </th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-sumi hidden md:table-cell">
+                  請求状況
+                </th>
                 <th
                   className={cn(
                     'px-4 py-3 text-right text-sm font-semibold text-sumi cursor-pointer transition-colors duration-200 hover:bg-cha-50 hidden sm:table-cell',
@@ -434,7 +487,7 @@ export default function PlotListTable({
             <tbody className="divide-y divide-gin">
               {isLoading ? (
                 <tr>
-                  <td colSpan={11} className="px-6 py-8 text-center text-sm text-hai">
+                  <td colSpan={12} className="px-6 py-8 text-center text-sm text-hai">
                     <div className="flex items-center justify-center">
                       <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-matsu mr-2"></div>
                       データを読み込み中...
@@ -443,7 +496,7 @@ export default function PlotListTable({
                 </tr>
               ) : error ? (
                 <tr>
-                  <td colSpan={11} className="px-6 py-8 text-center text-sm text-beni">
+                  <td colSpan={12} className="px-6 py-8 text-center text-sm text-beni">
                     エラーが発生しました: {error}
                   </td>
                 </tr>
@@ -484,6 +537,11 @@ export default function PlotListTable({
                                 未収 {(plot.uncollectedAmount ?? 0).toLocaleString()}円
                               </span>
                             )}
+                            {plot.billingSummary?.unpaidYearCount > 0 && (
+                              <span className="text-beni font-medium">
+                                未納{plot.billingSummary.unpaidYearCount}年
+                              </span>
+                            )}
                           </div>
                         </div>
                       </td>
@@ -521,6 +579,9 @@ export default function PlotListTable({
                           </StatusBadge>
                         )}
                       </td>
+                      <td className="px-4 py-3 text-sm hidden md:table-cell">
+                        <BillingSummaryBadges summary={plot.billingSummary} />
+                      </td>
                       <td className="px-4 py-3 whitespace-nowrap text-sm text-right hidden sm:table-cell">
                         <span className={cn(
                           'font-medium tabular-nums',
@@ -534,7 +595,7 @@ export default function PlotListTable({
                 })
               ) : (
                 <tr>
-                  <td colSpan={11} className="px-4 md:px-6 py-6">
+                  <td colSpan={12} className="px-4 md:px-6 py-6">
                     <EmptyState
                       container="plain"
                       icon={

--- a/src/lib/api/plots.ts
+++ b/src/lib/api/plots.ts
@@ -19,6 +19,7 @@ import {
   RestoreContractRequest,
   RestoreContractResponse,
   GraveClassificationsResponse,
+  BillingRecordStatus,
 } from '@komine/types';
 import { apiGet, apiPost, apiPut, apiDelete, shouldUseMockData } from './client';
 import { ApiResponse } from './types';
@@ -104,6 +105,12 @@ const mockPlots: PlotListItem[] = [
     nextBillingDate: '2025-04-01',
     managementFee: '5000',
     uncollectedAmount: 0,
+    billingSummary: {
+      hasBilling: true,
+      latestYear: 2024,
+      latestYearStatus: BillingRecordStatus.Paid,
+      unpaidYearCount: 0,
+    },
     createdAt: '2020-04-01T00:00:00Z',
     updatedAt: '2024-01-15T10:30:00Z',
   },
@@ -137,6 +144,12 @@ const mockPlots: PlotListItem[] = [
     nextBillingDate: '2025-08-15',
     managementFee: '3000',
     uncollectedAmount: 0,
+    billingSummary: {
+      hasBilling: true,
+      latestYear: 2024,
+      latestYearStatus: BillingRecordStatus.Overdue,
+      unpaidYearCount: 2,
+    },
     createdAt: '2022-08-15T00:00:00Z',
     updatedAt: '2024-02-20T14:45:00Z',
   },


### PR DESCRIPTION
## 概要

旧画面01（区画一覧）の年度別請求 status（`受付済 / 09年 / 10年 …`）を、新システムの一覧では **1 列に集約**して表示する（B10、サマリ列方式）。本 PR は frontend 側の表示を担当。

## 変更

- 区画一覧テーブルに「**請求状況**」列を追加（`md` 以上で表示）
- `BillingSummaryBadges` コンポーネントを追加
  - 最新年度の status バッジ（例: `2024年 完納`）
  - 未納年数バッジ（例: `未納2年`、`overdue` variant）
  - Billing が無い場合は `—`
- `BILLING_STATUS_LABELS` / `BILLING_STATUS_VARIANTS`（`BillingRecordStatus` → ラベル / StatusBadge variant）
- モバイル（375px / iPhone SE）対応: 列自体は `md` 以上、`sm:hidden` の補足行に「未納N年」を併記
- `mockPlots` に `billingSummary` を追加（完納例 / 延滞・未納2年例）
- `BillingSummaryBadges` の jest 4 ケース追加

## 表示イメージ（md 以上）

```
区画番号 | … | 入金状況 | 請求状況            | 未集金額
A-001    | … | 入金済   | 2024年 完納
B-015    | … | 未入金   | 2024年 延滞 / 未納2年
```

## 依存

- types#24（`PlotBillingSummary` 型）merged 済み
- backend#148（getPlots の `billingSummary`）— レスポンスは `response.data.data` を pass-through するため backend merge 後に実データが反映される

Refs B10 (`query_result/UI_GAP_HANDOFF.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)