### PR TITLE
feat(plots): 台帳一覧・詳細UX（遷移導線/状態分離/タブ件数/強調色/ロード）(#163 #165 #172 #190)

### DIFF
--- a/src/components/plot-availability-management.tsx
+++ b/src/components/plot-availability-management.tsx
@@ -128,6 +128,10 @@ export default function PlotAvailabilityManagement() {
   // ローディング状態
   const isLoading = isSummaryLoading || isPeriodsLoading || sectionsHook.isLoading || areasHook.isLoading;
 
+  // ロード中は確定前の 0 を表示せず "--" を出す（初回ロードの 0件フラッシュ防止 #172）
+  const stat = (value: number, suffix = ''): string =>
+    isLoading ? '--' : `${value.toLocaleString()}${suffix}`;
+
   // 使用率に応じた色を取得
   const getUsageRateColor = (usageRate: number) => {
     if (usageRate >= 95) return 'bg-beni-50 text-beni-dark';
@@ -267,27 +271,27 @@ export default function PlotAvailabilityManagement() {
             >
               <div className="flex-1 flex items-center justify-between gap-2 text-center">
                 <div className="flex-1 min-w-0">
-                  <div className="text-lg md:text-xl font-bold text-matsu tabular-nums">{summary.totalCount}</div>
+                  <div className="text-lg md:text-xl font-bold text-matsu tabular-nums">{stat(summary.totalCount)}</div>
                   <div className="text-[10px] md:text-xs text-hai">総数</div>
                 </div>
                 <div className="w-px h-8 bg-gin" />
                 <div className="flex-1 min-w-0">
-                  <div className="text-lg md:text-xl font-bold text-ai tabular-nums">{summary.usedCount}</div>
+                  <div className="text-lg md:text-xl font-bold text-ai tabular-nums">{stat(summary.usedCount)}</div>
                   <div className="text-[10px] md:text-xs text-hai">使用</div>
                 </div>
                 <div className="w-px h-8 bg-gin" />
                 <div className="flex-1 min-w-0">
-                  <div className="text-lg md:text-xl font-bold text-kohaku tabular-nums">{summary.remainingCount}</div>
+                  <div className="text-lg md:text-xl font-bold text-kohaku tabular-nums">{stat(summary.remainingCount)}</div>
                   <div className="text-[10px] md:text-xs text-hai">残</div>
                 </div>
                 <div className="w-px h-8 bg-gin" />
                 <div className="flex-1 min-w-0">
-                  <div className="text-lg md:text-xl font-bold text-cha tabular-nums">{summary.usageRate}%</div>
+                  <div className="text-lg md:text-xl font-bold text-cha tabular-nums">{stat(summary.usageRate, '%')}</div>
                   <div className="text-[10px] md:text-xs text-hai">使用率</div>
                 </div>
                 <div className="w-px h-8 bg-gin hidden sm:block" />
                 <div className="flex-1 min-w-0 hidden sm:block">
-                  <div className="text-lg md:text-xl font-bold text-sumi tabular-nums">{(summary.remainingCount * 2)}</div>
+                  <div className="text-lg md:text-xl font-bold text-sumi tabular-nums">{stat(summary.remainingCount * 2)}</div>
                   <div className="text-[10px] md:text-xs text-hai">半区画</div>
                 </div>
               </div>

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -178,6 +178,20 @@ function InfoField({ label, value }: { label: string; value: string | null | und
   );
 }
 
+/** タブの件数バッジ（#180）。アクティブ時の matsu 背景でも見えるよう白チップで表示。 */
+function TabCount({ count }: { count: number }) {
+  return (
+    <span
+      className={cn(
+        'ml-1 inline-flex items-center justify-center rounded-full px-1.5 min-w-[1.125rem] h-4 text-[10px] font-semibold tabular-nums border',
+        count > 0 ? 'bg-white text-matsu border-matsu-200' : 'bg-white/70 text-hai border-gin'
+      )}
+    >
+      {count}
+    </span>
+  );
+}
+
 function Section({
   title,
   children,
@@ -839,28 +853,37 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
               {plot.managementFee?.lastBillingMonth || '―'}
             </p>
           </div>
-          {/* 区画状態 */}
+          {/* 状態（入金 / 契約 / 区画販売 を区分ラベル付きで分離表示）#165 */}
           <div className="min-w-0 col-span-2 md:col-span-1">
             <p className="text-[11px] md:text-xs text-hai mb-1.5">状態</p>
-            <div className="flex flex-wrap gap-1.5">
-              <StatusBadge
-                variant={PAYMENT_STATUS_VARIANTS[plot.paymentStatus as PaymentStatus]}
-                withSymbol
-              >
-                {PAYMENT_STATUS_LABELS[plot.paymentStatus as PaymentStatus]}
-              </StatusBadge>
-              <StatusBadge
-                variant={CONTRACT_STATUS_VARIANTS[plot.contractStatus as ContractStatus]}
-                withSymbol
-              >
-                {CONTRACT_STATUS_LABELS[plot.contractStatus as ContractStatus]}
-              </StatusBadge>
-              <StatusBadge
-                variant={PHYSICAL_STATUS_VARIANTS[plot.physicalPlot.status]}
-                withSymbol
-              >
-                {PHYSICAL_STATUS_LABELS[plot.physicalPlot.status]}
-              </StatusBadge>
+            <div className="flex flex-wrap gap-x-3 gap-y-1.5">
+              <span className="inline-flex items-center gap-1">
+                <span className="text-[10px] text-hai">入金</span>
+                <StatusBadge
+                  variant={PAYMENT_STATUS_VARIANTS[plot.paymentStatus as PaymentStatus]}
+                  withSymbol
+                >
+                  {PAYMENT_STATUS_LABELS[plot.paymentStatus as PaymentStatus]}
+                </StatusBadge>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="text-[10px] text-hai">契約</span>
+                <StatusBadge
+                  variant={CONTRACT_STATUS_VARIANTS[plot.contractStatus as ContractStatus]}
+                  withSymbol
+                >
+                  {CONTRACT_STATUS_LABELS[plot.contractStatus as ContractStatus]}
+                </StatusBadge>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="text-[10px] text-hai">区画</span>
+                <StatusBadge
+                  variant={PHYSICAL_STATUS_VARIANTS[plot.physicalPlot.status]}
+                  withSymbol
+                >
+                  {PHYSICAL_STATUS_LABELS[plot.physicalPlot.status]}
+                </StatusBadge>
+              </span>
             </div>
           </div>
         </div>
@@ -886,12 +909,15 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
           </TabsTrigger>
           <TabsTrigger value="contacts" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             連絡先
+            <TabCount count={plot.roles.length + (plot.familyContacts?.length ?? 0)} />
           </TabsTrigger>
           <TabsTrigger value="burial" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             埋葬情報
+            <TabCount count={plot.buriedPersons?.length ?? 0} />
           </TabsTrigger>
           <TabsTrigger value="construction" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             工事情報
+            <TabCount count={plot.constructionInfos?.length ?? 0} />
           </TabsTrigger>
           <TabsTrigger value="billing" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             請求
@@ -901,6 +927,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
           </TabsTrigger>
           <TabsTrigger value="history" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             履歴情報
+            <TabCount count={plot.histories?.length ?? 0} />
           </TabsTrigger>
         </TabsList>
 

--- a/src/components/plot-registry/PlotCardList.tsx
+++ b/src/components/plot-registry/PlotCardList.tsx
@@ -4,7 +4,7 @@ import { cn, truncateAddressToCity } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge } from '@/components/ui/status-badge';
 import { PAYMENT_STATUS_LABELS, PAYMENT_STATUS_VARIANTS } from './constants';
-import { formatContractDate, getRowBgColor, getStatusBadge } from './utils';
+import { formatContractDate, getRowBgColor } from './utils';
 
 interface PlotCardListProps {
   plots: PlotListItem[];
@@ -53,13 +53,13 @@ export function PlotCardList({
                   className={cn(
                     'w-full min-h-[44px] rounded-elegant border border-gin bg-white p-3 text-left shadow-sm transition-colors',
                     'active:bg-matsu-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-matsu',
-                    selectedPlotId === plot.id && 'border-matsu bg-matsu-50 ring-1 ring-matsu',
+                    // 選択は藍(ai)アクセントでホバー(緑)と区別 (#190)
+                    selectedPlotId === plot.id && 'border-ai bg-ai-50 ring-1 ring-ai',
                     getRowBgColor(plot, absoluteIndex)
                   )}
                 >
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2 min-w-0">
-                      {getStatusBadge(plot)}
                       <span className="font-mono text-matsu font-semibold text-sm truncate">
                         {plot.plotNumber}
                       </span>
@@ -67,15 +67,21 @@ export function PlotCardList({
                         <span className="text-xs text-hai truncate">{plot.areaName}</span>
                       )}
                     </div>
-                    {paymentStatus && (
-                      <StatusBadge
-                        variant={PAYMENT_STATUS_VARIANTS[paymentStatus]}
-                        size="sm"
-                        withSymbol
-                      >
-                        {PAYMENT_STATUS_LABELS[paymentStatus]}
-                      </StatusBadge>
-                    )}
+                    <div className="flex items-center gap-1 shrink-0">
+                      {paymentStatus && (
+                        <StatusBadge
+                          variant={PAYMENT_STATUS_VARIANTS[paymentStatus]}
+                          size="sm"
+                          withSymbol
+                        >
+                          {PAYMENT_STATUS_LABELS[paymentStatus]}
+                        </StatusBadge>
+                      )}
+                      {/* 詳細を開くシェブロン (#163) */}
+                      <svg className="w-4 h-4 text-hai" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </div>
                   </div>
                   <div className="mt-1.5 flex items-baseline justify-between gap-2">
                     <div className="min-w-0">

--- a/src/components/plot-registry/PlotTable.tsx
+++ b/src/components/plot-registry/PlotTable.tsx
@@ -9,7 +9,7 @@ import {
   type ResizableColumnKey,
 } from '@/lib/plots-column-widths';
 import { PAYMENT_STATUS_LABELS, PAYMENT_STATUS_VARIANTS } from './constants';
-import { formatContractDate, formatMoneyString, getRowBgColor, getStatusBadge } from './utils';
+import { formatContractDate, formatMoneyString, getRowBgColor } from './utils';
 import { ColumnResizer } from './ColumnResizer';
 import { SortIndicator } from './SortIndicator';
 import type { SortKey, SortOrder } from './types';
@@ -63,9 +63,8 @@ export function PlotTable({
     <div className="hidden md:block bg-white rounded-elegant-lg border border-gin shadow-elegant overflow-hidden flex-1 min-w-0">
       <div className="overflow-auto h-full">
         <table className="w-full divide-y divide-gin text-sm table-fixed">
-          {/* 状態 / 区画No / エリア / 契約者 / 住所 / 電話 / 取扱 / 許可番号 / 備考(flex) / [埋葬者] / 契約日 / 入金 / 管理料 / 次請求 */}
+          {/* 区画No / エリア / 契約者 / 住所 / 電話 / 取扱 / 許可番号 / 備考(flex) / [埋葬者] / 契約日 / 入金 / 管理料 / 次請求 */}
           <colgroup>
-            <col className="w-[40px]" />
             <col className="w-[68px]" style={colStyle('plotNumber')} />
             <col className="w-[52px]" style={colStyle('areaName')} />
             <col className="w-[110px]" style={colStyle('customerName')} />
@@ -81,22 +80,10 @@ export function PlotTable({
             <col className="w-[60px]" />
             <col className="hidden sm:table-column w-[72px]" />
             <col className="hidden md:table-column w-[60px]" />
+            <col className="w-[40px]" />
           </colgroup>
           <thead className="bg-gradient-matsu sticky top-0 z-10">
             <tr>
-              <th
-                className={cn(
-                  "px-2 py-2 text-center text-xs font-bold text-white cursor-pointer transition-all duration-200",
-                  "hover:bg-matsu-light",
-                  sortKey === 'status' && "bg-matsu-dark"
-                )}
-                onClick={() => onSort('status')}
-                title="入金状況"
-              >
-                <div className="flex items-center justify-center">
-                  <span>状態</span>
-                </div>
-              </th>
               <th
                 className={cn(
                   "relative px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200",
@@ -214,6 +201,10 @@ export function PlotTable({
               <th className="px-2 py-2 text-left text-xs font-bold text-white hidden md:table-cell">
                 <span>次請求</span>
               </th>
+              {/* 詳細遷移アフォーダンス列 (#163) */}
+              <th className="px-2 py-2 text-center text-xs font-bold text-white">
+                <span className="sr-only">詳細</span>
+              </th>
             </tr>
           </thead>
 
@@ -222,7 +213,6 @@ export function PlotTable({
               <>
                 {Array.from({ length: 8 }).map((_, i) => (
                   <tr key={i}>
-                    <td className="px-2 py-2.5 text-center"><Skeleton className="h-6 w-6 rounded-full mx-auto" /></td>
                     <td className="px-2 py-2.5"><Skeleton className="h-4 w-14" /></td>
                     <td className="px-2 py-2.5"><Skeleton className="h-4 w-10" /></td>
                     <td className="px-2 py-2.5"><Skeleton className="h-4 w-20" /></td>
@@ -265,17 +255,25 @@ export function PlotTable({
                   <tr
                     key={plot.id}
                     className={cn(
-                      'cursor-pointer hover:bg-matsu-50 transition-all duration-200',
-                      selectedPlotId === plot.id && 'bg-matsu-100 border-l-4 border-matsu',
+                      'group cursor-pointer transition-all duration-200',
+                      'hover:bg-matsu-50 focus-visible:outline-none focus-visible:bg-matsu-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-matsu',
+                      // 選択行は藍(ai)の左ボーダーで強調し、緑のホバーと区別 (#190)
+                      selectedPlotId === plot.id && 'bg-ai-50 border-l-4 border-ai',
                       getRowBgColor(plot, absoluteIndex)
                     )}
                     onClick={() => onPlotSelect(plot)}
                     onMouseEnter={() => onPlotHover?.(plot)}
+                    role="link"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        onPlotSelect(plot);
+                      }
+                    }}
+                    aria-label={`${plot.plotNumber} の詳細を開く`}
                   >
-                    <td className="px-2 py-2 text-center">
-                      {getStatusBadge(plot)}
-                    </td>
-                    <td className={cellWrapClass('plotNumber', 'px-2 py-2 font-mono text-matsu font-medium text-xs')} title={plot.plotNumber}>
+                    <td className={cellWrapClass('plotNumber', 'px-2 py-2 font-mono text-matsu font-medium text-xs underline-offset-2 group-hover:underline')} title={plot.plotNumber}>
                       {plot.plotNumber}
                     </td>
                     <td className={cellWrapClass('areaName', 'px-2 py-2 text-xs text-hai')} title={plot.areaName || undefined}>
@@ -339,6 +337,12 @@ export function PlotTable({
                     </td>
                     <td className="px-2 py-2 text-xs text-hai truncate hidden md:table-cell" title={plot.nextBillingDate ? new Date(plot.nextBillingDate).toLocaleDateString('ja-JP', { year: 'numeric', month: 'numeric', day: 'numeric' }) : undefined}>
                       {plot.nextBillingDate ? new Date(plot.nextBillingDate).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' }) : '-'}
+                    </td>
+                    {/* 詳細を開くシェブロン (#163)。行全体クリックでも遷移する */}
+                    <td className="px-2 py-2 text-center text-hai">
+                      <svg className="w-4 h-4 inline-block transition-colors group-hover:text-matsu" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
                     </td>
                   </tr>
                 );

--- a/src/components/plot-registry/index.tsx
+++ b/src/components/plot-registry/index.tsx
@@ -444,6 +444,16 @@ export default function PlotRegistry({
           />
         )}
 
+        {/* 詳細遷移の導線案内 (#163) */}
+        {!isLoading && plots.length > 0 && (
+          <p className="px-3 md:px-6 pt-2 text-xs text-hai flex items-center gap-1">
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            行をクリックすると詳細を開きます
+          </p>
+        )}
+
         <PlotCardList
           plots={plots}
           isLoading={isLoading}


### PR DESCRIPTION
## 概要
台帳問い合わせ・区画詳細・区画残数の表示の分かりにくさ（業務確認不要 UI バッチ）をまとめて改善。

| Issue | 内容 | 対応 |
|---|---|---|
| #163 | 一覧行クリックの詳細遷移が分かりづらい | 行に `role=link`+キーボード操作、末尾にシェブロン列、「行クリックで詳細」案内。カード/テーブル両対応で1クリック遷移を明示 |
| #165 | 入金状態と区画販売状態が混在 | 冗長な先頭「状態」丸印列を廃止し、ラベル付き入金 StatusBadge + 行背景に一本化（未/未入金 重複解消）。詳細は「入金/契約/区画」を区分ラベルで分離 |
| #180 | タブに件数バッジがない | 連絡先・埋葬情報・工事情報・履歴情報に件数バッジを追加（**Refs**） |
| #190 | 淡い緑が多く選択/ホバー/状態が区別しにくい | 選択行を藍(ai)アクセントに変更し、緑(matsu)ホバー・状態色と区別 |
| #172 | 区画残数で初回0件が一瞬見える | サマリKPIをロード中 `--` 表示にして0件フラッシュ防止 |

## 設計メモ
- **#165**: 先頭丸印（未/滞/正）と「入金」ラベル列が両方とも入金状態で重複していたため、ラベル付き `StatusBadge`（色+記号で色覚対応）+ 行背景色に統一。一覧の at-a-glance 性は行背景（滞納=紅/未入金=琥珀）で維持。`status` ソート列は廃止（既定ソートは区画No、影響なし）
- **#180**: 請求/入金タブは子コンポーネントが内部で paginated fetch するため、開く前の総件数はクライアントに無い。サーバ側の件数フィールド追加が必要なため本PRでは連絡先/埋葬/工事/履歴のみ対応し #180 は残課題として継続
- **#190**: 「画面全体の淡い緑」のうち、最も誤認を生む選択行 vs ホバーの競合を解消（選択=藍、ホバー=緑）。状態バッジ・行背景は従来どおり役割別の色

## 検証
- `eslint` 対象ファイル clean / `tsc --noEmit` 該当エラーなし
- `jest src/__tests__/components` 106 pass（既存テスト影響なし）

Closes #163
Closes #165
Closes #172
Closes #190
Refs #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)