### PR TITLE
fix(plot-detail): 未収金額の矛盾表示を解消（請求未生成注記） (#170)

### DIFF
--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -838,6 +838,11 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
               {formatNumber(plot.uncollectedAmount ?? 0)}
               <span className="text-xs md:text-sm text-hai ml-1 font-normal">円</span>
             </p>
+            {/* 未収0 かつ未入金 = まだ請求が起票されていない（#170）。矛盾に見えるため理由を明示。 */}
+            {(plot.uncollectedAmount ?? 0) === 0 &&
+              plot.paymentStatus === PaymentStatus.Unpaid && (
+                <p className="mt-0.5 text-[10px] md:text-xs text-hai">請求未生成</p>
+              )}
           </div>
           {/* 直近請求月（管理料） */}
           <div className="min-w-0">


### PR DESCRIPTION
## 概要
frontend #170 の表示改善。台帳詳細サマリーで「未収0＋未入金バッジ」が矛盾して見える問題に対し、請求未起票が理由であることを「請求未生成」注記で明示する。

未収金額自体を請求実績から導出してサマリーとタブの整合を取るコア対応は backend/types 側（下記）。本PRはその表示面。

## 変更
- `plot-detail-view.tsx`: 未収0 && 未入金 のとき「請求未生成」注記（`billingsCount` 非依存、既存フィールドのみで判定）

## 受け入れ条件
- [x] 未入金かつ管理料設定ありの区画で、サマリーと詳細タブの金額が矛盾しない（backend 導出で担保）
- [x] データ未連携時にユーザーに理由が伝わる（請求未生成注記）

## 関連
- backend: 未収金額を請求実績から導出（zaitsu82/komine-crm-backend#195）
- types: zaitsu82/komine-types#30

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)