### PR TITLE
feat(plot-detail): 空値表示を統一し凡例を追加（#181 mainへ再着地）

### DIFF
--- a/src/__tests__/lib/empty-display.test.ts
+++ b/src/__tests__/lib/empty-display.test.ts
@@ -1,0 +1,32 @@
+import { isEmptyDisplayValue, EMPTY_LABELS } from '@/lib/empty-display';
+
+/**
+ * #181: 空値表示の統一ルール。
+ */
+describe('isEmptyDisplayValue (#181)', () => {
+  it('null / undefined / 空文字は空とみなす', () => {
+    expect(isEmptyDisplayValue(null)).toBe(true);
+    expect(isEmptyDisplayValue(undefined)).toBe(true);
+    expect(isEmptyDisplayValue('')).toBe(true);
+    expect(isEmptyDisplayValue('   ')).toBe(true);
+  });
+
+  it('各種ダッシュ・「未設定」などのフォールバック値も空とみなす', () => {
+    expect(isEmptyDisplayValue('-')).toBe(true);
+    expect(isEmptyDisplayValue('—')).toBe(true);
+    expect(isEmptyDisplayValue('―')).toBe(true);
+    expect(isEmptyDisplayValue('未設定')).toBe(true);
+  });
+
+  it('実データは空とみなさない', () => {
+    expect(isEmptyDisplayValue('田中太郎')).toBe(false);
+    expect(isEmptyDisplayValue('0')).toBe(false); // 金額0等は有効値
+    expect(isEmptyDisplayValue('2020/04/01')).toBe(false);
+    expect(isEmptyDisplayValue('面積×単価')).toBe(false);
+  });
+
+  it('空値ラベルは未登録/対象外', () => {
+    expect(EMPTY_LABELS.unregistered).toBe('未登録');
+    expect(EMPTY_LABELS.na).toBe('対象外');
+  });
+});

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -25,6 +25,7 @@ import { useMasters } from '@/hooks/useMasters';
 import type { MasterItem, TaxTypeMasterItem } from '@/lib/api/masters';
 import { resolveMasterName, LEGACY_FEE_CODE_MAP } from '@/lib/master-resolve';
 import { getPlotSizeLabel } from '@/types/plot-constants';
+import { isEmptyDisplayValue, EMPTY_LABELS, type EmptyKind } from '@/lib/empty-display';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -152,16 +153,27 @@ function InfoField({
   label,
   value,
   hint,
+  emptyKind = 'unregistered',
 }: {
   label: string;
   value: string | null | undefined;
   /** 値の意味を補足する小さなヘルプ文（常時表示・モバイル対応）。#178 */
   hint?: string;
+  /** 空値の意味（#181）。未入力=unregistered（「未登録」）/ 該当なし=na（「対象外」）。 */
+  emptyKind?: EmptyKind;
 }) {
+  const empty = isEmptyDisplayValue(value);
   return (
     <div className="py-2">
       <dt className="text-sm text-hai">{label}</dt>
-      <dd className="mt-1 font-semibold text-sumi text-sm">{value || '-'}</dd>
+      <dd
+        className={cn(
+          'mt-1 text-sm',
+          empty ? 'font-normal italic text-hai' : 'font-semibold text-sumi'
+        )}
+      >
+        {empty ? EMPTY_LABELS[emptyKind] : value}
+      </dd>
       {hint && <p className="mt-0.5 text-[11px] text-hai font-normal leading-snug">{hint}</p>}
     </div>
   );
@@ -293,6 +305,11 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
   const applicantIsSameAsContractor =
     !!applicantRole && !!primaryRole && applicantRole.customer.id === primaryRole.customer.id;
 
+  // 空き区画は contract_status='vacant' の器契約。契約日・受付等が空でも
+  // 「未登録（入力漏れ）」ではなく「対象外（契約がそもそも無い）」なので区別する（#181）。
+  const isVacant = plot.contractStatus === ContractStatus.Vacant;
+  const contractEmptyKind: EmptyKind = isVacant ? 'na' : 'unregistered';
+
   return (
     <div className="space-y-4">
       {/* 区画情報 */}
@@ -321,18 +338,18 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
 
       {/* 契約情報 */}
       <Section title="契約情報">
-        <InfoField label="契約日" value={formatDate(plot.contractDate)} />
-        <InfoField label="契約金額" value={formatPrice(plot.price)} />
+        <InfoField label="契約日" value={formatDate(plot.contractDate)} emptyKind={contractEmptyKind} />
+        <InfoField label="契約金額" value={formatPrice(plot.price)} emptyKind={contractEmptyKind} />
         <InfoField label="利用申込" value={CONTRACT_STATUS_LABELS[plot.contractStatus as ContractStatus]} />
         <InfoField label="入金状態" value={PAYMENT_STATUS_LABELS[plot.paymentStatus as PaymentStatus]} />
         <InfoField label="予約日" value={formatDate(plot.reservationDate)} />
-        <InfoField label="受付番号" value={plot.acceptanceNumber} />
-        <InfoField label="受付日" value={formatDate(plot.acceptanceDate)} />
+        <InfoField label="受付番号" value={plot.acceptanceNumber} emptyKind={contractEmptyKind} />
+        <InfoField label="受付日" value={formatDate(plot.acceptanceDate)} emptyKind={contractEmptyKind} />
         <InfoField label="担当者" value={plot.staffInCharge} />
         <InfoField label="取扱" value={plot.agentName} />
-        <InfoField label="許可日" value={formatDate(plot.permitDate)} />
-        <InfoField label="平成書番号" value={plot.permitNumber} />
-        <InfoField label="開始日" value={formatDate(plot.startDate)} />
+        <InfoField label="許可日" value={formatDate(plot.permitDate)} emptyKind={contractEmptyKind} />
+        <InfoField label="平成書番号" value={plot.permitNumber} emptyKind={contractEmptyKind} />
+        <InfoField label="開始日" value={formatDate(plot.startDate)} emptyKind={contractEmptyKind} />
         <InfoField label="契約備考" value={plot.contractNotes} />
       </Section>
 
@@ -347,7 +364,7 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
         />
       ) : (
         <Section title="申込者情報">
-          <InfoField label="申込者" value="登録なし" />
+          <InfoField label="申込者" value={null} />
         </Section>
       )}
 
@@ -1025,6 +1042,14 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
           </div>
         </div>
       </div>
+
+      {/* 空値表示の凡例（#181）— 「-」が未登録・対象外・取得失敗のどれか分からない問題への対応 */}
+      <p className="mb-3 text-[11px] md:text-xs text-hai leading-relaxed">
+        <span className="font-semibold text-sumi">表示の凡例</span>：
+        <span className="italic">未登録</span>＝未入力の項目／
+        <span className="italic">対象外</span>＝この区画では該当しない項目。
+        該当しない情報はセクションごと非表示になり、取得に失敗した場合はエラー画面を表示します。
+      </p>
 
       {/* タブ — モバイル: 横スクロール / タブレット以上: グリッド */}
       <Tabs defaultValue="basic" className="w-full">

--- a/src/lib/empty-display.ts
+++ b/src/lib/empty-display.ts
@@ -1,0 +1,32 @@
+/**
+ * 空値表示の統一ルール（#181）
+ *
+ * 台帳詳細では「-」表示が多く、未登録・対象外・取得失敗の区別がつかなかった。
+ * 表示上の空値を一意のラベルに正規化し、意味を利用者に伝える。
+ *
+ * - 未登録 (unregistered): 項目は該当するが値が未入力
+ * - 対象外 (na): この区画では該当しない項目
+ * - 取得失敗: ページ単位のエラー画面で表示（フィールド単位の空値ではない）
+ */
+
+export type EmptyKind = 'unregistered' | 'na';
+
+export const EMPTY_LABELS: Record<EmptyKind, string> = {
+  unregistered: '未登録',
+  na: '対象外',
+};
+
+/**
+ * 「空」を意味する表示値。フォーマッタ（formatDate/formatCurrency 等）の
+ * フォールバック値や各種ダッシュ・「未設定」を空として扱い、表記を統一する。
+ */
+const EMPTY_SENTINELS = new Set(['', '-', '—', '―', '未設定']);
+
+/**
+ * 表示値が「空（未入力）」を意味するか判定する。
+ * null / undefined / 空文字 / 各種ダッシュ / 「未設定」 を空とみなす。
+ */
+export function isEmptyDisplayValue(value: string | null | undefined): boolean {
+  if (value == null) return true;
+  return EMPTY_SENTINELS.has(value.trim());
+}


### PR DESCRIPTION
## 概要

PR #208（#181 空値表示の統一）は誤って `fix/area-labels-clarify`（#207のブランチ・既にmainへマージ済み）をベースにマージされたため、**変更がmainに着地していなかった**。issue #181 もOPENのまま。本PRで #181 の変更を main へ再着地させる。

内容は PR #208 と同一（commit 6fb2809 を main から切ったブランチへ cherry-pick）:

- InfoField の空値を統一表示に変更: null/空文字/各種ダッシュ/「未設定」を空とみなし「未登録」を明示
- 空き区画（contract_status='vacant'）では契約日・受付等を「対象外」と表示し、入力漏れと契約なしを区別
- サマリー下に凡例を追加（未登録/対象外/非表示/取得失敗）
- 空値判定 `isEmptyDisplayValue` を `src/lib/empty-display.ts` に切り出し単体テスト追加

## テスト

- `npx jest src/__tests__/lib/empty-display.test.ts` 4 passed
- ESLint clean

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
