### PR TITLE
fix(yucho): CSV実出力件数と口座未登録の除外を可視化

### DIFF
--- a/src/components/yucho/YuchoManagement.tsx
+++ b/src/components/yucho/YuchoManagement.tsx
@@ -88,6 +88,10 @@ export default function YuchoManagement() {
   const collectiveTotal = summary?.byCategory.collective.amount ?? 0;
   const grandTotal = summary?.totalAmount ?? 0;
   const totalCount = summary?.totalCount ?? 0;
+  // 実際にCSV（振替ファイル）へ出力される件数・金額と、口座未登録で除外される件数（#172）
+  const exportableCount = summary?.exportableCount ?? 0;
+  const exportableAmount = summary?.exportableAmount ?? 0;
+  const excludedNoAccountCount = summary?.excludedNoAccountCount ?? 0;
 
   // プレビュー用: バックエンドのCSV出力(全銀協固定長)を取得して表示
   const [previewText, setPreviewText] = useState<string>('');
@@ -122,7 +126,9 @@ export default function YuchoManagement() {
     try {
       const blob = await exportYuchoCsv(buildExportParams());
       downloadBlob(`yucho_${billingYear}.csv`, blob);
-      showSuccess('CSVを出力しました', `${billingYear}年度 ${totalCount}件`);
+      const excludedNote =
+        excludedNoAccountCount > 0 ? `（口座未登録${excludedNoAccountCount}件は除外）` : '';
+      showSuccess('CSVを出力しました', `${billingYear}年度 ${exportableCount}件出力${excludedNote}`);
       setPreviewOpen(false);
     } catch (e) {
       showError('CSV出力に失敗しました', e instanceof Error ? e.message : String(e));
@@ -167,7 +173,7 @@ export default function YuchoManagement() {
                 variant="outline"
                 size="sm"
                 onClick={openPreview}
-                disabled={totalCount === 0 || isLoading}
+                disabled={exportableCount === 0 || isLoading}
               >
                 <FileText className="w-4 h-4 mr-1.5" />
                 プレビュー
@@ -176,7 +182,7 @@ export default function YuchoManagement() {
                 variant="ai"
                 size="sm"
                 onClick={handleDownload}
-                disabled={totalCount === 0 || isLoading || isExporting}
+                disabled={exportableCount === 0 || isLoading || isExporting}
               >
                 {isExporting ? (
                   <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
@@ -202,6 +208,23 @@ export default function YuchoManagement() {
           </div>
         )}
 
+        {/* 口座未登録による除外の警告（#172: 無言除外で請求漏れに気づけない問題への可視化） */}
+        {!isLoading && excludedNoAccountCount > 0 && (
+          <div className="bg-kohaku-50 border border-kohaku-200 rounded-lg p-3 md:p-4 shadow-elegant-sm">
+            <div className="flex items-start gap-2 text-kohaku-dark">
+              <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+              <div className="text-sm">
+                <p className="font-medium">
+                  口座未登録の {excludedNoAccountCount}件 が振替ファイルから除外されます
+                </p>
+                <p className="text-xs mt-0.5">
+                  全{totalCount}件中 {exportableCount}件 を出力します。記号・番号が「—」の対象は口座が未登録のため、別途の請求対応が必要です。
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* サマリー */}
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4">
           <StatCard
@@ -221,7 +244,11 @@ export default function YuchoManagement() {
           <StatCard
             label="総合計"
             value={formatYen(grandTotal)}
-            description={`全${totalCount}件`}
+            description={
+              excludedNoAccountCount > 0
+                ? `全${totalCount}件・出力${exportableCount}件`
+                : `全${totalCount}件`
+            }
             icon={<Landmark className="w-4 h-4" />}
             theme="ai"
           />
@@ -269,7 +296,9 @@ export default function YuchoManagement() {
         isOpen={previewOpen}
         onClose={() => setPreviewOpen(false)}
         title="CSVプレビュー"
-        description={`${billingYear}年度 ゆうちょ自動払込CSV（${totalCount}件 / ${formatYen(grandTotal)}）`}
+        description={`${billingYear}年度 ゆうちょ自動払込CSV（出力${exportableCount}件 / ${formatYen(exportableAmount)}${
+          excludedNoAccountCount > 0 ? ` ・口座未登録${excludedNoAccountCount}件は除外` : ''
+        }）`}
         size="full"
         footer={
           <>
@@ -279,7 +308,7 @@ export default function YuchoManagement() {
             <Button
               variant="ai"
               onClick={handleDownload}
-              disabled={totalCount === 0 || isExporting}
+              disabled={exportableCount === 0 || isExporting}
             >
               {isExporting ? (
                 <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />

--- a/src/lib/api/yucho.ts
+++ b/src/lib/api/yucho.ts
@@ -41,8 +41,16 @@ export interface YuchoBillingItem {
 }
 
 export interface YuchoBillingSummary {
+  /** 請求対象の総件数（口座未登録を含む） */
   totalCount: number;
+  /** 請求対象の総額（口座未登録を含む） */
   totalAmount: number;
+  /** 実際にCSV（振替ファイル）へ出力される件数（口座登録あり・金額>0） */
+  exportableCount: number;
+  /** 実際にCSVへ出力される金額の合計 */
+  exportableAmount: number;
+  /** 口座未登録のため振替ファイルから除外される件数（請求漏れ検知用） */
+  excludedNoAccountCount: number;
   byCategory: {
     management: { count: number; amount: number };
     collective: { count: number; amount: number };


### PR DESCRIPTION
## 概要
ゆうちょ連携画面で、口座未登録の請求が振替ファイル（CSV）から**無言で除外**される一方、件数表示が除外前の全件のままで**請求漏れに気づけない**問題に対応する。backend（zaitsu82/komine-crm-backend#172）が追加した `summary.exportableCount` / `excludedNoAccountCount` を使って表示を実態に合わせる。

## 変更内容（`YuchoManagement.tsx`）
- **成功トースト**を実出力件数（`exportableCount`）に修正し、除外件数を併記
  - 例: 「2026年度 80件出力（口座未登録20件は除外）」
- **プレビュー / CSV出力 / ダウンロード**の可否判定を `totalCount` → `exportableCount` に変更
  - 口座が1件も無い（実出力0件）場合にボタンを無効化し、ヘッダ＋トレーラのみの実質空ファイルが落ちるのを防止
- **口座未登録の除外件数を警告バナーで明示**（kohaku 警告色）。記号・番号が「—」の行が対象である旨を案内
- 総合計カード・プレビューダイアログの件数/金額を出力ベースに整理（除外がある時のみ「全N件・出力M件」表示）

## 依存
- backend PR: zaitsu82/komine-crm-backend#178（summary フィールド追加）。マージ後に値が入る。未マージ時は `?? 0` でフォールバックし表示が壊れない

## 検証
- `npx tsc --noEmit` clean / `eslint` 0 errors
- 除外0件時は従来通りの表示（バナー非表示・「全N件」）

関連: zaitsu82/komine-crm-backend#172（本PRはそのフロント側対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
