### PR TITLE
feat(nav): 請求管理/入金管理のサイドバー導線を削除

### DIFF
--- a/src/app/(main)/billings/page.tsx
+++ b/src/app/(main)/billings/page.tsx
@@ -1,7 +1,0 @@
-'use client';
-
-import BillingManagement from '@/components/billing';
-
-export default function BillingsPage() {
-  return <BillingManagement />;
-}

--- a/src/app/(main)/payments/page.tsx
+++ b/src/app/(main)/payments/page.tsx
@@ -1,7 +1,0 @@
-'use client';
-
-import PaymentManagement from '@/components/payment';
-
-export default function PaymentsPage() {
-  return <PaymentManagement />;
-}

--- a/src/components/layout/GlobalSidebar.tsx
+++ b/src/components/layout/GlobalSidebar.tsx
@@ -26,10 +26,6 @@ function MenuIcon({ icon, className = 'w-5 h-5' }: { icon: NavItem['icon']; clas
       return <svg {...props}><path {...pathProps} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" /></svg>;
     case 'bank':
       return <svg {...props}><path {...pathProps} d="M3 21h18M3 10h18M5 6l7-3 7 3M4 10v11m4-11v11m4-11v11m4-11v11m4-11v11" /></svg>;
-    case 'invoice':
-      return <svg {...props}><path {...pathProps} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>;
-    case 'cash':
-      return <svg {...props}><path {...pathProps} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>;
   }
 }
 

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -3,7 +3,7 @@ import { UserRole } from '@/types/plot-detail';
 export interface NavItem {
   label: string;
   path: string;
-  icon: 'search' | 'archive' | 'grid' | 'file-text' | 'users' | 'settings' | 'upload' | 'bank' | 'invoice' | 'cash';
+  icon: 'search' | 'archive' | 'grid' | 'file-text' | 'users' | 'settings' | 'upload' | 'bank';
   requiredRoles: UserRole[];
 }
 
@@ -20,8 +20,6 @@ export const NAV_GROUPS: NavGroup[] = [
       { label: '合祀管理', path: '/collective-burials', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'archive' },
       { label: '区画残数管理', path: '/plot-availability', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'grid' },
       { label: '書類管理', path: '/documents', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'file-text' },
-      { label: '請求管理', path: '/billings', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'invoice' },
-      { label: '入金管理', path: '/payments', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'cash' },
       { label: 'ゆうちょ連携', path: '/yucho', requiredRoles: ['operator', 'manager', 'admin'], icon: 'bank' },
     ],
   },


### PR DESCRIPTION
## 概要
サイドバーの「請求管理」「入金管理」（グローバル全件導線）を削除する。集金の実導線はゆうちょ自動払込（CSV）であり、`Billing`/`Payment` 取引台帳をサイドバーから能動管理する業務実態が無いため。

## 変更内容
- `config/navigation.ts`: 「請求管理」「入金管理」ナビ項目を削除、`NavItem.icon` 型から未使用の `invoice`/`cash` を削除
- `components/layout/GlobalSidebar.tsx`: 未使用になった `invoice`/`cash` アイコンの `case` を削除
- `app/(main)/billings/page.tsx`・`app/(main)/payments/page.tsx`: ルートページを削除

### ルート削除の判断
issue の未決事項「`/billings`・`/payments` を削除するか URL 直叩き用に残すか」については **削除**を選択。
- nav 削除後、両ルートへのリンクは皆無（参照は nav 2行と API モジュール import のみで、後者は別物）
- 「全件導線を消す」という issue の主旨に合致。区画単位の請求/入金履歴は区画詳細の埋め込みで従来通り閲覧可能

## 維持（変更なし）
- 区画詳細の埋め込み `BillingManagement`/`PaymentManagement`（`plot-detail-view.tsx`）
- コンポーネント本体（`components/billing/`・`components/payment/`）
- API クライアント（`lib/api/billings`・`lib/api/payments`）、バックエンド API、データモデル

## 検証
- ✅ `npm run lint` 0 errors
- ✅ `npx tsc --noEmit` 0 errors
- ✅ `npm test` 345 passed
- ✅ E2E `navigation.spec.ts` は請求/入金導線をアサートしていない（影響なし）

## 受け入れ条件
- [x] サイドバーから「請求管理」「入金管理」が消えている
- [x] 区画詳細の請求/入金タブは従来通り（コンポーネント・埋め込み未変更）
- [x] バックエンドAPI・データに影響なし

Closes zaitsu82/komine-crm-backend#159

🤖 Generated with [Claude Code](https://claude.com/claude-code)