### PR TITLE
feat(plot-detail): 面積ラベルを明確化し分割区画を注記 (#178)

### DIFF
--- a/src/__tests__/types/plot-constants.test.ts
+++ b/src/__tests__/types/plot-constants.test.ts
@@ -1,0 +1,27 @@
+import { getPlotSizeLabel, PLOT_SIZE } from '@/types/plot-constants';
+
+/**
+ * #178: 面積から区画サイズラベルを導出するヘルパー。
+ * 分割販売注記（物理区画 3.6㎡ / 契約 1.8㎡ 等）の表示に使用。
+ */
+describe('getPlotSizeLabel (#178)', () => {
+  it('3.6㎡（FULL）は「1区画」', () => {
+    expect(getPlotSizeLabel(PLOT_SIZE.FULL)).toBe('1区画');
+    expect(getPlotSizeLabel(3.6)).toBe('1区画');
+  });
+
+  it('1.8㎡（HALF）は「半区画」', () => {
+    expect(getPlotSizeLabel(PLOT_SIZE.HALF)).toBe('半区画');
+    expect(getPlotSizeLabel(1.8)).toBe('半区画');
+  });
+
+  it('既知サイズ以外（0.9㎡ 等）は null', () => {
+    expect(getPlotSizeLabel(0.9)).toBeNull();
+    expect(getPlotSizeLabel(2.7)).toBeNull();
+  });
+
+  it('null / undefined は null', () => {
+    expect(getPlotSizeLabel(null)).toBeNull();
+    expect(getPlotSizeLabel(undefined)).toBeNull();
+  });
+});

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -24,6 +24,7 @@ import { usePlotDetail } from '@/hooks/usePlots';
 import { useMasters } from '@/hooks/useMasters';
 import type { MasterItem, TaxTypeMasterItem } from '@/lib/api/masters';
 import { resolveMasterName, LEGACY_FEE_CODE_MAP } from '@/lib/master-resolve';
+import { getPlotSizeLabel } from '@/types/plot-constants';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -147,11 +148,43 @@ interface FeeMasters {
 
 // ===== サブコンポーネント =====
 
-function InfoField({ label, value }: { label: string; value: string | null | undefined }) {
+function InfoField({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string | null | undefined;
+  /** 値の意味を補足する小さなヘルプ文（常時表示・モバイル対応）。#178 */
+  hint?: string;
+}) {
   return (
     <div className="py-2">
       <dt className="text-sm text-hai">{label}</dt>
       <dd className="mt-1 font-semibold text-sumi text-sm">{value || '-'}</dd>
+      {hint && <p className="mt-0.5 text-[11px] text-hai font-normal leading-snug">{hint}</p>}
+    </div>
+  );
+}
+
+/**
+ * 物理区画面積 > 契約面積（分割販売）のとき、面積の意味の違いを注記する（#178）。
+ * 区画情報セクションのグリッド内に全幅で表示する。
+ */
+function PlotAreaSplitNote({
+  physicalAreaSqm,
+  contractAreaSqm,
+}: {
+  physicalAreaSqm: number | null | undefined;
+  contractAreaSqm: number | null | undefined;
+}) {
+  if (physicalAreaSqm == null || contractAreaSqm == null) return null;
+  if (contractAreaSqm >= physicalAreaSqm) return null;
+  const sizeLabel = getPlotSizeLabel(contractAreaSqm);
+  return (
+    <div className="col-span-full mt-1 rounded-elegant border border-cha-200 bg-cha-50 px-3 py-2 text-[11px] md:text-xs text-sumi leading-relaxed">
+      この区画は分割販売です。物理区画 {physicalAreaSqm}㎡ のうち、本契約の取得面積は{' '}
+      {contractAreaSqm}㎡{sizeLabel ? `（${sizeLabel}）` : ''} です。料金は契約・課金面積に基づいて計算されます。
     </div>
   );
 }
@@ -266,10 +299,24 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
       <Section title="区画情報">
         <InfoField label="区画番号" value={plot.physicalPlot.plotNumber} />
         <InfoField label="エリア" value={plot.physicalPlot.areaName} />
-        <InfoField label="面積 (m²)" value={plot.physicalPlot.areaSqm?.toString()} />
-        <InfoField label="契約面積 (m²)" value={plot.contractAreaSqm?.toString()} />
+        <InfoField
+          label="物理区画面積 (㎡)"
+          value={plot.physicalPlot.areaSqm?.toString()}
+          hint="区画全体の面積（分割前）"
+        />
+        <InfoField
+          label="契約面積 (㎡)"
+          value={plot.contractAreaSqm?.toString()}
+          hint={`この契約で取得した面積${
+            getPlotSizeLabel(plot.contractAreaSqm) ? `（${getPlotSizeLabel(plot.contractAreaSqm)}）` : ''
+          }`}
+        />
         <InfoField label="区画状態" value={PHYSICAL_STATUS_LABELS[plot.physicalPlot.status as PhysicalPlotStatus]} />
         <InfoField label="備考" value={plot.locationDescription} />
+        <PlotAreaSplitNote
+          physicalAreaSqm={plot.physicalPlot.areaSqm}
+          contractAreaSqm={plot.contractAreaSqm}
+        />
       </Section>
 
       {/* 契約情報 */}
@@ -348,7 +395,7 @@ function FeeInfoTab({ plot, masters }: { plot: PlotDetailResponse; masters: FeeM
           <InfoField label="税区分" value={resolveMasterName(masters.taxTypes, plot.usageFee.taxType, LEGACY_FEE_CODE_MAP.tax)} />
           <InfoField label="請求タイプ" value={resolveMasterName(masters.billingTypes, plot.usageFee.billingType, LEGACY_FEE_CODE_MAP.billing)} />
           <InfoField label="請求年数" value={plot.usageFee.billingYears?.toString()} />
-          <InfoField label="面積" value={plot.usageFee.area} />
+          <InfoField label="課金面積 (㎡)" value={plot.usageFee.area} hint="料金計算に用いる面積" />
           <InfoField label="単価" value={formatCurrency(plot.usageFee.unitPrice)} />
           <InfoField label="使用料" value={formatCurrency(plot.usageFee.usageFee)} />
           <InfoField label="送付方法" value={resolveMasterName(masters.paymentMethods, plot.usageFee.paymentMethod)} />
@@ -362,7 +409,7 @@ function FeeInfoTab({ plot, masters }: { plot: PlotDetailResponse; masters: FeeM
           <InfoField label="税区分" value={resolveMasterName(masters.taxTypes, plot.managementFee.taxType, LEGACY_FEE_CODE_MAP.tax)} />
           <InfoField label="請求タイプ" value={resolveMasterName(masters.billingTypes, plot.managementFee.billingType, LEGACY_FEE_CODE_MAP.billing)} />
           <InfoField label="請求年数" value={plot.managementFee.billingYears?.toString()} />
-          <InfoField label="面積" value={plot.managementFee.area} />
+          <InfoField label="課金面積 (㎡)" value={plot.managementFee.area} hint="料金計算に用いる面積" />
           <InfoField label="請求月" value={plot.managementFee.billingMonth?.toString()} />
           <InfoField label="管理料" value={formatCurrency(plot.managementFee.managementFee)} />
           <InfoField label="単価" value={formatCurrency(plot.managementFee.unitPrice)} />

--- a/src/types/plot-constants.ts
+++ b/src/types/plot-constants.ts
@@ -66,6 +66,17 @@ export const PLOT_SIZE_LABELS: Record<PlotSizeType, string> = {
   half: '半区画（1.8㎡）',
 };
 
+/**
+ * 面積(㎡)から区画サイズの短いラベルを返す（'1区画' / '半区画'）。
+ * 既知サイズ以外（0.9㎡ 等）は null。台帳詳細の面積注記（#178）で使用。
+ */
+export function getPlotSizeLabel(areaSqm: number | null | undefined): string | null {
+  if (areaSqm == null) return null;
+  if (areaSqm === PLOT_SIZE.FULL) return '1区画';
+  if (areaSqm === PLOT_SIZE.HALF) return '半区画';
+  return null;
+}
+
 // ===== 所有区画情報 =====
 
 export interface OwnedPlot {


### PR DESCRIPTION
## 概要

Closes #178

台帳詳細で基本情報の「面積 3.6」と料金情報の「面積 1.8」が同じ "面積" ラベルで表示され、物理区画面積／契約面積／課金面積のどれか利用者に判断できない問題に対応。

## 指摘の妥当性（調査結果）

**妥当**。同名ラベル「面積」が異なる意味の値に使われていた:
- 基本情報 `面積 (m²)` = `plot.physicalPlot.areaSqm`（物理区画＝分割前の全体, 例 3.6）
- 基本情報 `契約面積 (m²)` = `plot.contractAreaSqm`
- 料金情報 `面積` = `plot.usageFee.area` / `plot.managementFee.area`（料金計算に用いる課金面積, 例 1.8）

データモデル上は PhysicalPlot(物理区画) → ContractPlot(契約区画: 3.6/1.8/0.9㎡) の分割販売構造で、値が異なるのは正常。ラベルが同名で説明が無いことが問題。

## 変更内容

- **区画情報**: ラベルを「物理区画面積 (㎡)」「契約面積 (㎡)」に明確化し、各フィールドに補足ヘルプ（常時表示・モバイル対応）を追加。契約面積には半区画(1.8㎡)等の**サイズラベルを併記**。
- **料金情報（使用料/管理料）**: 「面積」→「**課金面積 (㎡)**」+ ヘルプ「料金計算に用いる面積」。
- `InfoField` に `hint` プロパティを追加（値の下に小さなヘルプ文）。
- **物理区画面積 > 契約面積（分割販売）のとき**、区画情報に「この区画は分割販売です。物理区画 3.6㎡ のうち、本契約の取得面積は 1.8㎡（半区画）です。料金は契約・課金面積に基づいて計算されます。」という注記を表示。
- `plot-constants` に `getPlotSizeLabel`（3.6→「1区画」/1.8→「半区画」）を追加し単体テスト。

## 受け入れ条件

- [x] 3.6 と 1.8 の意味が画面上で区別できる（ラベル＋ヘルプ＋分割注記）

## 検証

- `npx tsc --noEmit` ✅ / `npx eslint`（変更ファイル）✅
- `npx jest` → **381 passed**（新規4件含む）✅
- レスポンシブ: ヘルプ/注記は `text-[11px] md:text-xs`、注記は `px-3 py-2`（375px 対応）。ツールチップ（hover）ではなく常時表示のヘルプ文にしてモバイルでも読めるようにした。

## 補足

ツールチップ用UIコンポーネントが無いため、hover に依存しない「常時表示のヘルプ文＋分割注記」で実装（iPhone SE 375px でも判読可能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)