### PR TITLE
fix(collective-burial): デモデータ明示と合祀⇔台帳モックの整合 (#176)

### DIFF
--- a/src/__tests__/components/mock-data-banner.test.tsx
+++ b/src/__tests__/components/mock-data-banner.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const mockShouldUseMockData = jest.fn();
+jest.mock('@/lib/api/client', () => ({
+  __esModule: true,
+  shouldUseMockData: () => mockShouldUseMockData(),
+}));
+
+import MockDataBanner from '@/components/mock-data-banner';
+
+/**
+ * #176: デモデータ表示中バナー
+ */
+describe('MockDataBanner', () => {
+  afterEach(() => mockShouldUseMockData.mockReset());
+
+  it('モックデータ無効時は何も描画しない（本番相当）', () => {
+    mockShouldUseMockData.mockReturnValue(false);
+    const { container } = render(<MockDataBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('モックデータ有効時はデモデータ表示中であることを明示する', () => {
+    mockShouldUseMockData.mockReturnValue(true);
+    render(<MockDataBanner />);
+    expect(screen.getByText('デモデータ表示中')).toBeInTheDocument();
+    expect(
+      screen.getByText(/実際の台帳・契約・顧客とは紐づいていません/)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/lib/api/collective-burial-mock-consistency.test.ts
+++ b/src/__tests__/lib/api/collective-burial-mock-consistency.test.ts
@@ -1,0 +1,38 @@
+jest.mock('@/lib/api/client', () => {
+  const actual = jest.requireActual('@/lib/api/client');
+  return { __esModule: true, ...actual, shouldUseMockData: () => true };
+});
+
+import { ContractRole } from '@komine/types';
+import { getCollectiveBurialList } from '@/lib/api/collective-burials';
+import { getPlotById } from '@/lib/api/plots';
+
+/**
+ * #176: 合祀モックと台帳（plots）モックが同一区画・同一契約者を指すことを保証する。
+ * これが崩れると「合祀管理と台帳問い合わせが別世界のサンプルに見える」状態が再発する。
+ */
+describe('合祀モック ⇔ 台帳モックの整合 (#176)', () => {
+  it('各合祀レコードの contractPlotId が台帳に解決し、plotNumber と契約者名が一致する', async () => {
+    const list = await getCollectiveBurialList();
+    expect(list.success).toBe(true);
+    if (!list.success) return;
+
+    expect(list.data.items.length).toBeGreaterThan(0);
+
+    for (const cb of list.data.items) {
+      // 合祀一覧 → 台帳詳細への遷移リンク（/plots/[contractPlotId]）が解決する
+      const plot = await getPlotById(cb.contractPlotId);
+      expect(plot.success).toBe(true);
+      if (!plot.success) continue;
+
+      // 区画番号が両画面で一致する
+      expect(plot.data.physicalPlot.plotNumber).toBe(cb.plotNumber);
+
+      // 契約者名が両画面で一致する
+      const contractor = plot.data.roles.find(
+        (r) => r.role === ContractRole.Contractor
+      );
+      expect(contractor?.customer.name).toBe(cb.applicantName);
+    }
+  });
+});

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { AuthGuard } from '@/components/auth-guard';
 import GlobalSidebar from '@/components/layout/GlobalSidebar';
+import MockDataBanner from '@/components/mock-data-banner';
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -27,6 +28,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
         />
 
         <div className={`flex-1 min-w-0 flex flex-col ml-0 ${sidebarWidth} transition-all duration-300`}>
+          <MockDataBanner />
           {children}
         </div>
       </div>

--- a/src/components/mock-data-banner.tsx
+++ b/src/components/mock-data-banner.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { shouldUseMockData } from '@/lib/api/client';
+
+/**
+ * デモ（モック）データ表示中であることを全画面で明示するバナー（#176）
+ *
+ * `NEXT_PUBLIC_USE_MOCK_DATA=true` のとき、画面のデータはサンプルで
+ * 実際の台帳・契約・顧客とは紐づいていない。台帳と合祀など画面間で
+ * データが食い違って「別世界のサンプルに見える」混乱を防ぐため、
+ * デモデータであることを常時明示する。本番（フラグ false）では何も描画しない。
+ */
+export default function MockDataBanner() {
+  if (!shouldUseMockData()) return null;
+
+  return (
+    <div
+      role="status"
+      className="shrink-0 flex items-center gap-2 bg-kohaku-50 border-b border-kohaku-200 px-3 md:px-6 py-1.5 text-kohaku-dark"
+    >
+      <svg
+        className="w-4 h-4 shrink-0"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+        />
+      </svg>
+      <p className="text-[11px] md:text-xs leading-snug">
+        <span className="font-semibold">デモデータ表示中</span>
+        <span className="ml-2">
+          画面のデータはサンプルです。実際の台帳・契約・顧客とは紐づいていません。
+        </span>
+      </p>
+    </div>
+  );
+}

--- a/src/lib/api/collective-burials.ts
+++ b/src/lib/api/collective-burials.ts
@@ -138,74 +138,55 @@ export interface CollectiveBurialSearchParams {
 // モックデータ
 // ============================================================
 
+// 台帳（plots.ts の mockPlots）と同一区画・同一契約者を指すよう整合させる（#176）。
+// contractPlotId は mockPlots の id と一致させ、合祀一覧 → 台帳詳細への遷移が解決し、
+// plotNumber / 契約者名が両画面で一致するようにする。
 const mockCollectiveBurials: CollectiveBurialListItem[] = [
   {
     id: 'cb-001',
-    contractPlotId: 'cp-001',
+    contractPlotId: 'mock-plot-1', // 台帳: A-001 / 田中太郎
     plotNumber: 'A-001',
     areaName: '第1期',
-    contractDate: '2020-01-15',
-    applicantName: '山田 太郎',
-    applicantNameKana: 'ヤマダ タロウ',
+    contractDate: '2020-04-01',
+    applicantName: '田中太郎',
+    applicantNameKana: 'タナカタロウ',
     burialCapacity: 10,
-    currentBurialCount: 5,
+    currentBurialCount: 3,
     capacityReachedDate: null,
     validityPeriodYears: 33,
-    billingScheduledDate: '2057-01-15',
+    billingScheduledDate: '2053-04-01',
     billingStatus: 'pending',
     billingAmount: 300000,
     notes: null,
     buriedPersons: [
-      { id: 'bp-001', name: '山田 一郎', burialDate: '2020-03-15' },
-      { id: 'bp-002', name: '山田 花子', burialDate: '2022-08-20' },
+      { id: 'bp-001', name: '田中一郎', burialDate: '2020-05-10' },
+      { id: 'bp-002', name: '田中梅', burialDate: '2022-08-20' },
     ],
-    createdAt: '2024-01-15T09:00:00Z',
+    createdAt: '2020-04-01T09:00:00Z',
     updatedAt: '2024-06-20T14:30:00Z',
   },
   {
     id: 'cb-002',
-    contractPlotId: 'cp-002',
+    contractPlotId: 'mock-plot-2', // 台帳: B-015 / 鈴木花子
     plotNumber: 'B-015',
     areaName: '第2期',
-    contractDate: '2021-04-01',
-    applicantName: '佐藤 健一',
-    applicantNameKana: 'サトウ ケンイチ',
+    contractDate: '2022-08-15',
+    applicantName: '鈴木花子',
+    applicantNameKana: 'スズキハナコ',
     burialCapacity: 8,
     currentBurialCount: 8,
-    capacityReachedDate: '2023-11-01',
+    capacityReachedDate: '2024-02-20',
     validityPeriodYears: 13,
-    billingScheduledDate: '2036-11-01',
-    billingStatus: 'pending',
+    billingScheduledDate: '2037-02-20',
+    billingStatus: 'billed',
     billingAmount: 250000,
     notes: '上限到達済み',
     buriedPersons: [
-      { id: 'bp-003', name: '佐藤 次郎', burialDate: '2021-05-10' },
-      { id: 'bp-004', name: '佐藤 美智子', burialDate: '2023-11-01' },
+      { id: 'bp-003', name: '鈴木次郎', burialDate: '2022-09-10' },
+      { id: 'bp-004', name: '鈴木美智子', burialDate: '2024-02-20' },
     ],
-    createdAt: '2021-04-01T10:00:00Z',
-    updatedAt: '2023-11-01T16:00:00Z',
-  },
-  {
-    id: 'cb-003',
-    contractPlotId: 'cp-003',
-    plotNumber: 'C-102',
-    areaName: '第3期',
-    contractDate: '2014-12-01',
-    applicantName: '鈴木 一郎',
-    applicantNameKana: 'スズキ イチロウ',
-    burialCapacity: 6,
-    currentBurialCount: 6,
-    capacityReachedDate: '2020-06-15',
-    validityPeriodYears: 7,
-    billingScheduledDate: '2027-06-15',
-    billingStatus: 'billed',
-    billingAmount: 200000,
-    notes: '請求書送付済み',
-    buriedPersons: [
-      { id: 'bp-005', name: '鈴木 三郎', burialDate: '2018-01-20' },
-    ],
-    createdAt: '2014-12-01T11:00:00Z',
-    updatedAt: '2027-01-10T09:00:00Z',
+    createdAt: '2022-08-15T10:00:00Z',
+    updatedAt: '2024-02-20T16:00:00Z',
   },
 ];
 
@@ -337,7 +318,7 @@ export async function getCollectiveBurialById(
 
     const detail: CollectiveBurialDetail = {
       ...item,
-      contractDate: '2024-01-15',
+      contractDate: item.contractDate,
       applicant: item.applicantName
         ? {
           id: 'cust-001',


### PR DESCRIPTION
## 概要

Closes #176

合祀管理（例: 山田花子 / A-001）と台帳問い合わせ（例: legacy-101 / エリア 1-29）が「別世界のサンプル」に見え、実データとして信頼できない印象を与える問題に対応。

## 指摘の妥当性（調査結果）

**妥当**。ただし発生条件は **モックデータ有効環境（`NEXT_PUBLIC_USE_MOCK_DATA=true`）に限定**される。

- `shouldUseMockData()` は `NEXT_PUBLIC_USE_MOCK_DATA` のグローバルフラグ。`.env` は `false`（実バックエンド参照）。
- 台帳の `legacy-101 / エリア 1-29` は実バックエンド（レガシー移行）データ。`A-001 / 山田花子` は合祀のモックデータそのもの。両者が同時に見えるのは **環境/ビルドの混在**（issue 記載の通り）。
- モック有効時の実害が2つ実在した:
  1. 同じ `A-001` が台帳モックでは「田中太郎」、合祀モックでは「山田太郎」と食い違う
  2. 合祀→台帳の遷移リンク `/plots/${contractPlotId}` が `cp-001`（台帳モックに存在しない）を指し**リンク切れ**
- 本番（フラグ `false`）では両画面とも実バックエンドを参照するため不整合は出ない。問題はデモ/本番の区別が画面で分からないこと。

## 変更内容

- **`MockDataBanner` を追加**（`src/components/mock-data-banner.tsx`）。`shouldUseMockData()` が true のとき全認証画面の上部に「デモデータ表示中 — 画面のデータはサンプルです。実際の台帳・契約・顧客とは紐づいていません。」を常時表示。本番では何も描画しない。`src/app/(main)/layout.tsx` に組み込み。
- **合祀モックを台帳モック（`plots.ts`）と整合**。`contractPlotId` を `mock-plot-1` / `mock-plot-2` に合わせ、`plotNumber`・契約者名を一致（A-001/田中太郎、B-015/鈴木花子）。これで合祀一覧→台帳詳細の遷移が解決し、両画面で区画番号・契約者名が一致。対応する台帳の無い C-102 エントリは削除。
- 合祀詳細モックの `contractDate` ハードコードを一覧と一致させた。
- 回帰テスト追加（バナー表示制御 / 合祀⇔台帳モックの整合検証）。

## 受け入れ条件

- [x] 合祀と台帳で同一区画の plotNumber / 顧客名が一致する（モック整合 + テストで担保）
- [x] デモデータと本番データの区別が管理者に伝わる（MockDataBanner）

## 検証

- `npx tsc --noEmit` ✅ / `npx eslint`（変更ファイル）✅
- `npx jest` → 377 passed（新規3件含む）✅
  - 合祀⇔台帳整合テスト: 各合祀レコードの `contractPlotId` が台帳に解決し plotNumber・契約者名が一致することを検証
- レスポンシブ: バナーは `text-[11px] md:text-xs` + `px-3 md:px-6`（375px 対応）

## 補足

合祀一覧→台帳詳細への遷移導線は既存（`ListView.tsx`、#188）。本PRはその遷移先がモック時に解決するようデータを整合させた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)