### PR TITLE
feat(plot-detail): 請求・入金タブに件数バッジを追加（#180）

### DIFF
--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -7,7 +7,7 @@
  * Phase 2-B: Plot-centric migration
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { ChevronDown } from 'lucide-react';
 import {
@@ -46,6 +46,8 @@ import { HistoryTab } from '@/components/plot-form/HistoryTab';
 import { useAuth } from '@/contexts/auth-context';
 import BillingManagement from '@/components/billing';
 import PaymentManagement from '@/components/payment';
+import { getBillings } from '@/lib/api/billings';
+import { getPayments } from '@/lib/api/payments';
 
 // ===== 型定義 =====
 
@@ -654,6 +656,34 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
     useMasters();
   const feeMasters: FeeMasters = { calcTypes, taxTypes, billingTypes, paymentMethods };
 
+  // #180: 請求・入金タブの件数バッジ用。子コンポーネントが内部 fetch する構造のため
+  // タブを開く前は件数が分からない問題に対し、limit=1 の軽量 fetch で pagination.totalCount
+  // のみ取得する。CRUD 後の自動更新は無し（次の plot リロードで再取得）。
+  const [billingsCount, setBillingsCount] = useState<number | null>(null);
+  const [paymentsCount, setPaymentsCount] = useState<number | null>(null);
+  useEffect(() => {
+    const contractPlotId = plot?.id;
+    if (!contractPlotId) return;
+    let cancelled = false;
+    setBillingsCount(null);
+    setPaymentsCount(null);
+    Promise.all([
+      getBillings({ contractPlotId, page: 1, limit: 1 }),
+      getPayments({ contractPlotId, page: 1, limit: 1 }),
+    ])
+      .then(([b, p]) => {
+        if (cancelled) return;
+        if (b.success) setBillingsCount(b.data.pagination.totalCount);
+        if (p.success) setPaymentsCount(p.data.pagination.totalCount);
+      })
+      .catch(() => {
+        // 件数取得失敗時はバッジ非表示（null のまま）。
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [plot?.id]);
+
   if (isLoading) {
     return (
       <div className="space-y-4 p-4">
@@ -914,9 +944,11 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
           </TabsTrigger>
           <TabsTrigger value="billing" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             請求
+            {billingsCount !== null && <TabCount count={billingsCount} />}
           </TabsTrigger>
           <TabsTrigger value="payment" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             入金
+            {paymentsCount !== null && <TabCount count={paymentsCount} />}
           </TabsTrigger>
           <TabsTrigger value="history" className="shrink-0 sm:shrink snap-start px-3 sm:px-2 py-2 text-xs sm:text-sm whitespace-nowrap data-[state=active]:bg-matsu data-[state=active]:text-white">
             履歴情報


### PR DESCRIPTION
**Closes #180**

#199 で連絡先・埋葬・工事・履歴の各タブには件数バッジを追加済みでしたが、請求・入金タブは子コンポーネント（BillingManagement / PaymentManagement）が**内部で paginated fetch する構造**のため、タブを開く前は件数が親に存在せず未対応でした。

issue コメントで「API 側にサマリ件数を追加する案が望ましい」と書いていましたが、既存の \`/billings\` / \`/payments\` エンドポイントがどちらも \`contractPlotId\` フィルタと \`pagination.totalCount\` を返すため、**詳細ロード時に \`limit=1\` の軽量 fetch で件数のみ取得する frontend 完結のアプローチ**で対応しました。types / backend 変更不要。

## 実装

- \`plot-detail-view.tsx\` のみ変更:
  - \`billingsCount\` / \`paymentsCount\` の \`useState<number | null>\`（null=未取得）
  - \`plot.id\` 確定時に \`Promise.all([getBillings, getPayments])\` を \`{ contractPlotId, page: 1, limit: 1 }\` で並列実行し \`pagination.totalCount\` を抽出
  - 取得失敗時はバッジ非表示（null のまま）、unmount 時の setState 防止に \`cancelled\` フラグ
  - \`<TabsTrigger value=\"billing\">\` / \`value=\"payment\"\` に \`<TabCount>\` を **条件付き描画**（\`!== null\` チェックでロード中の 0 件フラッシュを防止）

## 既知の制約

- タブ内 CRUD（請求作成・入金記録など）後の**件数自動更新は無し**。次の plot リロード（編集後の再表示等）で再取得されます。
- 即時更新が必要な場合は BillingManagement / PaymentManagement から件数を上方向に通知する callback を追加可能ですが、本 PR では最小スコープに留めました。

## トレードオフ

- BillingManagement / PaymentManagement は Tabs の構造上タブ非アクティブでもマウントされ独自に fetch するため、件数取得との重複 fetch が発生します。ただし**件数側は \`limit=1\` で payload 最小**のため実質的な負荷増は軽微です。

## 検証

- \`npm run lint\`: ✅ clean
- \`npx tsc --noEmit\`: ✅ clean
- \`npm test\`: ✅ 371/371 pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)