### PR TITLE
feat(plots): /plots モバイル一覧をカードビュー化 (#120)

### DIFF
--- a/src/components/plot-registry.tsx
+++ b/src/components/plot-registry.tsx
@@ -528,6 +528,38 @@ export default function PlotRegistry({
     </div>
   );
 
+  // 空状態（テーブル・モバイルカードで共用）
+  const emptyStateEl = (
+    <EmptyState
+      container="plain"
+      icon={
+        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z" />
+        </svg>
+      }
+      title={hasActiveFilters || searchQuery.trim() || activeTab !== '全'
+        ? '該当する区画が見つかりませんでした'
+        : '区画データがまだありません'}
+      description={hasActiveFilters || searchQuery.trim() || activeTab !== '全'
+        ? '検索語やフィルターを緩めて再検索してください。'
+        : '新規区画を登録するとここに表示されます。'}
+      action={(hasActiveFilters || searchQuery.trim() || activeTab !== '全') ? (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setSearchInput('');
+            setSearchQuery('');
+            handleClearFilters();
+            setActiveTab('全');
+          }}
+        >
+          条件をクリア
+        </Button>
+      ) : undefined}
+    />
+  );
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       <PageHeader
@@ -857,8 +889,89 @@ export default function PlotRegistry({
           </div>
         )}
 
-        {/* 区画一覧テーブル */}
-        <div className="bg-white rounded-elegant-lg border border-gin shadow-elegant overflow-hidden flex-1 min-w-0">
+        {/* 区画一覧カード（モバイル: md 未満）issue #120 */}
+        <div className="md:hidden flex-1 min-w-0 overflow-auto -mx-1 px-1">
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="rounded-elegant border border-gin bg-white p-3">
+                  <div className="flex items-center justify-between">
+                    <Skeleton className="h-5 w-24" />
+                    <Skeleton className="h-5 w-12 rounded-full" />
+                  </div>
+                  <Skeleton className="mt-2 h-4 w-32" />
+                  <Skeleton className="mt-1.5 h-3 w-40" />
+                </div>
+              ))}
+            </div>
+          ) : plots.length > 0 ? (
+            <ul className="space-y-2">
+              {plots.map((plot, index) => {
+                const absoluteIndex = startIndex + index;
+                const paymentStatus = plot.paymentStatus as PaymentStatus;
+                return (
+                  <li key={plot.id}>
+                    <button
+                      type="button"
+                      data-testid="plot-card"
+                      onClick={() => onPlotSelect(plot)}
+                      className={cn(
+                        'w-full min-h-[44px] rounded-elegant border border-gin bg-white p-3 text-left shadow-sm transition-colors',
+                        'active:bg-matsu-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-matsu',
+                        selectedPlotId === plot.id && 'border-matsu bg-matsu-50 ring-1 ring-matsu',
+                        getRowBgColor(plot, absoluteIndex)
+                      )}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2 min-w-0">
+                          {getStatusBadge(plot)}
+                          <span className="font-mono text-matsu font-semibold text-sm truncate">
+                            {plot.plotNumber}
+                          </span>
+                          {plot.areaName && (
+                            <span className="text-xs text-hai truncate">{plot.areaName}</span>
+                          )}
+                        </div>
+                        {paymentStatus && (
+                          <StatusBadge
+                            variant={PAYMENT_STATUS_VARIANTS[paymentStatus]}
+                            size="sm"
+                            withSymbol
+                          >
+                            {PAYMENT_STATUS_LABELS[paymentStatus]}
+                          </StatusBadge>
+                        )}
+                      </div>
+                      <div className="mt-1.5 flex items-baseline justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="font-medium text-sumi text-sm truncate">
+                            {plot.customerName || '-'}
+                          </div>
+                          {plot.customerNameKana && (
+                            <div className="text-xs text-hai truncate">{plot.customerNameKana}</div>
+                          )}
+                        </div>
+                        <div className="text-xs text-hai whitespace-nowrap tabular-nums">
+                          {formatContractDate(plot.contractDate)}
+                        </div>
+                      </div>
+                      {plot.customerAddress && (
+                        <div className="mt-1 text-xs text-hai truncate">
+                          {truncateAddressToCity(plot.customerAddress)}
+                        </div>
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <div className="rounded-elegant border border-gin bg-white px-4 py-6">{emptyStateEl}</div>
+          )}
+        </div>
+
+        {/* 区画一覧テーブル（タブレット・PC: md 以上）*/}
+        <div className="hidden md:block bg-white rounded-elegant-lg border border-gin shadow-elegant overflow-hidden flex-1 min-w-0">
           <div className="overflow-auto h-full">
             <table className="w-full divide-y divide-gin text-sm table-fixed">
               {/* 状態 / 区画No / エリア / 契約者 / 住所 / 電話 / 取扱 / 許可番号 / 備考(flex) / [埋葬者] / 契約日 / 入金 / 管理料 / 次請求 */}
@@ -1144,34 +1257,7 @@ export default function PlotRegistry({
                 ) : (
                   <tr>
                     <td colSpan={showBuriedPersons ? 14 : 13} className="px-4 md:px-6 py-6">
-                      <EmptyState
-                        container="plain"
-                        icon={
-                          <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 100-15 7.5 7.5 0 000 15z" />
-                          </svg>
-                        }
-                        title={hasActiveFilters || searchQuery.trim() || activeTab !== '全'
-                          ? '該当する区画が見つかりませんでした'
-                          : '区画データがまだありません'}
-                        description={hasActiveFilters || searchQuery.trim() || activeTab !== '全'
-                          ? '検索語やフィルターを緩めて再検索してください。'
-                          : '新規区画を登録するとここに表示されます。'}
-                        action={(hasActiveFilters || searchQuery.trim() || activeTab !== '全') ? (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => {
-                              setSearchInput('');
-                              setSearchQuery('');
-                              handleClearFilters();
-                              setActiveTab('全');
-                            }}
-                          >
-                            条件をクリア
-                          </Button>
-                        ) : undefined}
-                      />
+                      {emptyStateEl}
                     </td>
                   </tr>
                 )}

--- a/tests/plot-list.spec.ts
+++ b/tests/plot-list.spec.ts
@@ -202,4 +202,22 @@ test.describe('台帳問い合わせ（区画一覧）', () => {
       expect(reset === '{}' || reset === null).toBeTruthy();
     }
   });
+
+  // issue #120: モバイル（iPhone SE 375px）でカードビューに切り替わる
+  test('4-9: モバイル幅では一覧がカード表示になりタップで詳細へ遷移する', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.waitForTimeout(500);
+
+    const cards = page.getByTestId('plot-card');
+    const cardCount = await cards.count().catch(() => 0);
+    if (cardCount === 0) return; // データ未投入環境ではスキップ
+
+    // モバイルではテーブルは非表示（md:block）
+    const table = page.locator('table').first();
+    await expect(table).toBeHidden();
+
+    // カードタップで区画詳細に遷移
+    await cards.first().click();
+    await expect(page).toHaveURL(/\/plots\//, { timeout: 10_000 });
+  });
 });


### PR DESCRIPTION
## 概要

`/plots`（台帳問い合わせ）のモバイル表示（**md 未満**）で、横並びテーブルを情報密度の高い**カードビュー**に切り替える（#120）。タブレット・PC（md 以上）は従来のテーブルを維持。

## 変更内容

- **md 未満**: カードリスト
  - 1行目: 状態バッジ（滞/未/正）+ 区画No（mono強調）+ エリア / 右に入金 StatusBadge
  - 2行目: 契約者名・カナ / 右に契約日
  - 3行目: 住所（市区町村まで）
  - カード全体が `<button>`（`min-h-44px`）→ タップで詳細遷移、`active:`/`focus-visible:` 対応
- **md 以上**: 既存テーブル（`hidden md:block`）をそのまま維持
- 空状態を `emptyStateEl` に共通化（テーブル/カードで再利用）
- ローディングはカード型スケルトン6枚
- E2E（`4-9`）: 375px でカード表示・テーブル非表示・タップ遷移を検証

## 完了条件（issue）

- [x] モバイルでテーブル→カードビュー切替
- [x] 表示項目の優先順位設計（区画No・契約者・状態・入金・エリア・契約日・住所）
- [x] タップターゲット（44px）・余白の最適化
- [x] カードタップで詳細遷移
- [x] デスクトップ・タブレットのテーブル維持
- [ ] **iPhone SE 375px 実機/ブラウザでの目視確認**（次セッションで実施推奨）

## 検証

- `npx tsc --noEmit` … pass
- `npm run lint` … exit 0
- `npm test` … 345 passed
- E2E（`4-9`）は `npm run test:e2e`（認証付き環境）で要実行

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)