### PR TITLE
fix(plot-detail): 基本情報タブで申込者情報を常に表示 (#159)

### DIFF
--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -263,8 +263,10 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
   const primaryRole = contractorRole ?? plot.roles[0];
   const primaryCustomer = primaryRole?.customer;
 
-  const showApplicantSection =
-    !!applicantRole && (!primaryRole || applicantRole.customer.id !== primaryRole.customer.id);
+  // 申込者は契約者と同一人物でも基本情報タブに常に表示する（#159, 旧システム準拠）。
+  // 「申込者＝契約者で省略」と「申込者未登録」を区別できるようにするため。
+  const applicantIsSameAsContractor =
+    !!applicantRole && !!primaryRole && applicantRole.customer.id === primaryRole.customer.id;
 
   return (
     <div className="space-y-4">
@@ -298,8 +300,17 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
       {/* 契約者情報 */}
       {primaryRole && <CustomerInfoSection role={primaryRole} title="契約者情報" />}
 
-      {/* 申込者情報（契約者と別人の場合のみ表示） */}
-      {showApplicantSection && <CustomerInfoSection role={applicantRole} title="申込者情報" />}
+      {/* 申込者情報（申込者ロールがあれば同一人物でも常に表示。未登録時は明示する） */}
+      {applicantRole ? (
+        <CustomerInfoSection
+          role={applicantRole}
+          title={applicantIsSameAsContractor ? '申込者情報（契約者に同じ）' : '申込者情報'}
+        />
+      ) : (
+        <Section title="申込者情報">
+          <InfoField label="申込者" value="登録なし" />
+        </Section>
+      )}
 
       {/* 勤務先情報（契約者） */}
       {primaryCustomer?.workInfo && (


### PR DESCRIPTION
## 概要
区画詳細の**基本情報タブ**で、申込者が契約者と同一人物の場合に「申込者情報」セクションが非表示になり、「申込者＝契約者で省略」なのか「申込者未登録」なのか区別できなかった。旧システムは申込者欄を常時表示していたため、業務担当者から「申込者情報が見当たらない」との報告があった。旧システム準拠で常時表示に修正する。

## 変更内容（`src/components/plot-detail-view.tsx` BasicInfoTab）
- 申込者ロールが存在すれば、**契約者と同一人物でも「申込者情報」を常に表示**
  - 同一人物のときはタイトルに `（契約者に同じ）` を注記し、重複感に配慮
- 申込者ロールが**無い**場合は「申込者: 登録なし」を表示し、未登録を明示的に区別
- 連絡先タブの「契約関係者」一覧は従来どおり（変更なし）

## 受け入れ条件
- [x] 申込者ロールがあれば契約者と同一人物でも基本情報タブに「申込者情報」が表示される
- [x] 同一人物時の重複表示に配慮（タイトル注記で区別）
- [x] 申込者未登録時の表示方針を定義（「登録なし」を明示）

## 検証
- `npx tsc --noEmit` clean / `eslint` 0 errors
- 変更は1ファイル・表示条件のみ（データ取得・他タブに影響なし）

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)
