### PR TITLE
fix(plot-availability): useEffect の exhaustive-deps 警告5件を解消 (#144)

### DIFF
--- a/src/components/plot-availability-management.tsx
+++ b/src/components/plot-availability-management.tsx
@@ -54,41 +54,53 @@ export default function PlotAvailabilityManagement() {
   const sectionsHook = usePlotInventorySections();
   const areasHook = usePlotInventoryAreas();
 
+  // useCallback 済みで安定した setter 群を取り出す。フックの戻り値オブジェクト自体は
+  // 毎レンダー新しい参照になるため、effect の依存にはこの安定 setter を使う。
+  const { setPeriod: setSectionsPeriod, setStatus: setSectionsStatus, setSearch: setSectionsSearch } =
+    sectionsHook;
+  const { setPeriod: setAreasPeriod, setSearch: setAreasSearch } = areasHook;
+
   // 期の変更をセクション・面積フックに反映
   useEffect(() => {
     if (selectedPeriod === 'all') {
-      sectionsHook.setPeriod(undefined);
-      areasHook.setPeriod(undefined);
+      setSectionsPeriod(undefined);
+      setAreasPeriod(undefined);
     } else {
-      sectionsHook.setPeriod(selectedPeriod);
-      areasHook.setPeriod(selectedPeriod);
+      setSectionsPeriod(selectedPeriod);
+      setAreasPeriod(selectedPeriod);
     }
-  }, [selectedPeriod]);
+  }, [selectedPeriod, setSectionsPeriod, setAreasPeriod]);
 
   // 表示モード変更時のステータスフィルタ
   useEffect(() => {
     if (viewMode === 'available') {
-      sectionsHook.setStatus('available');
+      setSectionsStatus('available');
     } else if (viewMode === 'soldout') {
-      sectionsHook.setStatus('sold_out');
+      setSectionsStatus('sold_out');
     } else {
-      sectionsHook.setStatus(undefined);
+      setSectionsStatus(undefined);
     }
-  }, [viewMode]);
+  }, [viewMode, setSectionsStatus]);
 
   // 検索クエリの反映
   useEffect(() => {
-    sectionsHook.setSearch(searchQuery);
-    areasHook.setSearch(searchQuery);
-  }, [searchQuery]);
+    setSectionsSearch(searchQuery);
+    setAreasSearch(searchQuery);
+  }, [searchQuery, setSectionsSearch, setAreasSearch]);
 
   // ソートの反映
+  // setSort は params.sortBy/sortOrder の変化で再生成されるため依存に含めない。
+  // 常に明示的な引数で呼ぶので stale closure にはならず、sortKey/sortOrder の変化時のみ
+  // 実行すれば十分（含めると同一ソートで余分な再フェッチが発生する）。
   useEffect(() => {
     sectionsHook.setSort(sortKey, sortOrder);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortKey, sortOrder]);
 
+  // 面積別ソートの反映（setSort を依存に含めない理由は上記と同じ）
   useEffect(() => {
     areasHook.setSort(areaSortKey, sortOrder);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [areaSortKey, sortOrder]);
 
   // 全体サマリー（デフォルト値付き）


### PR DESCRIPTION
## 概要

`plot-availability-management.tsx` の `react-hooks/exhaustive-deps` 警告**5件**（L66/77/83/88/92）を解消。Closes #144

## 原因と対応

フックの戻り値オブジェクト（`sectionsHook` / `areasHook`）は毎レンダーで新しい参照になるため、そのままオブジェクトを依存に入れると無限再フェッチになる。一方、各 setter は `useCallback` 済み。setter の安定性に応じて2通りで対応した：

| effect | 参照 setter | 安定性 | 対応 |
|---|---|---|---|
| 期の反映 | `setPeriod` | ✅ 安定（`[setParams]`、`setParams` は `[]`） | 分割代入して依存に追加 |
| ステータス | `setStatus` | ✅ 安定 | 同上 |
| 検索 | `setSearch` | ✅ 安定 | 同上 |
| ソート | `setSort` | ❌ `params.sortBy/sortOrder` で再生成 | `eslint-disable` + 理由明記 |
| 面積ソート | `setSort` | ❌ 同上 | 同上 |

- **安定 setter（setPeriod/setStatus/setSearch）**: 分割代入してローカル変数化し、effect の依存配列に追加。useCallback 済みなので**挙動は不変**（余分な再実行なし）。stale closure リスクを排除。
- **setSort**: `params.sortBy/sortOrder` 依存で識別子が変わる。依存に含めると `fetchSections`（`params` 依存）が同一ソート操作で**余分に再フェッチ**してしまう。effect は常に明示引数で `setSort` を呼ぶため stale closure にはならず、`sortKey/sortOrder` の変化時のみ実行すれば十分。よって意図的に除外し `eslint-disable-next-line` + 理由コメントを付与（issue が許容する選択肢）。

## 確認

- `npx eslint src/components/plot-availability-management.tsx` → **0 warnings**（修正前 5件）
- `tsc --noEmit` クリーン

## 備考

- 区画在庫画面の E2E は frontend に E2E 基盤が未整備のため #140（E2E未カバー、区画在庫を明記）のスコープに委譲。本PRは挙動不変のため既存ユニットテスト（影響なし）でカバー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)