### PR TITLE
fix(plot-detail): 請求タブが空の理由を説明し料金設定サマリーを表示 (#171)

### DIFF
--- a/src/__tests__/components/billing-list-table.test.tsx
+++ b/src/__tests__/components/billing-list-table.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BillingListTable } from '@/components/billing/billing-list-table';
+
+/**
+ * #171: 請求一覧の空状態テスト
+ * - emptyState 未指定時は既定メッセージ
+ * - emptyState 指定時は文脈付き説明を表示（理由・次のアクション）
+ */
+describe('BillingListTable empty state', () => {
+  it('items が空で emptyState 未指定なら既定メッセージを表示する', () => {
+    render(<BillingListTable items={[]} />);
+    expect(screen.getByText('請求データがありません')).toBeInTheDocument();
+  });
+
+  it('items が空で emptyState 指定なら、その文脈付きノードを表示し既定メッセージは出さない', () => {
+    render(
+      <BillingListTable
+        items={[]}
+        emptyState={
+          <div>
+            <p>発行済みの請求はありません</p>
+            <p>「新規登録」から請求を追加してください</p>
+          </div>
+        }
+      />
+    );
+    expect(screen.getByText('発行済みの請求はありません')).toBeInTheDocument();
+    expect(screen.getByText(/新規登録/)).toBeInTheDocument();
+    expect(screen.queryByText('請求データがありません')).not.toBeInTheDocument();
+  });
+
+  it('読み込み中は emptyState ではなくローディング表示を出す', () => {
+    render(
+      <BillingListTable
+        items={[]}
+        isLoading
+        emptyState={<p>発行済みの請求はありません</p>}
+      />
+    );
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    expect(screen.queryByText('発行済みの請求はありません')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/billing/billing-list-table.tsx
+++ b/src/components/billing/billing-list-table.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { Billing } from '@komine/types';
 import { BILLING_CATEGORY_LABELS, BILLING_RECORD_STATUS_LABELS } from '@/lib/api/billings';
 
@@ -32,6 +33,8 @@ export interface BillingListTableProps {
   onView?: (billing: Billing) => void;
   /** 区画コンテキストで表示するときは true → 区画情報カラムを非表示 */
   hidePlotColumns?: boolean;
+  /** 一覧が空のときに表示するノード（未指定時は既定メッセージ）。#171 で文脈付き説明を差し込む用 */
+  emptyState?: ReactNode;
 }
 
 export function BillingListTable({
@@ -41,6 +44,7 @@ export function BillingListTable({
   onDelete,
   onView,
   hidePlotColumns = false,
+  emptyState,
 }: BillingListTableProps) {
   if (isLoading) {
     return (
@@ -52,6 +56,9 @@ export function BillingListTable({
   }
 
   if (items.length === 0) {
+    if (emptyState) {
+      return <div className="p-4 md:p-6">{emptyState}</div>;
+    }
     return (
       <div className="p-12 text-center text-hai">
         <p className="text-sm">請求データがありません</p>

--- a/src/components/billing/billing-management.tsx
+++ b/src/components/billing/billing-management.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   Billing,
   BillingCategory,
@@ -36,12 +36,15 @@ export interface BillingManagementProps {
   customerId?: string;
   /** ページヘッダを表示するか（埋め込み時は false） */
   showHeader?: boolean;
+  /** 一覧が空のときに表示する文脈付き空状態（#171）。未指定時は既定メッセージ */
+  emptyState?: ReactNode;
 }
 
 export default function BillingManagement({
   contractPlotId,
   customerId,
   showHeader = true,
+  emptyState,
 }: BillingManagementProps) {
   const [items, setItems] = useState<Billing[]>([]);
   const [total, setTotal] = useState(0);
@@ -249,6 +252,7 @@ export default function BillingManagement({
             items={items}
             isLoading={isLoading}
             hidePlotColumns={Boolean(contractPlotId)}
+            emptyState={emptyState}
             onView={(b) => setDetailId(b.id)}
             onEdit={(b) => {
               setEditing(b);

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -42,6 +42,7 @@ import {
   formatDate,
 } from '@/lib/format';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { HistoryTab } from '@/components/plot-form/HistoryTab';
 import { useAuth } from '@/contexts/auth-context';
 import BillingManagement from '@/components/billing';
@@ -395,6 +396,85 @@ function FeeInfoTab({ plot, masters }: { plot: PlotDetailResponse; masters: FeeM
           </div>
         </Section>
       )}
+    </div>
+  );
+}
+
+/**
+ * 請求タブ（#171）
+ *
+ * paymentStatus / uncollectedAmount は請求レコードからの派生値のため、
+ * 料金（管理料・使用料）設定はあっても請求書が未起票だと
+ * 「未入金・管理料あり」かつ請求一覧が空、という一見矛盾した状態になる。
+ * これはバグではなく「請求未起票」の正常状態なので、
+ * 上部に料金設定サマリーと関係性の説明を、空一覧には理由と次のアクションを示す。
+ */
+function BillingTabPanel({
+  plot,
+  customerId,
+}: {
+  plot: PlotDetailResponse;
+  customerId?: string;
+}) {
+  const hasFeeConfig = Boolean(plot.usageFee || plot.managementFee);
+
+  const emptyState = (
+    <EmptyState
+      icon={
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+      }
+      title="発行済みの請求はありません"
+      description={
+        hasFeeConfig
+          ? '料金（管理料・使用料）の設定はありますが、請求（請求書）はまだ起票されていません。設定があっても請求は自動では作成されないため、上の「新規登録」から請求を追加してください。'
+          : '料金設定・請求ともに未登録です。料金情報を登録のうえ、上の「新規登録」から請求を起票してください。'
+      }
+    />
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* 料金設定サマリー：請求レコードとの関係を明示（#171） */}
+      {hasFeeConfig && (
+        <div className="rounded-elegant-lg border border-cha-200 bg-cha-50 p-3 md:p-4">
+          <p className="text-sm font-semibold text-sumi mb-2">料金設定（請求の元）</p>
+          <div className="flex flex-wrap gap-x-6 gap-y-1.5 text-sm text-sumi">
+            {plot.managementFee && (
+              <span>
+                管理料{' '}
+                <span className="font-semibold tabular-nums">
+                  {formatCurrency(plot.managementFee.managementFee)}
+                </span>
+                {plot.managementFee.billingMonth
+                  ? `（毎年${plot.managementFee.billingMonth}月請求）`
+                  : ''}
+              </span>
+            )}
+            {plot.usageFee && (
+              <span>
+                使用料{' '}
+                <span className="font-semibold tabular-nums">
+                  {formatCurrency(plot.usageFee.usageFee)}
+                </span>
+              </span>
+            )}
+          </div>
+          <p className="mt-2 text-xs text-hai">
+            これは料金の「設定」です。実際の請求（請求書）は下の一覧で管理します。設定があっても請求は自動では作成されないため、「未入金」でも請求が無い場合は「新規登録」から起票してください。
+          </p>
+        </div>
+      )}
+
+      <div className="bg-white border border-gin rounded-elegant-lg overflow-hidden">
+        <BillingManagement
+          contractPlotId={plot.id}
+          customerId={customerId}
+          showHeader={false}
+          emptyState={emptyState}
+        />
+      </div>
     </div>
   );
 }
@@ -982,16 +1062,13 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
         </TabsContent>
 
         <TabsContent value="billing" className="mt-4 md:mt-6">
-          <div className="bg-white border border-gin rounded-elegant-lg overflow-hidden">
-            <BillingManagement
-              contractPlotId={plot.id}
-              customerId={
-                plot.roles.find((r) => r.role === ContractRole.Contractor)?.customer.id ??
-                plot.roles[0]?.customer.id
-              }
-              showHeader={false}
-            />
-          </div>
+          <BillingTabPanel
+            plot={plot}
+            customerId={
+              plot.roles.find((r) => r.role === ContractRole.Contractor)?.customer.id ??
+              plot.roles[0]?.customer.id
+            }
+          />
         </TabsContent>
 
         <TabsContent value="payment" className="mt-4 md:mt-6">


### PR DESCRIPTION
## 概要

Closes #171

台帳詳細の「請求」タブが空なのに基本情報では「未入金・管理料あり」と表示され、理由が利用者に伝わらない問題を改善する。

## 指摘の妥当性（調査結果）

**妥当**。ただし *データバグではなく説明不足* が本質。

- `paymentStatus` / `uncollectedAmount` は #162 / #170 以降、**請求レコードからの派生値**（backend `paymentStatusLogic.ts`）。請求0件 → `unpaid` / 未収0 に評価される。
- 一方「管理料あり」は ManagementFee 設定テーブル由来。
- つまり「未入金・管理料あり・請求タブ空」は **「料金設定はあるが請求書が未起票」という正常状態**（管理料/使用料の請求自動生成バッチは存在せず、`POST /api/v1/billings`＝「新規登録」での手動起票のみ）。
- #170 でサマリーヘッダーに「請求未生成」注記は入ったが、**請求タブ内**は素の「請求データがありません」のままで理由が分からなかった → 本PRで対応。
- issue の原因分析はほぼ正しい（唯一「paymentStatus は ContractPlot の生フィールド」は派生値化で古くなったが結論は同じ）。

## 変更内容

- 請求タブ上部に**料金設定サマリー**（管理料・使用料の金額／請求月）を追加し、「設定」と「請求レコード」の関係・次のアクションを説明
- 請求一覧の**空状態を文脈付き**に変更（`BillingListTable` に `emptyState` prop を追加）。「発行済みの請求はありません」＋理由＋「新規登録」への導線を表示
- 既存の汎用空状態は `emptyState` 未指定時の既定として維持
- `BillingListTable` の空状態テストを追加

## 受け入れ条件

- [x] 未入金区画で請求タブが空の場合、理由が説明される
- [x] 管理料設定と請求レコードの関係が利用者に理解できる

## 検証

- `npx tsc --noEmit` ✅ / `npx eslint`（変更3ファイル）✅
- `npx jest src/__tests__/components` → 109 passed（新規 `billing-list-table.test.tsx` 3件含む）✅
- レスポンシブ: サマリーは `flex-wrap` + `p-3 md:p-6`、空状態は共通 `EmptyState`（375px 対応）

## スコープ外

- 管理料/使用料の**年度請求自動生成バッチ**は backend 未実装（issue 関連ファイルに記載のとおり別途要検討）。本PRはフロントエンドの説明・導線改善に限定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)