### PR TITLE
fix(plot-detail): 料金情報の旧コードをマスタ名へ解決し未解決値を明示 (#177)

### DIFF
--- a/src/__tests__/lib/master-resolve.test.ts
+++ b/src/__tests__/lib/master-resolve.test.ts
@@ -1,0 +1,55 @@
+import { resolveMasterName, LEGACY_FEE_CODE_MAP } from '@/lib/master-resolve';
+import type { MasterItem } from '@/lib/api/masters';
+
+const calcTypes: MasterItem[] = [
+  { id: 1, code: 'AREA', name: '面積×単価', description: null, sortOrder: 1, isActive: true },
+  { id: 2, code: 'FIXED', name: '任意設定', description: null, sortOrder: 2, isActive: true },
+];
+const taxTypes: MasterItem[] = [
+  { id: 1, code: 'INCLUSIVE', name: '内税', description: null, sortOrder: 1, isActive: true },
+  { id: 2, code: 'EXCLUSIVE', name: '外税', description: null, sortOrder: 2, isActive: true },
+];
+const directions: MasterItem[] = [
+  { id: 1, code: '1', name: '東', description: null, sortOrder: 1, isActive: true },
+  { id: 2, code: '2', name: '西', description: null, sortOrder: 2, isActive: true },
+];
+
+describe('resolveMasterName (#177)', () => {
+  it('null / 空文字は null を返す', () => {
+    expect(resolveMasterName(calcTypes, null)).toBeNull();
+    expect(resolveMasterName(calcTypes, undefined)).toBeNull();
+    expect(resolveMasterName(calcTypes, '')).toBeNull();
+  });
+
+  it('master code 一致でマスタ名を返す（新規データ）', () => {
+    expect(resolveMasterName(calcTypes, 'AREA', LEGACY_FEE_CODE_MAP.calc)).toBe('面積×単価');
+    expect(resolveMasterName(taxTypes, 'INCLUSIVE', LEGACY_FEE_CODE_MAP.tax)).toBe('内税');
+  });
+
+  it('旧int値を移行マップで正規化して正しいマスタ名に解決する', () => {
+    // calc: 0→AREA(面積×単価), 1→FIXED(任意設定)。id 一致の off-by-one 誤マッチを起こさない。
+    expect(resolveMasterName(calcTypes, '0', LEGACY_FEE_CODE_MAP.calc)).toBe('面積×単価');
+    expect(resolveMasterName(calcTypes, '1', LEGACY_FEE_CODE_MAP.calc)).toBe('任意設定');
+    // tax: 0→内税, 1→外税
+    expect(resolveMasterName(taxTypes, '0', LEGACY_FEE_CODE_MAP.tax)).toBe('内税');
+    expect(resolveMasterName(taxTypes, '1', LEGACY_FEE_CODE_MAP.tax)).toBe('外税');
+  });
+
+  it('マスタ未登録時は素の数値を残さず元の保存値を「旧コード: X」と明示する', () => {
+    // マスタが空（未 seed 環境）→ 正規化はするが解決できないので元値を明示
+    expect(resolveMasterName([], '1', LEGACY_FEE_CODE_MAP.calc)).toBe('旧コード: 1');
+    // legacyMap に無い未知コード
+    expect(resolveMasterName(calcTypes, '99', LEGACY_FEE_CODE_MAP.calc)).toBe('旧コード: 99');
+    // 送付方法（マップ無し・意味不明な旧コード）
+    expect(resolveMasterName([], '1')).toBe('旧コード: 1');
+  });
+
+  it('移行センチネル legacy-{prefix}-{value} は末尾の元値のみ表示する', () => {
+    expect(resolveMasterName([], 'legacy-shiharai-3')).toBe('旧コード: 3');
+  });
+
+  it('id 参照のマスタ（方位・位置）は legacyMap 無しで従来どおり解決する', () => {
+    expect(resolveMasterName(directions, '1')).toBe('東');
+    expect(resolveMasterName(directions, '2')).toBe('西');
+  });
+});

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -23,6 +23,7 @@ import {
 import { usePlotDetail } from '@/hooks/usePlots';
 import { useMasters } from '@/hooks/useMasters';
 import type { MasterItem, TaxTypeMasterItem } from '@/lib/api/masters';
+import { resolveMasterName, LEGACY_FEE_CODE_MAP } from '@/lib/master-resolve';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -135,25 +136,6 @@ const ACCOUNT_TYPE_LABELS: Record<string, string> = {
 
 function formatPrice(price: number | null | undefined): string {
   return formatCurrency(price);
-}
-
-/**
- * Master 名解決ヘルパー。
- * legacy migration が int 文字列 ("1" "2" 等) を格納している区分系フィールドと、
- * 新規入力で master code ("AREA" 等) を格納する場合の両方に対応するため、
- * id 一致 → code 一致 → raw 値 の順に試す。
- * master に無い既存値はそのまま表示して欠落を防ぐ。
- */
-function resolveMasterName(
-  masters: ReadonlyArray<MasterItem | TaxTypeMasterItem>,
-  value: string | null | undefined,
-): string | null {
-  if (value == null || value === '') return null;
-  const byId = masters.find((m) => m.id.toString() === value);
-  if (byId) return byId.name;
-  const byCode = masters.find((m) => m.code === value);
-  if (byCode) return byCode.name;
-  return value;
 }
 
 interface FeeMasters {
@@ -362,9 +344,9 @@ function FeeInfoTab({ plot, masters }: { plot: PlotDetailResponse; masters: FeeM
       {/* 使用料 */}
       {plot.usageFee && (
         <Section title="使用料">
-          <InfoField label="計算タイプ" value={resolveMasterName(masters.calcTypes, plot.usageFee.calculationType)} />
-          <InfoField label="税区分" value={resolveMasterName(masters.taxTypes, plot.usageFee.taxType)} />
-          <InfoField label="請求タイプ" value={resolveMasterName(masters.billingTypes, plot.usageFee.billingType)} />
+          <InfoField label="計算タイプ" value={resolveMasterName(masters.calcTypes, plot.usageFee.calculationType, LEGACY_FEE_CODE_MAP.calc)} />
+          <InfoField label="税区分" value={resolveMasterName(masters.taxTypes, plot.usageFee.taxType, LEGACY_FEE_CODE_MAP.tax)} />
+          <InfoField label="請求タイプ" value={resolveMasterName(masters.billingTypes, plot.usageFee.billingType, LEGACY_FEE_CODE_MAP.billing)} />
           <InfoField label="請求年数" value={plot.usageFee.billingYears?.toString()} />
           <InfoField label="面積" value={plot.usageFee.area} />
           <InfoField label="単価" value={formatCurrency(plot.usageFee.unitPrice)} />
@@ -376,9 +358,9 @@ function FeeInfoTab({ plot, masters }: { plot: PlotDetailResponse; masters: FeeM
       {/* 管理料 */}
       {plot.managementFee && (
         <Section title="管理料">
-          <InfoField label="計算タイプ" value={resolveMasterName(masters.calcTypes, plot.managementFee.calculationType)} />
-          <InfoField label="税区分" value={resolveMasterName(masters.taxTypes, plot.managementFee.taxType)} />
-          <InfoField label="請求タイプ" value={resolveMasterName(masters.billingTypes, plot.managementFee.billingType)} />
+          <InfoField label="計算タイプ" value={resolveMasterName(masters.calcTypes, plot.managementFee.calculationType, LEGACY_FEE_CODE_MAP.calc)} />
+          <InfoField label="税区分" value={resolveMasterName(masters.taxTypes, plot.managementFee.taxType, LEGACY_FEE_CODE_MAP.tax)} />
+          <InfoField label="請求タイプ" value={resolveMasterName(masters.billingTypes, plot.managementFee.billingType, LEGACY_FEE_CODE_MAP.billing)} />
           <InfoField label="請求年数" value={plot.managementFee.billingYears?.toString()} />
           <InfoField label="面積" value={plot.managementFee.area} />
           <InfoField label="請求月" value={plot.managementFee.billingMonth?.toString()} />

--- a/src/lib/master-resolve.ts
+++ b/src/lib/master-resolve.ts
@@ -1,0 +1,55 @@
+import type { MasterItem, TaxTypeMasterItem } from '@/lib/api/masters';
+
+/**
+ * 旧システムの int コード → 新マスタ code への対応表（#177）。
+ *
+ * バックエンドの移行スクリプト `scripts/legacy-migration/steps/05-contract-plot.ts`
+ * の CALC_TYPE_MAP / TAX_TYPE_MAP / BILLING_TYPE_MAP と同一定義。
+ * 料金フィールド（計算タイプ・税区分・請求タイプ）は新規入力では master code
+ * （"AREA" 等）を保存する（plot-form/FeeInfoTab）。したがって数値文字列が残るのは
+ * 未 remap の旧データのみなので、ここで正規化しても新規データを壊さない。
+ *
+ * 送付方法（旧 shiharai）は旧コードの意味が不明なため remap 対象外（マップ無し）。
+ */
+export const LEGACY_FEE_CODE_MAP: {
+  calc: Record<string, string>;
+  tax: Record<string, string>;
+  billing: Record<string, string>;
+} = {
+  calc: { '0': 'AREA', '1': 'FIXED' },
+  tax: { '0': 'INCLUSIVE', '1': 'EXCLUSIVE' },
+  billing: { '0': 'NONE', '1': 'PRESENT', '2': 'PERPETUAL' },
+};
+
+/**
+ * Master 名解決ヘルパー。
+ *
+ * legacy migration が int 文字列 ("1" "2" 等) を格納している区分系フィールドと、
+ * 新規入力で master code ("AREA" 等) や id を格納する場合の両方に対応する。
+ *
+ * 解決順:
+ *  1. legacyMap が与えられていれば旧int値を master code に正規化（id 一致による誤マッチを回避）
+ *  2. id 一致 → code 一致 でマスタ名を返す
+ *  3. 解決できなければ素の数値表示を残さず「旧コード: X」と明示する（#177）
+ */
+export function resolveMasterName(
+  masters: ReadonlyArray<MasterItem | TaxTypeMasterItem>,
+  value: string | null | undefined,
+  legacyMap?: Record<string, string>,
+): string | null {
+  if (value == null || value === '') return null;
+
+  // 旧int値はマスタ code へ正規化してから解決する。
+  const normalized = legacyMap?.[value] ?? value;
+
+  const byId = masters.find((m) => m.id.toString() === normalized);
+  if (byId) return byId.name;
+  const byCode = masters.find((m) => m.code === normalized);
+  if (byCode) return byCode.name;
+
+  // 解決不能（マスタ未登録 / 意味不明な旧コード）。
+  // 数値の素表示を残さず、元の保存値を「旧コード」として明示する。
+  // 移行時の "legacy-{prefix}-{value}" センチネルは末尾の元値のみ表示する。
+  const sentinel = value.match(/^legacy-[^-]+-(.+)$/);
+  return `旧コード: ${sentinel ? sentinel[1] : value}`;
+}


### PR DESCRIPTION
## 概要

Closes #177

台帳詳細の料金情報で「計算タイプ 1」「税区分 0」「請求タイプ 2」「送付方法 1」等の内部コード（数値）がそのまま表示され、実務担当者に意味が分からない問題に対応。

## 指摘の妥当性（調査結果）

**妥当**。`resolveMasterName` は `id一致 → code一致 → raw値` の順で解決し、未解決時に素の値を返していた。

- 料金フィールドは新規入力では master `code`（'AREA' 等）を保存する（`plot-form/FeeInfoTab` の `value={item.code}`）。よって数値文字列（0/1/2）が残るのは **未 remap の旧データ** のみ。
- マスタ未 seed 環境（backend #46）や未 remap データでは、数値が code と一致せず素の数値が表示される。
- さらに潜在バグ: 旧 int "1"（計算=FIXED/任意設定）が `id一致` で `id=1`(=AREA/面積×単価) に**誤マッチ**しうる（off-by-one）。

backend には確定的な旧int→code マップが存在する（移行スクリプト `scripts/legacy-migration/steps/05-contract-plot.ts`）:
`calc {0:AREA,1:FIXED}` / `tax {0:INCLUSIVE,1:EXCLUSIVE}` / `billing {0:NONE,1:PRESENT,2:PERPETUAL}`。送付方法(旧 shiharai)は意味不明で移行でも未 remap。

## 変更内容

- `resolveMasterName` を **`src/lib/master-resolve.ts` に切り出し**、以下に拡張:
  1. `legacyMap` が渡されたら旧int値を master code に**正規化してから解決**（id一致の誤マッチを回避）
  2. 解決不能なら素の数値を残さず **「旧コード: X」と明示**（移行センチネル `legacy-{prefix}-{value}` は末尾の元値のみ表示）
- `FeeInfoTab` の計算タイプ/税区分/請求タイプに `LEGACY_FEE_CODE_MAP`（移行スクリプト準拠）を渡す。
  - → マスタがあれば正しい名称（面積×単価・内税 等）に解決し、無くても「旧コード: 1」と明示。
  - 送付方法は旧コードの意味が不明なため**推測せず明示のみ**。
  - 方位/位置（id 参照）は legacyMap 無しで従来どおり解決。
- `resolveMasterName` の単体テストを追加。

## 受け入れ条件

- [x] 料金情報タブに数値コードのみの表示が残らない（解決できれば名称、できなければ「旧コード: X」と明示）

## 検証

- `npx tsc --noEmit` ✅ / `npx eslint`（変更ファイル）✅
- `npx jest` → **380 passed**（新規6件含む）✅
  - 旧int正規化（0→面積×単価, 1→任意設定 等）/ off-by-one 回避 / 未登録時の明示 / センチネル除去 / 方位位置の従来解決 を検証

## スコープ / 補足

- 根本解決（マスタ seed・旧データの remap）は **backend #46 / #163** の領域。本PRはフロントで「正しく解決できる場合は解決、できない場合は旧値を明示」する対応。
- マスタが seed されれば（#46）本PRの正規化により旧データも自動的に正しい名称で表示される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)