### PR TITLE
feat(masters): 墓石の方位/位置を詳細画面で名称解決 (komine-crm-backend#147)

### DIFF
--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -454,7 +454,15 @@ function ContactsTab({ plot }: { plot: PlotDetailResponse }) {
   );
 }
 
-function BurialInfoTab({ plot }: { plot: PlotDetailResponse }) {
+function BurialInfoTab({
+  plot,
+  directions,
+  positions,
+}: {
+  plot: PlotDetailResponse;
+  directions: MasterItem[];
+  positions: MasterItem[];
+}) {
   return (
     <div className="space-y-4">
       {/* 埋葬者情報 */}
@@ -510,8 +518,8 @@ function BurialInfoTab({ plot }: { plot: PlotDetailResponse }) {
           <InfoField label="墓石種類" value={plot.gravestoneInfo?.gravestoneType} />
           <InfoField label="周辺面積" value={plot.gravestoneInfo?.surroundingArea} />
           <InfoField label="墓石代" value={formatPrice(plot.gravestoneInfo?.gravestoneCost)} />
-          <InfoField label="方位" value={plot.gravestoneInfo?.directionId?.toString()} />
-          <InfoField label="位置" value={plot.gravestoneInfo?.positionId?.toString()} />
+          <InfoField label="方位" value={resolveMasterName(directions, plot.gravestoneInfo?.directionId?.toString())} />
+          <InfoField label="位置" value={resolveMasterName(positions, plot.gravestoneInfo?.positionId?.toString())} />
           <InfoField label="墓誌" value={plot.gravestoneInfo?.gravestoneInscription} />
           <InfoField label="建立期限" value={formatDate(plot.gravestoneInfo?.establishmentDeadline)} />
           <InfoField label="建立日" value={formatDate(plot.gravestoneInfo?.establishmentDate)} />
@@ -624,7 +632,8 @@ function ConstructionInfoTab({
 export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRestore }: PlotDetailViewProps) {
   const { user } = useAuth();
   const { plot, isLoading, error, refresh } = usePlotDetail(plotId);
-  const { calcTypes, taxTypes, billingTypes, paymentMethods, contractors } = useMasters();
+  const { calcTypes, taxTypes, billingTypes, paymentMethods, contractors, directions, positions } =
+    useMasters();
   const feeMasters: FeeMasters = { calcTypes, taxTypes, billingTypes, paymentMethods };
 
   if (isLoading) {
@@ -897,7 +906,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
         </TabsContent>
 
         <TabsContent value="burial" className="mt-4 md:mt-6">
-          <BurialInfoTab plot={plot} />
+          <BurialInfoTab plot={plot} directions={directions} positions={positions} />
         </TabsContent>
 
         <TabsContent value="construction" className="mt-4 md:mt-6">

--- a/src/hooks/useMasters.ts
+++ b/src/hooks/useMasters.ts
@@ -152,6 +152,8 @@ export function useMasters(options?: { skipCache?: boolean }) {
   const sectionNames = state.data?.sectionName || [];
   const relationships = state.data?.relationship || [];
   const contractors = state.data?.contractor || [];
+  const directions = state.data?.direction || [];
+  const positions = state.data?.position || [];
 
   return {
     // 状態
@@ -171,6 +173,8 @@ export function useMasters(options?: { skipCache?: boolean }) {
     sectionNames,
     relationships,
     contractors,
+    directions,
+    positions,
 
     // アクション
     refresh,

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -65,6 +65,8 @@ export {
   getSectionNames,
   getRelationships,
   getContractors,
+  getDirections,
+  getPositions,
   createMasterItem,
   updateMasterItem,
   deleteMasterItem,

--- a/src/lib/api/masters.ts
+++ b/src/lib/api/masters.ts
@@ -38,6 +38,8 @@ export interface AllMastersData {
   sectionName: SectionNameMasterItem[];
   relationship: MasterItem[];
   contractor: MasterItem[];
+  direction: MasterItem[];
+  position: MasterItem[];
 }
 
 // モックデータ
@@ -111,6 +113,23 @@ const mockMasterData: AllMastersData = {
     { id: 3, code: 'placeholder-3', name: '提携業者A', description: null, sortOrder: 3, isActive: true },
     { id: 4, code: 'placeholder-4', name: '提携業者B', description: null, sortOrder: 4, isActive: true },
     { id: 5, code: 'placeholder-99', name: 'その他', description: null, sortOrder: 99, isActive: true },
+  ],
+  // 方角: 旧 sykbnn KBNNO=2024。code は GravestoneInfo.directionId(int) の文字列。backend と一致。
+  direction: [
+    { id: 1, code: '1', name: '東', description: null, sortOrder: 1, isActive: true },
+    { id: 2, code: '2', name: '西', description: null, sortOrder: 2, isActive: true },
+    { id: 3, code: '3', name: '南', description: null, sortOrder: 3, isActive: true },
+    { id: 4, code: '4', name: '北', description: null, sortOrder: 4, isActive: true },
+    { id: 5, code: '5', name: '北東', description: null, sortOrder: 5, isActive: true },
+    { id: 6, code: '6', name: '南東', description: null, sortOrder: 6, isActive: true },
+    { id: 7, code: '7', name: '北西', description: null, sortOrder: 7, isActive: true },
+    { id: 8, code: '8', name: '南西', description: null, sortOrder: 8, isActive: true },
+  ],
+  // 位置: 旧 sykbnn KBNNO=2025。code は GravestoneInfo.positionId(int) の文字列。backend と一致。
+  position: [
+    { id: 1, code: '1', name: '角', description: null, sortOrder: 1, isActive: true },
+    { id: 2, code: '2', name: '端', description: null, sortOrder: 2, isActive: true },
+    { id: 3, code: '3', name: '中', description: null, sortOrder: 3, isActive: true },
   ],
 };
 
@@ -230,6 +249,26 @@ export async function getContractors(): Promise<ApiResponse<MasterItem[]>> {
   return apiGet<MasterItem[]>('/masters/contractor');
 }
 
+/**
+ * 方角マスタ取得
+ */
+export async function getDirections(): Promise<ApiResponse<MasterItem[]>> {
+  if (shouldUseMockData()) {
+    return { success: true, data: mockMasterData.direction };
+  }
+  return apiGet<MasterItem[]>('/masters/direction');
+}
+
+/**
+ * 位置マスタ取得
+ */
+export async function getPositions(): Promise<ApiResponse<MasterItem[]>> {
+  if (shouldUseMockData()) {
+    return { success: true, data: mockMasterData.position };
+  }
+  return apiGet<MasterItem[]>('/masters/position');
+}
+
 // CRUD用の型定義
 export type MasterType =
   | 'cemetery-type'
@@ -241,7 +280,9 @@ export type MasterType =
   | 'construction-type'
   | 'section-name'
   | 'relationship'
-  | 'contractor';
+  | 'contractor'
+  | 'direction'
+  | 'position';
 
 export interface CreateMasterRequest {
   code?: string;


### PR DESCRIPTION
## 概要
区画詳細の墓石情報で方位・位置が生のID（未解決値）で表示されていた問題に対応。backend の direction/position マスタを使って名称（東/角 等）に解決する。

## 変更
- `masters` API: `AllMastersData`/mock/getter に `direction`/`position` を追加（`code` はレガシー int の文字列、`MasterType` union も拡張）
- `useMasters` に `directions`/`positions` アクセサ追加
- `plot-detail-view`: `BurialInfoTab` に渡し `resolveMasterName`（`code === String(id)`）で方位・位置を名称表示
- tsc/lint/test OK（**337 件 pass**）

## ⚠️ スコープ外
墓石フォームの select 化は見送り。create/update 経路が `GravestoneInfo` を永続化しない既存ギャップ（`plots.ts` で `gravestoneInfo: null` をハードコード）があり、保存されないダミー入力になるため。方角/位置は `code` がレガシー int 固定のため管理画面(`masters-management`)にも意図的に追加していない（int-code 解決契約の保護）。

## 依存
komine-types#27 / komine-crm-backend#153 とセット。zaitsu82/komine-crm-backend#147 の表示側対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)