### PR TITLE
chore(config): Next.js 開発インジケータを非表示化 (#189)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import path from "path";
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@komine/types'],
+  // 画面右下の Next.js Dev Tools / 開発インジケータを非表示にする (#189)。
+  // 本番ビルドでは元々出ないが、非本番ビルド配信時にも管理画面へ出さないため明示的に無効化。
+  devIndicators: false,
   webpack: (config) => {
     // @komine/types がシンボリンク経由で参照される際、
     // zod をフロントエンドの node_modules から解決する


### PR DESCRIPTION
## 概要
画面右下に出る Next.js Dev Tools / 開発インジケータが管理画面に表示される件 (#189) を解消。

## 変更
`next.config.ts` に `devIndicators: false` を追加（Next 15.2+ の推奨方法）。

## 補足
- 本番ビルド（`next build` + `next start` / Vercel 本番）では元々表示されないが、非本番ビルドで配信された場合にも管理画面へ出さないよう明示的に無効化
- `devIndicators?: false | {...}` は Next 15.5 の型でサポート済み（`tsc` 確認）

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)