### PR TITLE
feat(display): 表示フォーマット共通化（電話/郵便/金額/年月） (#168 #169 #179)

### DIFF
--- a/src/__tests__/lib/format.test.ts
+++ b/src/__tests__/lib/format.test.ts
@@ -1,0 +1,122 @@
+import {
+  formatCurrency,
+  formatNumber,
+  formatPhoneNumber,
+  formatPostalCode,
+  formatBillingMonth,
+} from '@/lib/format';
+
+describe('formatCurrency', () => {
+  it('数値をカンマ区切り + 円で表示する', () => {
+    expect(formatCurrency(270000)).toBe('270,000円');
+    expect(formatCurrency(1500000)).toBe('1,500,000円');
+  });
+
+  it('0 は "0円" として表示する', () => {
+    expect(formatCurrency(0)).toBe('0円');
+  });
+
+  it('null / undefined / 空文字は fallback を返す', () => {
+    expect(formatCurrency(null)).toBe('-');
+    expect(formatCurrency(undefined)).toBe('-');
+    expect(formatCurrency('')).toBe('-');
+    expect(formatCurrency('  ')).toBe('-');
+    expect(formatCurrency(null, '未設定')).toBe('未設定');
+  });
+
+  it('カンマ・円・通貨記号付き文字列も数値として解釈する', () => {
+    expect(formatCurrency('270,000')).toBe('270,000円');
+    expect(formatCurrency('270000円')).toBe('270,000円');
+    expect(formatCurrency('¥270,000')).toBe('270,000円');
+  });
+
+  it('数値化できない文字列はトリムして返す', () => {
+    expect(formatCurrency('応相談')).toBe('応相談');
+  });
+});
+
+describe('formatNumber', () => {
+  it('カンマ区切りの数値文字列を返す', () => {
+    expect(formatNumber(1234567)).toBe('1,234,567');
+    expect(formatNumber(0)).toBe('0');
+  });
+
+  it('null / undefined は fallback を返す', () => {
+    expect(formatNumber(null)).toBe('0');
+    expect(formatNumber(undefined, '-')).toBe('-');
+  });
+});
+
+describe('formatPhoneNumber', () => {
+  it('携帯番号を 3-4-4 で区切る', () => {
+    expect(formatPhoneNumber('09083526733')).toBe('090-8352-6733');
+    expect(formatPhoneNumber('08012345678')).toBe('080-1234-5678');
+  });
+
+  it('東京/大阪の固定電話を 2-4-4 で区切る', () => {
+    expect(formatPhoneNumber('0312345678')).toBe('03-1234-5678');
+    expect(formatPhoneNumber('0612345678')).toBe('06-1234-5678');
+  });
+
+  it('その他10桁の固定電話は 3-3-4 で区切る', () => {
+    expect(formatPhoneNumber('0429876543')).toBe('042-987-6543');
+  });
+
+  it('フリーダイヤル 0120 を 4-3-3 で区切る', () => {
+    expect(formatPhoneNumber('0120123456')).toBe('0120-123-456');
+  });
+
+  it('null / 空は空文字を返す', () => {
+    expect(formatPhoneNumber(null)).toBe('');
+    expect(formatPhoneNumber('')).toBe('');
+  });
+
+  it('想定外の桁数は元の値を返す', () => {
+    expect(formatPhoneNumber('12345')).toBe('12345');
+  });
+});
+
+describe('formatPostalCode', () => {
+  it('7桁を XXX-XXXX で区切る', () => {
+    expect(formatPostalCode('8070842')).toBe('807-0842');
+  });
+
+  it('既にハイフン付きでも整形する', () => {
+    expect(formatPostalCode('807-0842')).toBe('807-0842');
+  });
+
+  it('null / 空は空文字、7桁以外はそのまま返す', () => {
+    expect(formatPostalCode(null)).toBe('');
+    expect(formatPostalCode('')).toBe('');
+    expect(formatPostalCode('123')).toBe('123');
+  });
+});
+
+describe('formatBillingMonth', () => {
+  it('YYYYMM を YYYY年M月 に変換する', () => {
+    expect(formatBillingMonth('202403')).toBe('2024年3月');
+    expect(formatBillingMonth('202412')).toBe('2024年12月');
+  });
+
+  it('YYYY年M月 形式は前ゼロを除いて返す', () => {
+    expect(formatBillingMonth('2024年03月')).toBe('2024年3月');
+    expect(formatBillingMonth('2024年3月')).toBe('2024年3月');
+  });
+
+  it('区切り付きの年月も変換する', () => {
+    expect(formatBillingMonth('2024/03')).toBe('2024年3月');
+    expect(formatBillingMonth('2024-03')).toBe('2024年3月');
+  });
+
+  it('"0" / 空 / null / 全ゼロは未設定を返す', () => {
+    expect(formatBillingMonth('0')).toBe('未設定');
+    expect(formatBillingMonth('')).toBe('未設定');
+    expect(formatBillingMonth(null)).toBe('未設定');
+    expect(formatBillingMonth('000000')).toBe('未設定');
+    expect(formatBillingMonth('0', '-')).toBe('-');
+  });
+
+  it('不正な月は未設定を返す', () => {
+    expect(formatBillingMonth('202413')).toBe('未設定');
+  });
+});

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -33,6 +33,13 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { StatusBadge, type StatusBadgeProps } from '@/components/ui/status-badge';
 import { cn } from '@/lib/utils';
+import {
+  formatCurrency,
+  formatNumber,
+  formatPhoneNumber,
+  formatPostalCode,
+  formatBillingMonth,
+} from '@/lib/format';
 import { Skeleton } from '@/components/ui/skeleton';
 import { HistoryTab } from '@/components/plot-form/HistoryTab';
 import { useAuth } from '@/contexts/auth-context';
@@ -137,8 +144,7 @@ function formatDate(dateStr: string | null | undefined): string {
 }
 
 function formatPrice(price: number | null | undefined): string {
-  if (price == null) return '-';
-  return `${price.toLocaleString()} 円`;
+  return formatCurrency(price);
 }
 
 /**
@@ -242,13 +248,13 @@ function CustomerInfoSection({ role, title }: { role: PlotRole; title: string })
       <InfoField label="ふりがな" value={customer.nameKana} />
       <InfoField label="性別" value={customer.gender ? GENDER_LABELS[customer.gender as Gender] : null} />
       <InfoField label="生年月日" value={formatDate(customer.birthDate)} />
-      <InfoField label="電話番号" value={customer.phoneNumber} />
-      <InfoField label="FAX" value={customer.faxNumber} />
+      <InfoField label="電話番号" value={formatPhoneNumber(customer.phoneNumber)} />
+      <InfoField label="FAX" value={formatPhoneNumber(customer.faxNumber)} />
       <InfoField label="メール" value={customer.email} />
-      <InfoField label="郵便番号" value={customer.postalCode} />
+      <InfoField label="郵便番号" value={formatPostalCode(customer.postalCode)} />
       <InfoField label="住所" value={customer.address} />
       <InfoField label="住所2" value={customer.addressLine2} />
-      <InfoField label="本籍郵便番号" value={customer.registeredPostalCode} />
+      <InfoField label="本籍郵便番号" value={formatPostalCode(customer.registeredPostalCode)} />
       <InfoField label="本籍地" value={customer.registeredAddress} />
       <InfoField label="役割開始日" value={formatDate(role.roleStartDate)} />
       <InfoField label="役割終了日" value={formatDate(role.roleEndDate)} />
@@ -317,9 +323,9 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
         <Section title="勤務先情報">
           <InfoField label="勤務先名称" value={primaryCustomer.workInfo.companyName} />
           <InfoField label="勤務先かな" value={primaryCustomer.workInfo.companyNameKana} />
-          <InfoField label="勤務先郵便番号" value={primaryCustomer.workInfo.workPostalCode} />
+          <InfoField label="勤務先郵便番号" value={formatPostalCode(primaryCustomer.workInfo.workPostalCode)} />
           <InfoField label="勤務先住所" value={primaryCustomer.workInfo.workAddress} />
-          <InfoField label="勤務先電話番号" value={primaryCustomer.workInfo.workPhoneNumber} />
+          <InfoField label="勤務先電話番号" value={formatPhoneNumber(primaryCustomer.workInfo.workPhoneNumber)} />
           <InfoField label="DM設定" value={primaryCustomer.workInfo.dmSetting ? DM_SETTING_LABELS[primaryCustomer.workInfo.dmSetting as DmSetting] : null} />
           <InfoField label="宛先区分" value={primaryCustomer.workInfo.addressType ? ADDRESS_TYPE_LABELS[primaryCustomer.workInfo.addressType as AddressType] : null} />
           <InfoField label="備考" value={primaryCustomer.workInfo.notes} />
@@ -357,8 +363,8 @@ function FeeInfoTab({ plot, masters }: { plot: PlotDetailResponse; masters: FeeM
           <InfoField label="請求タイプ" value={resolveMasterName(masters.billingTypes, plot.usageFee.billingType)} />
           <InfoField label="請求年数" value={plot.usageFee.billingYears?.toString()} />
           <InfoField label="面積" value={plot.usageFee.area} />
-          <InfoField label="単価" value={plot.usageFee.unitPrice} />
-          <InfoField label="使用料" value={plot.usageFee.usageFee} />
+          <InfoField label="単価" value={formatCurrency(plot.usageFee.unitPrice)} />
+          <InfoField label="使用料" value={formatCurrency(plot.usageFee.usageFee)} />
           <InfoField label="送付方法" value={resolveMasterName(masters.paymentMethods, plot.usageFee.paymentMethod)} />
         </Section>
       )}
@@ -372,9 +378,9 @@ function FeeInfoTab({ plot, masters }: { plot: PlotDetailResponse; masters: FeeM
           <InfoField label="請求年数" value={plot.managementFee.billingYears?.toString()} />
           <InfoField label="面積" value={plot.managementFee.area} />
           <InfoField label="請求月" value={plot.managementFee.billingMonth?.toString()} />
-          <InfoField label="管理料" value={plot.managementFee.managementFee} />
-          <InfoField label="単価" value={plot.managementFee.unitPrice} />
-          <InfoField label="終納請求年月" value={plot.managementFee.lastBillingMonth} />
+          <InfoField label="管理料" value={formatCurrency(plot.managementFee.managementFee)} />
+          <InfoField label="単価" value={formatCurrency(plot.managementFee.unitPrice)} />
+          <InfoField label="終納請求年月" value={formatBillingMonth(plot.managementFee.lastBillingMonth)} />
           <InfoField label="送付方法" value={resolveMasterName(masters.paymentMethods, plot.managementFee.paymentMethod)} />
         </Section>
       )}
@@ -402,7 +408,7 @@ function ContactsTab({ plot }: { plot: PlotDetailResponse }) {
                 <InfoField label="役割" value={CONTRACT_ROLE_LABELS[role.role as ContractRole]} />
                 <InfoField label="氏名" value={role.customer.name} />
                 <InfoField label="ふりがな" value={role.customer.nameKana} />
-                <InfoField label="電話番号" value={role.customer.phoneNumber} />
+                <InfoField label="電話番号" value={formatPhoneNumber(role.customer.phoneNumber)} />
                 <InfoField label="住所" value={role.customer.address} />
                 <InfoField label="開始日" value={formatDate(role.roleStartDate)} />
                 <InfoField label="終了日" value={formatDate(role.roleEndDate)} />
@@ -426,11 +432,11 @@ function ContactsTab({ plot }: { plot: PlotDetailResponse }) {
                 <InfoField label="ふりがな" value={contact.nameKana} />
                 <InfoField label="続柄" value={contact.relationship} />
                 <InfoField label="生年月日" value={formatDate(contact.birthDate)} />
-                <InfoField label="郵便番号" value={contact.postalCode} />
+                <InfoField label="郵便番号" value={formatPostalCode(contact.postalCode)} />
                 <InfoField label="住所" value={contact.address} />
-                <InfoField label="電話番号" value={contact.phoneNumber} />
-                <InfoField label="電話番号2" value={contact.phoneNumber2} />
-                <InfoField label="FAX" value={contact.faxNumber} />
+                <InfoField label="電話番号" value={formatPhoneNumber(contact.phoneNumber)} />
+                <InfoField label="電話番号2" value={formatPhoneNumber(contact.phoneNumber2)} />
+                <InfoField label="FAX" value={formatPhoneNumber(contact.faxNumber)} />
                 <InfoField label="メール" value={contact.email} />
                 <InfoField label="本籍住所" value={contact.registeredAddress} />
                 <InfoField label="送付先区分" value={contact.mailingType ? ADDRESS_TYPE_LABELS[contact.mailingType as AddressType] : null} />
@@ -444,7 +450,7 @@ function ContactsTab({ plot }: { plot: PlotDetailResponse }) {
                     <InfoField label="勤務先名称" value={contact.workCompanyName} />
                     <InfoField label="勤務先かな" value={contact.workCompanyNameKana} />
                     <InfoField label="勤務先住所" value={contact.workAddress} />
-                    <InfoField label="勤務先電話番号" value={contact.workPhoneNumber} />
+                    <InfoField label="勤務先電話番号" value={formatPhoneNumber(contact.workPhoneNumber)} />
                   </div>
                 </div>
               )}
@@ -828,7 +834,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
               'mt-1 text-lg md:text-2xl font-semibold tabular-nums',
               (plot.uncollectedAmount ?? 0) > 0 ? 'text-beni' : 'text-sumi'
             )}>
-              {(plot.uncollectedAmount ?? 0).toLocaleString()}
+              {formatNumber(plot.uncollectedAmount ?? 0)}
               <span className="text-xs md:text-sm text-hai ml-1 font-normal">円</span>
             </p>
           </div>
@@ -836,7 +842,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
           <div className="min-w-0">
             <p className="text-[11px] md:text-xs text-hai">直近請求</p>
             <p className="mt-1 text-sm md:text-base font-semibold text-sumi tabular-nums truncate">
-              {plot.managementFee?.lastBillingMonth || '―'}
+              {formatBillingMonth(plot.managementFee?.lastBillingMonth, '―')}
             </p>
           </div>
           {/* 区画状態 */}

--- a/src/components/plot-registry/PlotTable.tsx
+++ b/src/components/plot-registry/PlotTable.tsx
@@ -9,6 +9,7 @@ import {
   type ResizableColumnKey,
 } from '@/lib/plots-column-widths';
 import { PAYMENT_STATUS_LABELS, PAYMENT_STATUS_VARIANTS } from './constants';
+import { formatPhoneNumber } from '@/lib/format';
 import { formatContractDate, formatMoneyString, getRowBgColor, getStatusBadge } from './utils';
 import { ColumnResizer } from './ColumnResizer';
 import { SortIndicator } from './SortIndicator';
@@ -296,8 +297,8 @@ export function PlotTable({
                         ? (plot.customerAddress || '-')
                         : truncateAddressToCity(plot.customerAddress)}
                     </td>
-                    <td className={cellWrapClass('phone', 'px-2 py-2 text-xs text-hai hidden lg:table-cell')} title={plot.customerPhoneNumber || undefined}>
-                      {plot.customerPhoneNumber || '-'}
+                    <td className={cellWrapClass('phone', 'px-2 py-2 text-xs text-hai hidden lg:table-cell tabular-nums')} title={plot.customerPhoneNumber || undefined}>
+                      {formatPhoneNumber(plot.customerPhoneNumber) || '-'}
                     </td>
                     <td className={cellWrapClass('agent', 'px-2 py-2 text-xs text-hai hidden lg:table-cell')} title={plot.agentName || undefined}>
                       {plot.agentName || '-'}

--- a/src/components/plot-registry/utils.tsx
+++ b/src/components/plot-registry/utils.tsx
@@ -1,5 +1,6 @@
 import type { PlotListItem } from '@komine/types';
 import { getPlotDisplayStatus } from '@/lib/api/plots';
+import { formatCurrency } from '@/lib/format';
 import { SEARCH_HISTORY_KEY, SEARCH_HISTORY_MAX } from './constants';
 
 // ===== 検索履歴 =====
@@ -39,11 +40,9 @@ export function formatContractDate(dateStr: string | null | undefined): string {
   }
 }
 
+/** @deprecated 共通の {@link formatCurrency} を使用。後方互換のため残置。 */
 export function formatMoneyString(value: string | null | undefined): string {
-  if (!value) return '-';
-  const num = Number(value.replace(/,/g, ''));
-  if (isNaN(num)) return '-';
-  return `${num.toLocaleString()}円`;
+  return formatCurrency(value);
 }
 
 // ===== 行表示ヘルパー（テーブル・モバイルカードで共用） =====

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,118 @@
+/**
+ * 表示用フォーマットユーティリティ
+ *
+ * 保存値（ハイフンなし電話番号・カンマなし金額など）と表示形式を分離する。
+ * 一覧・詳細・書類で共通利用し、画面ごとの表記揺れ（#168 / #169 / #179）を解消する。
+ */
+
+const DASH = '-';
+
+/**
+ * 金額を「270,000円」形式に統一する。
+ * - null / undefined / 空文字 → fallback（既定 "-"）
+ * - 数値 0 → "0円"（無料を意味する有効値として表示）
+ * - カンマ・通貨記号・"円"・空白を含む文字列も数値として解釈する
+ * - 数値化できない文字列はトリムした元の値を返す（レガシーデータの欠落防止）
+ */
+export function formatCurrency(
+  value: number | string | null | undefined,
+  fallback: string = DASH,
+): string {
+  if (value === null || value === undefined) return fallback;
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') return fallback;
+    const num = Number(trimmed.replace(/[,¥￥円\s]/g, ''));
+    if (!Number.isFinite(num)) return trimmed;
+    return `${num.toLocaleString('ja-JP')}円`;
+  }
+
+  if (!Number.isFinite(value)) return fallback;
+  return `${value.toLocaleString('ja-JP')}円`;
+}
+
+/**
+ * 数値をカンマ区切り文字列にする（単位は呼び出し側で付与）。
+ * 未収金サマリーのように "円" を別要素で装飾する箇所向け。
+ */
+export function formatNumber(value: number | null | undefined, fallback: string = '0'): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return fallback;
+  return value.toLocaleString('ja-JP');
+}
+
+/**
+ * 電話番号を表示用にハイフン区切りする。保存値はハイフンなしの数字を想定。
+ * 区切り位置は代表的なパターンのヒューリスティック。判定できない桁数はそのまま返す。
+ */
+export function formatPhoneNumber(value: string | null | undefined): string {
+  if (!value) return '';
+  const digits = value.replace(/[^\d]/g, '');
+  if (digits.length === 0) return value;
+
+  // 携帯・IP電話（070/080/090/050）11桁: 3-4-4
+  if (digits.length === 11 && /^(070|080|090|050)/.test(digits)) {
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  }
+  // フリーダイヤル 0120（10桁）: 4-3-3
+  if (digits.length === 10 && digits.startsWith('0120')) {
+    return `${digits.slice(0, 4)}-${digits.slice(4, 7)}-${digits.slice(7)}`;
+  }
+  // 固定電話 10桁
+  if (digits.length === 10) {
+    // 東京03 / 大阪06 は市外局番2桁: 2-4-4
+    if (/^0[36]/.test(digits)) {
+      return `${digits.slice(0, 2)}-${digits.slice(2, 6)}-${digits.slice(6)}`;
+    }
+    // その他は市外局番3桁とみなす近似: 3-3-4
+    return `${digits.slice(0, 3)}-${digits.slice(3, 6)}-${digits.slice(6)}`;
+  }
+  // 想定外の桁数はそのまま返す
+  return value;
+}
+
+/**
+ * 郵便番号を「807-0842」形式にする。7桁数字を想定。判定できなければそのまま返す。
+ */
+export function formatPostalCode(value: string | null | undefined): string {
+  if (!value) return '';
+  const digits = value.replace(/[^\d]/g, '');
+  if (digits.length === 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+  return value;
+}
+
+/**
+ * 終納請求年月などの年月文字列を「YYYY年M月」に正規化する。
+ * - null / undefined / 空 / "0" / 全ゼロ → fallback（既定 "未設定"）
+ * - "YYYY年M月" / "YYYY年MM月" → 前ゼロを除いて返す
+ * - "YYYYMM"（6桁）/ "YYYY/MM" / "YYYY-MM" → "YYYY年M月"
+ * - 上記に当てはまらなければトリムした元の値を返す
+ */
+export function formatBillingMonth(
+  value: string | null | undefined,
+  fallback: string = '未設定',
+): string {
+  if (value === null || value === undefined) return fallback;
+  const trimmed = value.trim();
+  if (trimmed === '' || trimmed === '0') return fallback;
+
+  // "YYYY年M月" 形式
+  const jp = trimmed.match(/^(\d{4})年(\d{1,2})月$/);
+  if (jp) {
+    const y = Number(jp[1]);
+    const m = Number(jp[2]);
+    if (y === 0 || m === 0 || m > 12) return fallback;
+    return `${y}年${m}月`;
+  }
+
+  // 区切り文字を除いた連続数字（YYYYMM）
+  const digits = trimmed.replace(/[^\d]/g, '');
+  if (digits.length === 6) {
+    const y = Number(digits.slice(0, 4));
+    const m = Number(digits.slice(4));
+    if (y === 0 || m === 0 || m > 12) return fallback;
+    return `${y}年${m}月`;
+  }
+
+  return trimmed;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { formatCurrency } from "./format"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -278,14 +279,9 @@ export function formatPlotNumber(section: string, number: string): string {
 }
 
 /**
- * 価格を日本円形式でフォーマット
- * @param price 価格
- * @returns フォーマット済み価格文字列（例: "¥1,500,000"）
+ * 価格を日本円形式でフォーマット（例: "1,500,000円"）
+ * @deprecated 共通の {@link formatCurrency}（@/lib/format）を使用。後方互換のため残置。
  */
 export function formatPrice(price: number | undefined): string {
-  if (price === undefined) return "未設定";
-  return new Intl.NumberFormat("ja-JP", {
-    style: "currency",
-    currency: "JPY",
-  }).format(price);
+  return formatCurrency(price, "未設定");
 }


### PR DESCRIPTION
## 概要
台帳一覧・詳細の表記揺れ（業務確認不要 UI バッチ）を `src/lib/format.ts` への集約で解消。

| Issue | 内容 |
|---|---|
| #168 | 電話番号・郵便番号をハイフン区切り表示 |
| #169 | 金額表記を `270,000円` に統一（`¥`/スペース/カンマなし/生文字列の混在を解消） |
| #179 | 終納請求年月の `0` 等を「未設定」表示、有効値は `YYYY年M月` |

## 変更
- **新規** `src/lib/format.ts`: `formatCurrency` / `formatNumber` / `formatPhoneNumber` / `formatPostalCode` / `formatBillingMonth`
- `PlotTable` 電話番号列にハイフン整形（`tabular-nums`）
- `plot-detail-view`: 顧客・家族連絡先・勤務先の電話/郵便、料金（使用料・単価・管理料）・契約金額・未収金を共通フォーマッタへ。終納請求年月・直近請求を `formatBillingMonth` へ
- `formatMoneyString`（plot-registry）/ `formatPrice`（lib/utils）を `formatCurrency` へ委譲して一本化（後方互換のため関数は残置）
- `src/__tests__/lib/format.test.ts` 追加（21 ケース）

## フォーマット規定
- 金額: `270,000円`（通貨記号なし・円サフィックス・空白なし）。`0`→`0円`、null/空→`-`
- 電話: 携帯/IP `3-4-4`、東京03・大阪06 `2-4-4`、その他10桁 `3-3-4`（近似）、0120 `4-3-3`。判定不能はそのまま
- 郵便: `XXX-XXXX`
- 年月: `YYYY年M月`、`0`/空/全ゼロ/不正月は `未設定`

## 検証
- `jest src/__tests__/lib/format.test.ts` 21 pass / `utils.test.ts` pass
- `eslint` 対象ファイル clean / `tsc --noEmit` 変更ファイルにエラーなし

Closes #168
Closes #169
Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)