### PR TITLE
feat(plots): 台帳一覧の列幅ドラッグ調整・全文表示 (#146)

### DIFF
--- a/src/components/plot-registry.tsx
+++ b/src/components/plot-registry.tsx
@@ -7,7 +7,7 @@
  * @komine/types の PlotListItem を直接使用し、Customer型への変換なし。
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type CSSProperties } from 'react';
 import { PlotListItem, PaymentStatus, PhysicalPlotStatus } from '@komine/types';
 import {
   getPlots,
@@ -19,6 +19,15 @@ import type { GraveClassificationsResponse } from '@komine/types';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { cn, truncateAddressToCity } from '@/lib/utils';
+import {
+  COLUMN_DEFAULT_WIDTHS,
+  clampColumnWidth,
+  loadColumnWidths,
+  saveColumnWidths,
+  isColumnExpanded,
+  type ColumnWidths,
+  type ResizableColumnKey,
+} from '@/lib/plots-column-widths';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { StatusBadge, type StatusBadgeProps } from '@/components/ui/status-badge';
@@ -50,6 +59,37 @@ function saveSearchHistory(history: string[]) {
   } catch {
     // ignore quota/disabled errors
   }
+}
+
+// ===== 列リサイズ用ハンドル（issue #146） =====
+
+interface ColumnResizerProps {
+  columnKey: ResizableColumnKey;
+  onResizeStart: (key: ResizableColumnKey, startX: number, startWidth: number) => void;
+}
+
+/**
+ * ヘッダー右端のドラッグハンドル。十分な幅（8px）を確保し、
+ * クリックがソート操作に伝播しないよう stopPropagation する。
+ */
+function ColumnResizer({ columnKey, onResizeStart }: ColumnResizerProps) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="列幅を調整"
+      data-testid={`col-resizer-${columnKey}`}
+      className="absolute top-0 right-0 z-20 h-full w-2 cursor-col-resize touch-none select-none hover:bg-white/40"
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const th = e.currentTarget.parentElement;
+        const startWidth = th ? th.getBoundingClientRect().width : COLUMN_DEFAULT_WIDTHS[columnKey] ?? 90;
+        onResizeStart(columnKey, e.clientX, startWidth);
+      }}
+    />
+  );
 }
 
 // ===== 型定義 =====
@@ -181,6 +221,54 @@ export default function PlotRegistry({
   useEffect(() => {
     setSearchHistory(loadSearchHistory());
   }, []);
+
+  // 列幅（issue #146）— localStorage に永続化。SSR ハイドレーション差異を避けるため
+  // 初期値は空でマウント後に読み込む。
+  const [columnWidths, setColumnWidths] = useState<ColumnWidths>({});
+  useEffect(() => {
+    setColumnWidths(loadColumnWidths());
+  }, []);
+
+  // ヘッダー境界のドラッグで列幅を変更し、ドラッグ終了時に保存する
+  const handleColumnResizeStart = useCallback(
+    (key: ResizableColumnKey, startX: number, startWidth: number) => {
+      const handleMove = (e: PointerEvent) => {
+        const next = clampColumnWidth(startWidth + (e.clientX - startX));
+        setColumnWidths((prev) => ({ ...prev, [key]: next }));
+      };
+      const handleUp = () => {
+        window.removeEventListener('pointermove', handleMove);
+        window.removeEventListener('pointerup', handleUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        setColumnWidths((prev) => {
+          saveColumnWidths(prev);
+          return prev;
+        });
+      };
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      window.addEventListener('pointermove', handleMove);
+      window.addEventListener('pointerup', handleUp);
+    },
+    []
+  );
+
+  const handleResetColumnWidths = useCallback(() => {
+    setColumnWidths({});
+    saveColumnWidths({});
+  }, []);
+
+  const hasCustomColumnWidths = Object.keys(columnWidths).length > 0;
+
+  // <col> へ適用する幅。未設定列は Tailwind の既定幅クラスにフォールバック。
+  const colStyle = (key: ResizableColumnKey): CSSProperties | undefined => {
+    const width = columnWidths[key];
+    return typeof width === 'number' ? { width } : undefined;
+  };
+  // 展開（全文表示）中の列向けセルクラス。狭い列は truncate を維持。
+  const cellWrapClass = (key: ResizableColumnKey, base: string) =>
+    cn(base, isColumnExpanded(columnWidths, key) ? 'whitespace-normal break-words align-top' : 'truncate');
 
   // 区画区分 distinct 値（マスタ化されるまでの暫定 select 候補）
   useEffect(() => {
@@ -603,7 +691,24 @@ export default function PlotRegistry({
             </button>
           )}
 
-          <label className="hidden md:inline-flex items-center gap-1.5 text-xs sm:text-sm text-hai cursor-pointer select-none ml-auto">
+          {hasCustomColumnWidths && (
+            <button
+              type="button"
+              onClick={handleResetColumnWidths}
+              className="hidden md:inline-flex items-center gap-1 px-2 h-9 rounded-elegant text-xs text-hai hover:bg-kinari transition-colors ml-auto"
+              title="列幅を初期状態に戻す"
+            >
+              <X className="w-3.5 h-3.5" />
+              列幅をリセット
+            </button>
+          )}
+
+          <label
+            className={cn(
+              'hidden md:inline-flex items-center gap-1.5 text-xs sm:text-sm text-hai cursor-pointer select-none',
+              !hasCustomColumnWidths && 'ml-auto'
+            )}
+          >
             <input
               type="checkbox"
               checked={showBuriedPersons}
@@ -759,15 +864,17 @@ export default function PlotRegistry({
               {/* 状態 / 区画No / エリア / 契約者 / 住所 / 電話 / 取扱 / 許可番号 / 備考(flex) / [埋葬者] / 契約日 / 入金 / 管理料 / 次請求 */}
               <colgroup>
                 <col className="w-[40px]" />
-                <col className="w-[68px]" />
-                <col className="w-[52px]" />
-                <col className="w-[110px]" />
-                <col className="hidden md:table-column w-[90px]" />
-                <col className="hidden lg:table-column w-[100px]" />
-                <col className="hidden lg:table-column w-[72px]" />
-                <col className="hidden lg:table-column w-[96px]" />
-                <col className="hidden md:table-column" />
-                {showBuriedPersons && <col className="hidden lg:table-column w-[90px]" />}
+                <col className="w-[68px]" style={colStyle('plotNumber')} />
+                <col className="w-[52px]" style={colStyle('areaName')} />
+                <col className="w-[110px]" style={colStyle('customerName')} />
+                <col className="hidden md:table-column w-[90px]" style={colStyle('address')} />
+                <col className="hidden lg:table-column w-[100px]" style={colStyle('phone')} />
+                <col className="hidden lg:table-column w-[72px]" style={colStyle('agent')} />
+                <col className="hidden lg:table-column w-[96px]" style={colStyle('permitNumber')} />
+                <col className="hidden md:table-column" style={colStyle('notes')} />
+                {showBuriedPersons && (
+                  <col className="hidden lg:table-column w-[90px]" style={colStyle('buriedPersons')} />
+                )}
                 <col className="hidden sm:table-column w-[60px]" />
                 <col className="w-[60px]" />
                 <col className="hidden sm:table-column w-[72px]" />
@@ -790,7 +897,7 @@ export default function PlotRegistry({
                   </th>
                   <th
                     className={cn(
-                      "px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200",
+                      "relative px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200",
                       "hover:bg-matsu-light",
                       sortKey === 'plotNumber' && "bg-matsu-dark"
                     )}
@@ -800,10 +907,11 @@ export default function PlotRegistry({
                       <span>区画No</span>
                       <SortIndicator columnKey="plotNumber" />
                     </div>
+                    <ColumnResizer columnKey="plotNumber" onResizeStart={handleColumnResizeStart} />
                   </th>
                   <th
                     className={cn(
-                      "px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200",
+                      "relative px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200",
                       "hover:bg-matsu-light",
                       sortKey === 'areaName' && "bg-matsu-dark"
                     )}
@@ -813,10 +921,11 @@ export default function PlotRegistry({
                       <span>エリア</span>
                       <SortIndicator columnKey="areaName" />
                     </div>
+                    <ColumnResizer columnKey="areaName" onResizeStart={handleColumnResizeStart} />
                   </th>
                   <th
                     className={cn(
-                      "px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200",
+                      "relative px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200",
                       "hover:bg-matsu-light",
                       sortKey === 'customerName' && "bg-matsu-dark"
                     )}
@@ -826,13 +935,15 @@ export default function PlotRegistry({
                       <span>契約者</span>
                       <SortIndicator columnKey="customerName" />
                     </div>
+                    <ColumnResizer columnKey="customerName" onResizeStart={handleColumnResizeStart} />
                   </th>
-                  <th className="px-2 py-2 text-left text-xs font-bold text-white hidden md:table-cell">
+                  <th className="relative px-2 py-2 text-left text-xs font-bold text-white hidden md:table-cell">
                     <span>住所</span>
+                    <ColumnResizer columnKey="address" onResizeStart={handleColumnResizeStart} />
                   </th>
                   <th
                     className={cn(
-                      "px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200 hidden lg:table-cell",
+                      "relative px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200 hidden lg:table-cell",
                       "hover:bg-matsu-light",
                       sortKey === 'phoneNumber' && "bg-matsu-dark"
                     )}
@@ -842,19 +953,24 @@ export default function PlotRegistry({
                       <span>電話</span>
                       <SortIndicator columnKey="phoneNumber" />
                     </div>
+                    <ColumnResizer columnKey="phone" onResizeStart={handleColumnResizeStart} />
                   </th>
-                  <th className="px-2 py-2 text-left text-xs font-bold text-white hidden lg:table-cell">
+                  <th className="relative px-2 py-2 text-left text-xs font-bold text-white hidden lg:table-cell">
                     <span>取扱</span>
+                    <ColumnResizer columnKey="agent" onResizeStart={handleColumnResizeStart} />
                   </th>
-                  <th className="px-2 py-2 text-left text-xs font-bold text-white hidden lg:table-cell">
+                  <th className="relative px-2 py-2 text-left text-xs font-bold text-white hidden lg:table-cell">
                     <span>許可番号</span>
+                    <ColumnResizer columnKey="permitNumber" onResizeStart={handleColumnResizeStart} />
                   </th>
-                  <th className="px-2 py-2 text-left text-xs font-bold text-white hidden md:table-cell">
+                  <th className="relative px-2 py-2 text-left text-xs font-bold text-white hidden md:table-cell">
                     <span>備考</span>
+                    <ColumnResizer columnKey="notes" onResizeStart={handleColumnResizeStart} />
                   </th>
                   {showBuriedPersons && (
-                    <th className="px-2 py-2 text-left text-xs font-bold text-white hidden lg:table-cell">
+                    <th className="relative px-2 py-2 text-left text-xs font-bold text-white hidden lg:table-cell">
                       <span>埋葬者</span>
+                      <ColumnResizer columnKey="buriedPersons" onResizeStart={handleColumnResizeStart} />
                     </th>
                   )}
                   <th
@@ -957,44 +1073,46 @@ export default function PlotRegistry({
                         <td className="px-2 py-2 text-center">
                           {getStatusBadge(plot)}
                         </td>
-                        <td className="px-2 py-2 font-mono text-matsu font-medium text-xs truncate" title={plot.plotNumber}>
+                        <td className={cellWrapClass('plotNumber', 'px-2 py-2 font-mono text-matsu font-medium text-xs')} title={plot.plotNumber}>
                           {plot.plotNumber}
                         </td>
-                        <td className="px-2 py-2 text-xs text-hai truncate" title={plot.areaName || undefined}>
+                        <td className={cellWrapClass('areaName', 'px-2 py-2 text-xs text-hai')} title={plot.areaName || undefined}>
                           {plot.areaName || '-'}
                         </td>
-                        <td className="px-2 py-2">
-                          <div className="truncate">
-                            <div className="font-medium text-sumi text-sm truncate" title={plot.customerName || undefined}>
+                        <td className="px-2 py-2 align-top">
+                          <div className={isColumnExpanded(columnWidths, 'customerName') ? '' : 'truncate'}>
+                            <div className={cellWrapClass('customerName', 'font-medium text-sumi text-sm')} title={plot.customerName || undefined}>
                               {plot.customerName || '-'}
                             </div>
-                            <div className="text-xs text-hai truncate" title={plot.customerNameKana || undefined}>
+                            <div className={cellWrapClass('customerName', 'text-xs text-hai')} title={plot.customerNameKana || undefined}>
                               {plot.customerNameKana || ''}
                             </div>
                           </div>
                         </td>
-                        <td className="px-2 py-2 text-xs text-hai truncate hidden md:table-cell" title={plot.customerAddress || undefined}>
-                          {truncateAddressToCity(plot.customerAddress)}
+                        <td className={cellWrapClass('address', 'px-2 py-2 text-xs text-hai hidden md:table-cell')} title={plot.customerAddress || undefined}>
+                          {isColumnExpanded(columnWidths, 'address')
+                            ? (plot.customerAddress || '-')
+                            : truncateAddressToCity(plot.customerAddress)}
                         </td>
-                        <td className="px-2 py-2 text-xs text-hai truncate hidden lg:table-cell" title={plot.customerPhoneNumber || undefined}>
+                        <td className={cellWrapClass('phone', 'px-2 py-2 text-xs text-hai hidden lg:table-cell')} title={plot.customerPhoneNumber || undefined}>
                           {plot.customerPhoneNumber || '-'}
                         </td>
-                        <td className="px-2 py-2 text-xs text-hai truncate hidden lg:table-cell" title={plot.agentName || undefined}>
+                        <td className={cellWrapClass('agent', 'px-2 py-2 text-xs text-hai hidden lg:table-cell')} title={plot.agentName || undefined}>
                           {plot.agentName || '-'}
                         </td>
-                        <td className="px-2 py-2 text-xs text-hai tabular-nums truncate hidden lg:table-cell" title={plot.permitNumber || undefined}>
+                        <td className={cellWrapClass('permitNumber', 'px-2 py-2 text-xs text-hai tabular-nums hidden lg:table-cell')} title={plot.permitNumber || undefined}>
                           {plot.permitNumber || '-'}
                         </td>
-                        <td className="px-2 py-2 text-xs text-hai hidden md:table-cell">
+                        <td className="px-2 py-2 text-xs text-hai hidden md:table-cell align-top">
                           <div
-                            className="line-clamp-2 break-all"
+                            className={isColumnExpanded(columnWidths, 'notes') ? 'whitespace-normal break-words' : 'line-clamp-2 break-all'}
                             title={[plot.contractNotes, plot.customerNotes].filter(Boolean).join(' / ')}
                           >
                             {[plot.contractNotes, plot.customerNotes].filter(Boolean).join(' / ') || '-'}
                           </div>
                         </td>
                         {showBuriedPersons && (
-                          <td className="px-2 py-2 text-xs text-hai truncate hidden lg:table-cell" title={plot.buriedPersonNames?.join(', ') || undefined}>
+                          <td className={cellWrapClass('buriedPersons', 'px-2 py-2 text-xs text-hai hidden lg:table-cell')} title={plot.buriedPersonNames?.join(', ') || undefined}>
                             {plot.buriedPersonNames && plot.buriedPersonNames.length > 0 ? plot.buriedPersonNames.join(', ') : '-'}
                           </td>
                         )}

--- a/src/lib/__tests__/plots-column-widths.test.ts
+++ b/src/lib/__tests__/plots-column-widths.test.ts
@@ -1,0 +1,63 @@
+import {
+  COLUMN_WIDTHS_KEY,
+  COLUMN_MIN_WIDTH,
+  COLUMN_MAX_WIDTH,
+  clampColumnWidth,
+  loadColumnWidths,
+  saveColumnWidths,
+  isColumnExpanded,
+} from '../plots-column-widths';
+
+describe('plots-column-widths', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe('clampColumnWidth', () => {
+    it('下限・上限でクランプし整数に丸める', () => {
+      expect(clampColumnWidth(10)).toBe(COLUMN_MIN_WIDTH);
+      expect(clampColumnWidth(9999)).toBe(COLUMN_MAX_WIDTH);
+      expect(clampColumnWidth(120.7)).toBe(121);
+    });
+  });
+
+  describe('load/save', () => {
+    it('保存した値を読み戻せる（往復）', () => {
+      saveColumnWidths({ address: 240, customerName: 180 });
+      expect(loadColumnWidths()).toEqual({ address: 240, customerName: 180 });
+    });
+
+    it('未保存時は空オブジェクト', () => {
+      expect(loadColumnWidths()).toEqual({});
+    });
+
+    it('不正な JSON は無視して空を返す', () => {
+      window.localStorage.setItem(COLUMN_WIDTHS_KEY, '{not json');
+      expect(loadColumnWidths()).toEqual({});
+    });
+
+    it('未知のキー・非数値は除外し、数値はクランプする', () => {
+      window.localStorage.setItem(
+        COLUMN_WIDTHS_KEY,
+        JSON.stringify({ address: 9999, phone: 'wide', bogus: 100 })
+      );
+      expect(loadColumnWidths()).toEqual({ address: COLUMN_MAX_WIDTH });
+    });
+  });
+
+  describe('isColumnExpanded', () => {
+    it('デフォルト幅より広いと展開扱い', () => {
+      expect(isColumnExpanded({ address: 240 }, 'address')).toBe(true);
+    });
+
+    it('デフォルト幅以下なら非展開（truncate 維持）', () => {
+      expect(isColumnExpanded({ address: 60 }, 'address')).toBe(false);
+      expect(isColumnExpanded({}, 'address')).toBe(false);
+    });
+
+    it('デフォルト幅 null（備考）は幅指定があれば展開', () => {
+      expect(isColumnExpanded({ notes: 200 }, 'notes')).toBe(true);
+      expect(isColumnExpanded({}, 'notes')).toBe(false);
+    });
+  });
+});

--- a/src/lib/plots-column-widths.ts
+++ b/src/lib/plots-column-widths.ts
@@ -1,0 +1,90 @@
+/**
+ * 台帳問い合わせ（/plots）一覧テーブルの列幅管理ロジック（issue #146）
+ *
+ * 列幅は localStorage に永続化し、次回アクセス時も維持する。
+ * UI から独立した純粋関数として切り出し、単体テスト可能にしている。
+ */
+
+export const COLUMN_WIDTHS_KEY = 'komine:plots:column-widths';
+export const COLUMN_MIN_WIDTH = 40;
+export const COLUMN_MAX_WIDTH = 600;
+
+/** リサイズ可能な列のキー */
+export type ResizableColumnKey =
+  | 'plotNumber'
+  | 'areaName'
+  | 'customerName'
+  | 'address'
+  | 'phone'
+  | 'agent'
+  | 'permitNumber'
+  | 'notes'
+  | 'buriedPersons';
+
+/**
+ * 各列のデフォルト幅（px）。
+ * null は「幅指定なし（残り幅を吸収して伸縮）」を意味する（備考列）。
+ */
+export const COLUMN_DEFAULT_WIDTHS: Record<ResizableColumnKey, number | null> = {
+  plotNumber: 68,
+  areaName: 52,
+  customerName: 110,
+  address: 90,
+  phone: 100,
+  agent: 72,
+  permitNumber: 96,
+  notes: null,
+  buriedPersons: 90,
+};
+
+export type ColumnWidths = Partial<Record<ResizableColumnKey, number>>;
+
+const COLUMN_KEYS = Object.keys(COLUMN_DEFAULT_WIDTHS) as ResizableColumnKey[];
+
+/** 幅を [MIN, MAX] に収める */
+export function clampColumnWidth(width: number): number {
+  return Math.min(COLUMN_MAX_WIDTH, Math.max(COLUMN_MIN_WIDTH, Math.round(width)));
+}
+
+/** localStorage から列幅設定を読み込む（不正値は無視・クランプ） */
+export function loadColumnWidths(): ColumnWidths {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(COLUMN_WIDTHS_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    const source = parsed as Record<string, unknown>;
+    const result: ColumnWidths = {};
+    for (const key of COLUMN_KEYS) {
+      const value = source[key];
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        result[key] = clampColumnWidth(value);
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+/** localStorage に列幅設定を保存する */
+export function saveColumnWidths(widths: ColumnWidths): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(widths));
+  } catch {
+    // quota 超過や localStorage 無効時は黙って無視
+  }
+}
+
+/**
+ * 列がユーザーによって「広げられている」か判定する。
+ * 広げられた列はセルを折り返して全文表示する（狭い列は truncate 維持）。
+ */
+export function isColumnExpanded(widths: ColumnWidths, key: ResizableColumnKey): boolean {
+  const width = widths[key];
+  if (typeof width !== 'number') return false;
+  const base = COLUMN_DEFAULT_WIDTHS[key];
+  return base == null ? width > 0 : width > base;
+}

--- a/tests/plot-list.spec.ts
+++ b/tests/plot-list.spec.ts
@@ -158,4 +158,48 @@ test.describe('台帳問い合わせ（区画一覧）', () => {
       expect(hasEmptyMessage || rowCount === 0).toBeTruthy();
     }
   });
+
+  // issue #146: 列幅のドラッグ調整と localStorage 保持
+  test('4-8: 列幅をドラッグで広げると幅が変わりリロード後も保持される', async ({ page }) => {
+    // 住所列はデスクトップ幅（md 以上）でのみ表示される
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    const addressHeader = page.locator('thead th', { hasText: '住所' }).first();
+    const hasAddressHeader = await addressHeader.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (!hasAddressHeader) return; // テーブル未表示環境ではスキップ
+
+    const before = await addressHeader.boundingBox();
+    const resizer = addressHeader.getByTestId('col-resizer-address');
+    await expect(resizer).toBeVisible();
+
+    // ハンドルを右へ 150px ドラッグして列を広げる
+    const box = await resizer.boundingBox();
+    if (!box || !before) return;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 150, box.y + box.height / 2, { steps: 10 });
+    await page.mouse.up();
+    await page.waitForTimeout(300);
+
+    const after = await addressHeader.boundingBox();
+    expect(after && before && after.width).toBeGreaterThan(before.width);
+
+    // localStorage に保存され、リロード後も幅が維持される
+    const stored = await page.evaluate(() => localStorage.getItem('komine:plots:column-widths'));
+    expect(stored).toBeTruthy();
+
+    await page.reload();
+    await expect(addressHeader).toBeVisible({ timeout: 10_000 });
+    const afterReload = await addressHeader.boundingBox();
+    expect(afterReload && before && afterReload.width).toBeGreaterThan(before.width);
+
+    // 「列幅をリセット」で初期状態に戻る
+    const resetButton = page.getByRole('button', { name: '列幅をリセット' });
+    if (await resetButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await resetButton.click();
+      await page.waitForTimeout(300);
+      const reset = await page.evaluate(() => localStorage.getItem('komine:plots:column-widths'));
+      expect(reset === '{}' || reset === null).toBeTruthy();
+    }
+  });
 });


### PR DESCRIPTION
## 概要

台帳問い合わせ一覧（`/plots`）で住所・備考などが固定幅 + `truncate` で途中で切れ、全文を確認できなかった問題（#146）に対応。**ユーザー自身が列幅をドラッグで調整し、広げた列は全文表示** できる UI を追加した。

## 変更内容

### `src/lib/plots-column-widths.ts`（新規・純粋関数）
- 列幅の localStorage 永続化（`komine:plots:column-widths`）
- クランプ（40〜600px）、展開判定（`isColumnExpanded`）
- 単体テスト 8 件（`src/lib/__tests__/plots-column-widths.test.ts`）

### `src/components/plot-registry.tsx`
- ヘッダー右端に **ドラッグハンドル**（`ColumnResizer`, 8px幅, `cursor-col-resize`）
- 対象列: 区画No / エリア / 契約者 / **住所** / 電話 / 取扱 / 許可番号 / **備考** / 埋葬者
- `<colgroup>` の幅を state 駆動（未設定列は既存 Tailwind 幅にフォールバック）
- **広げた列はセルを折り返して全文表示**（狭い列は `truncate` 維持。住所は展開時に市区町村省略を解除してフル住所表示）
- 「**列幅をリセット**」ボタン（カスタム幅がある時のみ表示, md+）

### E2E
- `tests/plot-list.spec.ts` にドラッグ→幅変更→リロード後保持→リセットを検証する spec を追加

## 完了条件（issue 受け入れ）

- [x] 住所列を広げると全文が読める（折り返し）
- [x] 備考列を広げると全文確認できる
- [x] 列幅変更がリロード後も維持される（localStorage）
- [x] ソート・検索・50音タブ・ページネーションが壊れない（ハンドルは `stopPropagation`）
- [x] E2E を1本追加

## スコープ外

- モバイル（375px）のカード化 → #120 で別途対応
- 列の表示/非表示切替（列ピッカー）

## 検証

- `npx tsc --noEmit` … pass
- `npm run lint` … exit 0
- `npm test` … 345 passed（新規 8 件含む）
- E2E（`4-8`）は認証付きの e2e 環境（`npm run test:e2e`）での実行が必要

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)