### PR TITLE
feat(plot-availability): 残数状況の判定基準と半区画・内訳ボタンを明確化 (#183 #184)

### DIFF
--- a/src/__tests__/types/plot-constants.test.ts
+++ b/src/__tests__/types/plot-constants.test.ts
@@ -1,4 +1,10 @@
-import { getPlotSizeLabel, PLOT_SIZE } from '@/types/plot-constants';
+import {
+  getPlotSizeLabel,
+  PLOT_SIZE,
+  getAvailabilityStatus,
+  AVAILABILITY_STATUS_LABELS,
+  LOW_STOCK_THRESHOLD,
+} from '@/types/plot-constants';
 
 /**
  * #178: 面積から区画サイズラベルを導出するヘルパー。
@@ -23,5 +29,32 @@ describe('getPlotSizeLabel (#178)', () => {
   it('null / undefined は null', () => {
     expect(getPlotSizeLabel(null)).toBeNull();
     expect(getPlotSizeLabel(undefined)).toBeNull();
+  });
+});
+
+/**
+ * #183: 在庫状況ステータスは残数（絶対値）で判定する。
+ * テーブルの状況バッジと画面凡例が同じロジック・定数を参照することで表示と判定の乖離を防ぐ。
+ */
+describe('getAvailabilityStatus (#183)', () => {
+  it('残0 は完売', () => {
+    expect(getAvailabilityStatus(0)).toBe('sold_out');
+    expect(AVAILABILITY_STATUS_LABELS[getAvailabilityStatus(0)]).toBe('完売');
+  });
+
+  it('残1〜閾値は残少', () => {
+    expect(getAvailabilityStatus(1)).toBe('low_stock');
+    expect(getAvailabilityStatus(LOW_STOCK_THRESHOLD)).toBe('low_stock');
+    expect(AVAILABILITY_STATUS_LABELS[getAvailabilityStatus(3)]).toBe('残少');
+  });
+
+  it('閾値超は空有', () => {
+    expect(getAvailabilityStatus(LOW_STOCK_THRESHOLD + 1)).toBe('available');
+    expect(getAvailabilityStatus(100)).toBe('available');
+    expect(AVAILABILITY_STATUS_LABELS[getAvailabilityStatus(50)]).toBe('空有');
+  });
+
+  it('負の残数は完売扱い（防御的）', () => {
+    expect(getAvailabilityStatus(-1)).toBe('sold_out');
   });
 });

--- a/src/components/plot-availability-management.tsx
+++ b/src/components/plot-availability-management.tsx
@@ -13,7 +13,13 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { StatCard } from '@/components/ui/stat-card';
-import { PlotPeriod, PLOT_SIZE } from '@/types/plot-constants';
+import {
+  PlotPeriod,
+  PLOT_SIZE,
+  LOW_STOCK_THRESHOLD,
+  getAvailabilityStatus,
+  AVAILABILITY_STATUS_LABELS,
+} from '@/types/plot-constants';
 import PageHeader from '@/components/page-header';
 import {
   usePlotInventorySummary,
@@ -267,6 +273,8 @@ export default function PlotAvailabilityManagement() {
               type="button"
               onClick={() => setIsKpiExpanded((v) => !v)}
               aria-expanded={isKpiExpanded}
+              aria-label="区画数・面積・半区画換算の内訳を開閉"
+              title="区画数・面積（㎡）・半区画換算の内訳を開閉します"
               className="w-full p-3 flex items-center gap-2 hover:bg-kinari/40 transition-colors"
             >
               <div className="flex-1 flex items-center justify-between gap-2 text-center">
@@ -290,13 +298,16 @@ export default function PlotAvailabilityManagement() {
                   <div className="text-[10px] md:text-xs text-hai">使用率</div>
                 </div>
                 <div className="w-px h-8 bg-gin hidden sm:block" />
-                <div className="flex-1 min-w-0 hidden sm:block">
+                <div
+                  className="flex-1 min-w-0 hidden sm:block"
+                  title="残区画 × 2（3.6㎡区画を1.8㎡で2分割した場合の販売可能数の最大値）"
+                >
                   <div className="text-lg md:text-xl font-bold text-sumi tabular-nums">{stat(summary.remainingCount * 2)}</div>
-                  <div className="text-[10px] md:text-xs text-hai">半区画</div>
+                  <div className="text-[10px] md:text-xs text-hai">半区画（残×2）</div>
                 </div>
               </div>
               <span className="shrink-0 inline-flex items-center gap-1 text-xs text-hai whitespace-nowrap">
-                <span className="hidden sm:inline">{isKpiExpanded ? '詳細を閉じる' : '詳細を表示'}</span>
+                <span className="hidden sm:inline">{isKpiExpanded ? '内訳を閉じる' : '内訳を表示'}</span>
                 {isKpiExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
               </span>
             </button>
@@ -614,19 +625,22 @@ export default function PlotAvailabilityManagement() {
                             </div>
                           </td>
                           <td className="px-2 md:px-4 py-2 md:py-3 text-sm text-center hidden sm:table-cell">
-                            {item.remainingCount === 0 ? (
-                              <span className="px-2 py-0.5 bg-beni-50 text-beni rounded-full text-xs font-medium">
-                                完売
-                              </span>
-                            ) : item.remainingCount <= 5 ? (
-                              <span className="px-2 py-0.5 bg-kohaku-50 text-kohaku rounded-full text-xs font-medium">
-                                残少
-                              </span>
-                            ) : (
-                              <span className="px-2 py-0.5 bg-matsu-50 text-matsu rounded-full text-xs font-medium">
-                                空有
-                              </span>
-                            )}
+                            {(() => {
+                              const status = getAvailabilityStatus(item.remainingCount);
+                              const styles: Record<typeof status, string> = {
+                                sold_out: 'bg-beni-50 text-beni',
+                                low_stock: 'bg-kohaku-50 text-kohaku',
+                                available: 'bg-matsu-50 text-matsu',
+                              };
+                              return (
+                                <span
+                                  className={cn('px-2 py-0.5 rounded-full text-xs font-medium', styles[status])}
+                                  title={`残${item.remainingCount}区画（${AVAILABILITY_STATUS_LABELS[status]}）— 状況は残数で判定（使用率とは別軸）`}
+                                >
+                                  {AVAILABILITY_STATUS_LABELS[status]}
+                                </span>
+                              );
+                            })()}
                           </td>
                           <td className="px-2 md:px-4 py-2 md:py-3 text-sm text-right text-hai hidden lg:table-cell">
                             {remainingArea.toFixed(1)}
@@ -821,19 +835,22 @@ export default function PlotAvailabilityManagement() {
                             {item.plotType}
                           </td>
                           <td className="px-2 md:px-4 py-2 md:py-3 text-sm text-center hidden sm:table-cell">
-                            {item.remainingCount === 0 ? (
-                              <span className="px-2 py-0.5 bg-beni-50 text-beni rounded-full text-xs font-medium">
-                                完売
-                              </span>
-                            ) : item.remainingCount <= 5 ? (
-                              <span className="px-2 py-0.5 bg-kohaku-50 text-kohaku rounded-full text-xs font-medium">
-                                残少
-                              </span>
-                            ) : (
-                              <span className="px-2 py-0.5 bg-matsu-50 text-matsu rounded-full text-xs font-medium">
-                                空有
-                              </span>
-                            )}
+                            {(() => {
+                              const status = getAvailabilityStatus(item.remainingCount);
+                              const styles: Record<typeof status, string> = {
+                                sold_out: 'bg-beni-50 text-beni',
+                                low_stock: 'bg-kohaku-50 text-kohaku',
+                                available: 'bg-matsu-50 text-matsu',
+                              };
+                              return (
+                                <span
+                                  className={cn('px-2 py-0.5 rounded-full text-xs font-medium', styles[status])}
+                                  title={`残${item.remainingCount}区画（${AVAILABILITY_STATUS_LABELS[status]}）— 状況は残数で判定（使用率とは別軸）`}
+                                >
+                                  {AVAILABILITY_STATUS_LABELS[status]}
+                                </span>
+                              );
+                            })()}
                           </td>
                         </tr>
                       );
@@ -875,25 +892,55 @@ export default function PlotAvailabilityManagement() {
             )}
           </div>
 
-          {/* フッター情報 */}
-          <div className="mt-5 flex justify-between items-center text-sm text-hai bg-white rounded-elegant-lg p-4 border border-gin">
-            <div>
-              ※ 1区画 = 3.6㎡、半区画 = 1.8㎡として計算
+          {/* フッター情報（凡例）— 状況（残数）と使用率（%）は別軸である点を明示（#183） */}
+          <div className="mt-5 text-sm text-hai bg-white rounded-elegant-lg p-4 border border-gin space-y-3">
+            {/* 状況バッジの判定基準（残数の絶対値）*/}
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
+              <span className="text-xs font-semibold text-sumi shrink-0">状況（残数で判定）</span>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+                <span className="flex items-center gap-1.5">
+                  <span className="px-2 py-0.5 bg-matsu-50 text-matsu rounded-full text-xs font-medium">空有</span>
+                  残{LOW_STOCK_THRESHOLD + 1}区画以上
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="px-2 py-0.5 bg-kohaku-50 text-kohaku rounded-full text-xs font-medium">残少</span>
+                  残1〜{LOW_STOCK_THRESHOLD}区画
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="px-2 py-0.5 bg-beni-50 text-beni rounded-full text-xs font-medium">完売</span>
+                  残0区画
+                </span>
+              </div>
             </div>
-            <div className="flex items-center space-x-4">
-              <span className="flex items-center">
-                <span className="w-3 h-3 bg-matsu rounded mr-2" /> 60%未満
-              </span>
-              <span className="flex items-center">
-                <span className="w-3 h-3 bg-cha rounded mr-2" /> 60-80%
-              </span>
-              <span className="flex items-center">
-                <span className="w-3 h-3 bg-kohaku rounded mr-2" /> 80-95%
-              </span>
-              <span className="flex items-center">
-                <span className="w-3 h-3 bg-beni rounded mr-2" /> 95%以上
-              </span>
+
+            {/* 使用率バーの色帯（パーセント）*/}
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
+              <span className="text-xs font-semibold text-sumi shrink-0">使用率バー（%）</span>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+                <span className="flex items-center">
+                  <span className="w-3 h-3 bg-matsu rounded mr-2" /> 60%未満
+                </span>
+                <span className="flex items-center">
+                  <span className="w-3 h-3 bg-cha rounded mr-2" /> 60-80%
+                </span>
+                <span className="flex items-center">
+                  <span className="w-3 h-3 bg-kohaku rounded mr-2" /> 80-95%
+                </span>
+                <span className="flex items-center">
+                  <span className="w-3 h-3 bg-beni rounded mr-2" /> 95%以上
+                </span>
+              </div>
             </div>
+
+            <p className="text-xs text-hai border-t border-gin pt-2">
+              ※「状況」は残数（区画の絶対数）で判定し、使用率バーの色帯（%）とは別の基準です。
+              使用率が高くても残数が多ければ「空有」になります。
+            </p>
+            <p className="text-xs text-hai">
+              ※ 1区画 = {PLOT_SIZE.FULL}㎡、半区画 = {PLOT_SIZE.HALF}㎡。
+              上部サマリーの「半区画」は <span className="font-medium text-sumi">残区画 × 2</span>
+              （3.6㎡区画を1.8㎡で2分割した場合に販売できる最大数）です。
+            </p>
           </div>
         </div>
       </div>

--- a/src/types/plot-constants.ts
+++ b/src/types/plot-constants.ts
@@ -77,6 +77,41 @@ export function getPlotSizeLabel(areaSqm: number | null | undefined): string | n
   return null;
 }
 
+// ===== 在庫状況ステータス（区画残数管理の「状況」バッジ）=====
+
+/**
+ * 在庫状況ステータス。残数（絶対値）で判定する。
+ * 区画残数管理テーブルの「状況」列で使用。
+ */
+export type AvailabilityStatus = 'sold_out' | 'low_stock' | 'available';
+
+/**
+ * 「残少」とみなす残数の上限（この数「以下」かつ 1 以上が残少）。
+ * 状況バッジの判定ロジックと画面凡例で同じ値を参照し、表示と判定の乖離を防ぐ（#183）。
+ */
+export const LOW_STOCK_THRESHOLD = 5;
+
+export const AVAILABILITY_STATUS_LABELS: Record<AvailabilityStatus, string> = {
+  sold_out: '完売',
+  low_stock: '残少',
+  available: '空有',
+};
+
+/**
+ * 残数から在庫状況ステータスを判定する（#183）。
+ *
+ * 判定軸は「残数の絶対値」であり、テーブルに表示される使用率%（バーの色帯）とは別軸。
+ * 使用率が中程度でも残数が少なければ「残少」になり得るため、画面では両者を別の凡例で示す。
+ * - 残 0        → 完売
+ * - 残 1〜上限   → 残少（上限 = LOW_STOCK_THRESHOLD）
+ * - 残 上限超    → 空有
+ */
+export function getAvailabilityStatus(remainingCount: number): AvailabilityStatus {
+  if (remainingCount <= 0) return 'sold_out';
+  if (remainingCount <= LOW_STOCK_THRESHOLD) return 'low_stock';
+  return 'available';
+}
+
 // ===== 所有区画情報 =====
 
 export interface OwnedPlot {


### PR DESCRIPTION
## 概要

区画残数管理で、状況バッジ（残少/空有）が使用率と直感的に対応せず、上部サマリーの「半区画」や「詳細を表示」ボタンの意味が分かりにくい問題に対応する。Closes #183 / Closes #184。

### #183 残少/空有の判定基準を明示
- **根本原因**: 状況バッジ（完売/残少/空有）は**残数の絶対値**（残0 / 残5以下 / 残6以上）で判定しているのに、テーブルの使用率バーは**%閾値**（60/80/95）で色付けされており、2つの異なる軸が混在して見える（例: 使用率63.6%で「残少」、77.4%で「空有」）。
- 判定ロジックを `getAvailabilityStatus()` に切り出し、`LOW_STOCK_THRESHOLD`（=5）を定数化。**テーブルのバッジと画面凡例が同じロジック・定数を参照**するため、表示と判定が乖離しない。
- フッター凡例を **「状況（残数で判定）」** と **「使用率バー（%）」** の2セクションに分離し、それぞれの基準を明示。
- 「状況は残数で判定し使用率%とは別軸」という注記を追加。各バッジに `title` も付与。

### #184 半区画・「詳細を表示」の説明追加
- 上部サマリーの「半区画」→「**半区画（残×2）**」に変更。`残区画 × 2`（3.6㎡区画を1.8㎡で2分割した場合の最大販売数）の意味を `title` とフッター凡例で明示。
- 「詳細を表示」→「**内訳を表示**」に変更。開く内容（区画数・面積㎡・半区画換算）を `title`/`aria-label` で事前に分かるように。

## スコープ外

- issue #183 が挙げる「バックエンド `inventoryService.ts` の判定ロジック見直し」は、残少の閾値や%基準への変更が業務判断を伴うためフロント側では実施しない。本PRは**現行ロジックの透明化（凡例・判定基準の明示）**に限定し、受け入れ条件2項目を満たす。

## テスト

- `getAvailabilityStatus` 単体テスト追加（`src/__tests__/types/plot-constants.test.ts`、8 passed）
- ESLint clean / `tsc --noEmit` 変更ファイルにエラーなし

## 受け入れ条件

#183
- [x] 使用率と残少/空有の対応が利用者に理解できる（別軸である旨を凡例で明示）
- [x] 凡例とステータスバッジの関係が明示される

#184
- [x] 半区画数値の意味が総数/使用/残と一緒に理解できる
- [x] 「詳細を表示」の操作結果が事前に分かる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
