### PR TITLE
feat(plots): 日付表記の統一・検索ヒット理由の表示 (#167 #162)

### DIFF
--- a/src/__tests__/lib/format.test.ts
+++ b/src/__tests__/lib/format.test.ts
@@ -4,6 +4,8 @@ import {
   formatPhoneNumber,
   formatPostalCode,
   formatBillingMonth,
+  formatDate,
+  formatYearMonth,
 } from '@/lib/format';
 
 describe('formatCurrency', () => {
@@ -118,5 +120,36 @@ describe('formatBillingMonth', () => {
 
   it('不正な月は未設定を返す', () => {
     expect(formatBillingMonth('202413')).toBe('未設定');
+  });
+});
+
+describe('formatDate', () => {
+  it('ISO日付文字列を YYYY/MM/DD（ゼロ埋め）にする', () => {
+    expect(formatDate('2006-02-09')).toBe('2006/02/09');
+    expect(formatDate('2024-12-31T00:00:00.000Z')).toBe('2024/12/31');
+  });
+
+  it('Date インスタンスも受け付ける', () => {
+    expect(formatDate(new Date(2006, 1, 9))).toBe('2006/02/09');
+  });
+
+  it('null / 空 / 不正値は fallback を返す', () => {
+    expect(formatDate(null)).toBe('-');
+    expect(formatDate(undefined)).toBe('-');
+    expect(formatDate('')).toBe('-');
+    expect(formatDate('not-a-date')).toBe('-');
+    expect(formatDate(null, '未設定')).toBe('未設定');
+  });
+});
+
+describe('formatYearMonth', () => {
+  it('YYYY/MM（ゼロ埋め）にする', () => {
+    expect(formatYearMonth('2006-02-09')).toBe('2006/02');
+    expect(formatYearMonth(new Date(1991, 4, 15))).toBe('1991/05');
+  });
+
+  it('null / 不正値は fallback を返す', () => {
+    expect(formatYearMonth(null)).toBe('-');
+    expect(formatYearMonth('bad')).toBe('-');
   });
 });

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -39,6 +39,7 @@ import {
   formatPhoneNumber,
   formatPostalCode,
   formatBillingMonth,
+  formatDate,
 } from '@/lib/format';
 import { Skeleton } from '@/components/ui/skeleton';
 import { HistoryTab } from '@/components/plot-form/HistoryTab';
@@ -128,20 +129,6 @@ const ACCOUNT_TYPE_LABELS: Record<string, string> = {
 };
 
 // ===== ヘルパー関数 =====
-
-function formatDate(dateStr: string | null | undefined): string {
-  if (!dateStr) return '-';
-  try {
-    const date = new Date(dateStr);
-    return date.toLocaleDateString('ja-JP', {
-      year: 'numeric',
-      month: 'numeric',
-      day: 'numeric',
-    });
-  } catch {
-    return '-';
-  }
-}
 
 function formatPrice(price: number | null | undefined): string {
   return formatCurrency(price);

--- a/src/components/plot-registry/PlotCardList.tsx
+++ b/src/components/plot-registry/PlotCardList.tsx
@@ -4,7 +4,7 @@ import { cn, truncateAddressToCity } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge } from '@/components/ui/status-badge';
 import { PAYMENT_STATUS_LABELS, PAYMENT_STATUS_VARIANTS } from './constants';
-import { formatContractDate, getRowBgColor } from './utils';
+import { formatContractDate, getRowBgColor, getSearchHitReason } from './utils';
 
 interface PlotCardListProps {
   plots: PlotListItem[];
@@ -13,6 +13,8 @@ interface PlotCardListProps {
   selectedPlotId?: string;
   onPlotSelect: (plot: PlotListItem) => void;
   emptyState: ReactNode;
+  /** 検索語。氏名以外でヒットしたカードにヒット理由バッジを出すために使用（#162） */
+  searchQuery?: string;
 }
 
 /** 区画一覧カード（モバイル: md 未満）issue #120 */
@@ -23,6 +25,7 @@ export function PlotCardList({
   selectedPlotId,
   onPlotSelect,
   emptyState,
+  searchQuery,
 }: PlotCardListProps) {
   return (
     <div className="md:hidden flex-1 min-w-0 overflow-auto -mx-1 px-1">
@@ -44,6 +47,7 @@ export function PlotCardList({
           {plots.map((plot, index) => {
             const absoluteIndex = startIndex + index;
             const paymentStatus = plot.paymentStatus as PaymentStatus;
+            const hitReason = getSearchHitReason(plot, searchQuery);
             return (
               <li key={plot.id}>
                 <button
@@ -90,6 +94,11 @@ export function PlotCardList({
                       </div>
                       {plot.customerNameKana && (
                         <div className="text-xs text-hai truncate">{plot.customerNameKana}</div>
+                      )}
+                      {hitReason && (
+                        <span className="mt-0.5 inline-block rounded bg-ai-50 text-ai-700 border border-ai-200 px-1 py-px text-[10px] font-medium leading-tight">
+                          {hitReason}
+                        </span>
                       )}
                     </div>
                     <div className="text-xs text-hai whitespace-nowrap tabular-nums">

--- a/src/components/plot-registry/PlotTable.tsx
+++ b/src/components/plot-registry/PlotTable.tsx
@@ -9,8 +9,8 @@ import {
   type ResizableColumnKey,
 } from '@/lib/plots-column-widths';
 import { PAYMENT_STATUS_LABELS, PAYMENT_STATUS_VARIANTS } from './constants';
-import { formatPhoneNumber } from '@/lib/format';
-import { formatContractDate, formatMoneyString, getRowBgColor } from './utils';
+import { formatPhoneNumber, formatDate } from '@/lib/format';
+import { formatContractDate, formatMoneyString, getRowBgColor, getSearchHitReason } from './utils';
 import { ColumnResizer } from './ColumnResizer';
 import { SortIndicator } from './SortIndicator';
 import type { SortKey, SortOrder } from './types';
@@ -31,6 +31,8 @@ interface PlotTableProps {
   onPlotHover?: (plot: PlotListItem) => void;
   startIndex: number;
   emptyState: ReactNode;
+  /** 検索語。氏名以外でヒットした行にヒット理由バッジを出すために使用（#162） */
+  searchQuery?: string;
 }
 
 /** 区画一覧テーブル（タブレット・PC: md 以上）。 */
@@ -50,6 +52,7 @@ export function PlotTable({
   onPlotHover,
   startIndex,
   emptyState,
+  searchQuery,
 }: PlotTableProps) {
   // <col> へ適用する幅。未設定列は Tailwind の既定幅クラスにフォールバック。
   const colStyle = (key: ResizableColumnKey): CSSProperties | undefined => {
@@ -77,10 +80,10 @@ export function PlotTable({
             {showBuriedPersons && (
               <col className="hidden lg:table-column w-[90px]" style={colStyle('buriedPersons')} />
             )}
-            <col className="hidden sm:table-column w-[60px]" />
+            <col className="hidden sm:table-column w-[64px]" />
             <col className="w-[60px]" />
             <col className="hidden sm:table-column w-[72px]" />
-            <col className="hidden md:table-column w-[60px]" />
+            <col className="hidden md:table-column w-[82px]" />
             <col className="w-[40px]" />
           </colgroup>
           <thead className="bg-gradient-matsu sticky top-0 z-10">
@@ -251,6 +254,7 @@ export function PlotTable({
               plots.map((plot, index) => {
                 const absoluteIndex = startIndex + index;
                 const paymentStatus = plot.paymentStatus as PaymentStatus;
+                const hitReason = getSearchHitReason(plot, searchQuery);
 
                 return (
                   <tr
@@ -288,6 +292,14 @@ export function PlotTable({
                         <div className={cellWrapClass('customerName', 'text-xs text-hai')} title={plot.customerNameKana || undefined}>
                           {plot.customerNameKana || ''}
                         </div>
+                        {hitReason && (
+                          <span
+                            className="mt-0.5 inline-block rounded bg-ai-50 text-ai-700 border border-ai-200 px-1 py-px text-[10px] font-medium leading-tight"
+                            title={`「${searchQuery}」は契約者名以外で一致しました`}
+                          >
+                            {hitReason}
+                          </span>
+                        )}
                       </div>
                     </td>
                     <td className={cellWrapClass('address', 'px-2 py-2 text-xs text-hai hidden md:table-cell')} title={plot.customerAddress || undefined}>
@@ -336,8 +348,8 @@ export function PlotTable({
                     <td className="px-2 py-2 text-xs text-hai text-center hidden sm:table-cell">
                       {formatMoneyString(plot.managementFee)}
                     </td>
-                    <td className="px-2 py-2 text-xs text-hai truncate hidden md:table-cell" title={plot.nextBillingDate ? new Date(plot.nextBillingDate).toLocaleDateString('ja-JP', { year: 'numeric', month: 'numeric', day: 'numeric' }) : undefined}>
-                      {plot.nextBillingDate ? new Date(plot.nextBillingDate).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' }) : '-'}
+                    <td className="px-2 py-2 text-xs text-hai truncate tabular-nums hidden md:table-cell" title={formatDate(plot.nextBillingDate) === '-' ? undefined : formatDate(plot.nextBillingDate)}>
+                      {formatDate(plot.nextBillingDate)}
                     </td>
                     {/* 詳細を開くシェブロン (#163)。行全体クリックでも遷移する */}
                     <td className="px-2 py-2 text-center text-hai">

--- a/src/components/plot-registry/index.tsx
+++ b/src/components/plot-registry/index.tsx
@@ -461,6 +461,7 @@ export default function PlotRegistry({
           selectedPlotId={selectedPlotId}
           onPlotSelect={onPlotSelect}
           emptyState={emptyStateEl}
+          searchQuery={searchQuery}
         />
 
         <PlotTable
@@ -479,6 +480,7 @@ export default function PlotRegistry({
           onPlotHover={onPlotHover}
           startIndex={startIndex}
           emptyState={emptyStateEl}
+          searchQuery={searchQuery}
         />
 
         <PlotPagination

--- a/src/components/plot-registry/utils.tsx
+++ b/src/components/plot-registry/utils.tsx
@@ -1,6 +1,6 @@
 import type { PlotListItem } from '@komine/types';
 import { getPlotDisplayStatus } from '@/lib/api/plots';
-import { formatCurrency } from '@/lib/format';
+import { formatCurrency, formatYearMonth } from '@/lib/format';
 import { SEARCH_HISTORY_KEY, SEARCH_HISTORY_MAX } from './constants';
 
 // ===== 検索履歴 =====
@@ -30,14 +30,31 @@ export function saveSearchHistory(history: string[]) {
 
 // ===== フォーマッタ =====
 
+/** 一覧の契約日。2桁年を廃し共通の {@link formatYearMonth}（YYYY/MM）に統一（#167）。 */
 export function formatContractDate(dateStr: string | null | undefined): string {
-  if (!dateStr) return '-';
-  try {
-    const date = new Date(dateStr);
-    return `${date.getFullYear().toString().slice(-2)}/${date.getMonth() + 1}`;
-  } catch {
-    return '-';
-  }
+  return formatYearMonth(dateStr);
+}
+
+/**
+ * 検索語が「表示中の契約者名」以外でヒットした理由を返す（#162）。
+ * 氏名/フリガナ一致なら null（期待どおりなのでバッジ不要）。
+ * 表示フィールド（区画番号/住所/電話/埋葬者）で一致すればその項目を示し、
+ * いずれも一致しなければ別ロールの氏名等、一覧に出ていない情報での一致とみなす。
+ */
+export function getSearchHitReason(
+  plot: PlotListItem,
+  query: string | null | undefined,
+): string | null {
+  const q = query?.trim().toLowerCase();
+  if (!q) return null;
+  const has = (v: string | null | undefined): boolean => !!v && v.toLowerCase().includes(q);
+
+  if (has(plot.customerName) || has(plot.customerNameKana)) return null;
+  if (has(plot.plotNumber)) return '区画番号に一致';
+  if (has(plot.customerAddress)) return '住所に一致';
+  if (has(plot.customerPhoneNumber)) return '電話番号に一致';
+  if (plot.buriedPersonNames?.some((n) => has(n))) return '埋葬者名に一致';
+  return '関係者情報に一致';
 }
 
 /** @deprecated 共通の {@link formatCurrency} を使用。後方互換のため残置。 */

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -116,3 +116,31 @@ export function formatBillingMonth(
 
   return trimmed;
 }
+
+/**
+ * 日付を「YYYY/MM/DD」（西暦4桁・ゼロ埋め）に統一する。
+ * 2桁年や非ゼロ埋めの表記揺れ（#167）を解消する共通フォーマッタ。
+ * null / 空 / 不正日付は fallback（既定 "-"）。
+ */
+export function formatDate(value: string | Date | null | undefined, fallback: string = DASH): string {
+  if (value === null || value === undefined || value === '') return fallback;
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return fallback;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}/${m}/${day}`;
+}
+
+/**
+ * 年月を「YYYY/MM」（西暦4桁・ゼロ埋め）に統一する。
+ * 一覧の契約日など、日を省きたい狭い列向け（2桁年 "06/2" を廃止）。
+ */
+export function formatYearMonth(value: string | Date | null | undefined, fallback: string = DASH): string {
+  if (value === null || value === undefined || value === '') return fallback;
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return fallback;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  return `${y}/${m}`;
+}


### PR DESCRIPTION
## 概要
台帳問い合わせの表示の正確さに関する2件を対応。

| Issue | 内容 |
|---|---|
| #167 | 日付表記が画面・項目ごとに混在（`06/2`・`91/5`・`2006/2/9`）→ 西暦4桁・ゼロ埋めに統一 |
| #162 | 氏名検索で名前以外（住所・埋葬者等）に一致したレコードが混ざり、理由が分からない |

## #167 日付表記の統一
- `src/lib/format.ts` に **`formatDate`（`YYYY/MM/DD`）** と **`formatYearMonth`（`YYYY/MM`）** を追加（西暦4桁・ゼロ埋め）
- 一覧契約日 `formatContractDate` → `formatYearMonth` に委譲（**2桁年 `06/2` を廃止**）
- 詳細のローカル `formatDate`（`toLocaleDateString`・非ゼロ埋め）→ 共通 `formatDate` に置換
- 一覧の次請求日を直書き `toLocaleDateString` → `formatDate` に統一、列幅を調整
- `format.test.ts` にケース追加（計26件 pass）

## #162 検索ヒット理由の表示
バックエンドの `getPlots` は区画番号・全ロールの氏名/フリガナ/電話/住所・埋葬者名を **OR 横断検索**している（仕様）。そのため「山田」で契約者名に山田を含まない行もヒットし得る。

- **検索スコープは変更せず**、`getSearchHitReason(plot, query)` で「なぜヒットしたか」を可視化
  - 表示中の契約者名/フリガナで一致 → バッジなし（期待どおり）
  - 区画番号/住所/電話/埋葬者名で一致 → その項目名バッジ
  - いずれも非該当 → 「関係者情報に一致」（別ロール氏名など一覧非表示の情報での一致）
- `PlotTable` / `PlotCardList` に `searchQuery` を渡し、藍(ai)系の小バッジで表示

## 検証
- `eslint` clean / `tsc --noEmit` 該当エラーなし
- `jest`（lib + components）363件 pass

Closes #167
Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)