### PR TITLE
fix(plot-form): 基本情報タブに備考入力欄を追加 (#145)

### DIFF
--- a/src/__tests__/components/plot-form/basic-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/basic-info-tab.test.tsx
@@ -192,4 +192,44 @@ describe('BasicInfoTab', () => {
     // 区画 (areaName) は watch() から表示する独自実装
     expect(screen.getByText('第1期')).toBeInTheDocument();
   });
+
+  it('物理区画備考・契約備考・契約者備考の3つの備考入力欄を表示する（#145）', () => {
+    render(
+      <TabHost>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    expect(screen.getByText('契約備考')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('物理区画に関するメモ')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('契約に関するメモ')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('契約者に関するメモ')).toBeInTheDocument();
+  });
+
+  it('契約備考に入力できる（#145）', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    const notesInput = screen.getByPlaceholderText('契約に関するメモ');
+    await user.type(notesInput, '2026年度分は分割払い');
+    expect(notesInput).toHaveValue('2026年度分は分割払い');
+  });
+
+  it('viewMode=trueの場合、契約備考の値が表示用ボックスに表示される（#145）', () => {
+    render(
+      <TabHost defaultValues={{
+        saleContract: { notes: '解約予定あり' } as never,
+      }}>
+        {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} viewMode={true} />}
+      </TabHost>
+    );
+
+    // viewMode では入力欄ではなく値が表示される
+    expect(screen.queryByPlaceholderText('契約に関するメモ')).not.toBeInTheDocument();
+    expect(screen.getByText('解約予定あり')).toBeInTheDocument();
+  });
 });

--- a/src/components/plot-form/BasicInfoTab.tsx
+++ b/src/components/plot-form/BasicInfoTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { PlotTabBaseProps } from './types';
-import { ViewModeField, ViewModeSelect } from './ViewModeField';
+import { ViewModeField, ViewModeSelect, ViewModeTextarea } from './ViewModeField';
 import { SelectItem } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { useMemo } from 'react';
@@ -113,6 +113,15 @@ export function BasicInfoTab({
             register={register('physicalPlot.areaSqm')}
             error={errors.physicalPlot?.areaSqm?.message}
             placeholder="3.6"
+          />
+        </div>
+        <div className="mt-4">
+          <ViewModeTextarea
+            label="備考"
+            viewMode={viewMode}
+            value={watch('physicalPlot.notes') || ''}
+            register={register('physicalPlot.notes')}
+            placeholder="物理区画に関するメモ"
           />
         </div>
       </div>
@@ -241,6 +250,16 @@ export function BasicInfoTab({
             error={errors.saleContract?.agentName?.message}
             placeholder="販売代理店名"
           />
+
+          <div className="col-span-3">
+            <ViewModeTextarea
+              label="契約備考"
+              viewMode={viewMode}
+              value={watch('saleContract.notes') || ''}
+              register={register('saleContract.notes')}
+              placeholder="契約に関するメモ"
+            />
+          </div>
         </div>
       </div>
 
@@ -359,6 +378,15 @@ export function BasicInfoTab({
             placeholder="example@example.com"
           />
 
+          <div className="col-span-3">
+            <ViewModeTextarea
+              label="備考"
+              viewMode={viewMode}
+              value={watch('customer.notes') || ''}
+              register={register('customer.notes')}
+              placeholder="契約者に関するメモ"
+            />
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## 概要

台帳（区画編集）の「基本情報①」タブに**備考の入力欄が無く**、詳細画面では表示されるのに編集できなかった不具合を修正。Closes #145

## 変更内容

`BasicInfoTab.tsx` に既存の `ViewModeTextarea` を使って3つの備考欄を追加：

| セクション | ラベル | フィールド |
|---|---|---|
| 物理区画情報 | 備考 | `physicalPlot.notes` |
| 販売契約情報 | 契約備考 | `saleContract.notes`（API: `contractNotes`） |
| 契約者情報 | 備考 | `customer.notes` |

- データ配線（create / update リクエスト変換・detail パース）は `plot-form.ts` に**既に存在**していたため、本PRはUI入力欄の追加のみ。保存→詳細・一覧反映はそのまま動作する。
- `viewMode`（閲覧）では入力欄ではなく値表示ボックスに切り替わる（他フィールドと同挙動）。

## テスト

`basic-info-tab.test.tsx` にユニットテストを3件追加（全13件パス）：
- 3つの備考入力欄が表示される
- 契約備考に入力できる
- viewMode で値が表示される

```
Tests: 13 passed, 13 total
```

ESLint / tsc クリーン。

## 備考

- E2E（備考入力→保存→表示）は frontend に E2E 基盤が未整備のため別issue（#140 E2E未カバー）のスコープとし、本PRではコンポーネントテストでカバー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)