### PR TITLE
feat(sidebar): 主要機能の関係と各メニューの役割を明示 (#191)

### DIFF
--- a/src/components/layout/GlobalSidebar.tsx
+++ b/src/components/layout/GlobalSidebar.tsx
@@ -127,9 +127,16 @@ export default function GlobalSidebar({
                 )}
 
                 {!collapsed && (
-                  <p className="text-xs font-semibold text-hai uppercase tracking-wider mb-2 px-2">
-                    {group.label}
-                  </p>
+                  <div className="mb-2 px-2">
+                    <p className="text-xs font-semibold text-hai uppercase tracking-wider">
+                      {group.label}
+                    </p>
+                    {group.description && (
+                      <p className="text-[10px] text-hai/80 mt-0.5 normal-case tracking-normal leading-snug">
+                        {group.description}
+                      </p>
+                    )}
+                  </div>
                 )}
 
                 <div className="space-y-1">
@@ -145,8 +152,8 @@ export default function GlobalSidebar({
                           ? 'bg-matsu-50 text-matsu border border-matsu-200'
                           : 'text-sumi hover:bg-white hover:text-matsu'
                           }`}
-                        title={item.label}
-                        aria-label={item.label}
+                        title={item.description ? `${item.label} — ${item.description}` : item.label}
+                        aria-label={item.description ? `${item.label}（${item.description}）` : item.label}
                       >
                         <MenuIcon icon={item.icon} className="w-5 h-5" />
                       </Link>
@@ -159,6 +166,7 @@ export default function GlobalSidebar({
                           ? 'bg-matsu-50 text-matsu border-l-[3px] border-matsu shadow-sm font-medium'
                           : 'text-sumi hover:bg-white hover:text-matsu hover:shadow-sm border-l-[3px] border-transparent'
                           }`}
+                        title={item.description ? `${item.label} — ${item.description}` : item.label}
                       >
                         <MenuIcon icon={item.icon} className={`w-5 h-5 flex-shrink-0 ${active ? 'text-matsu' : 'text-hai'}`} />
                         <span>{item.label}</span>
@@ -170,6 +178,22 @@ export default function GlobalSidebar({
             ))}
           </nav>
         </div>
+
+        {/* 業務フローのヘルプ — 主要機能の関係を新規利用者にも伝える（#191） */}
+        {!collapsed && (
+          <div className="border-t border-gin p-4">
+            <p className="text-xs font-semibold text-hai uppercase tracking-wider mb-2">業務の流れ</p>
+            <ol className="space-y-1.5 text-[11px] text-hai leading-snug">
+              <li><span className="text-matsu font-medium">① 台帳問い合わせ</span>：区画ごとに契約・顧客・請求・入金を管理（基点）</li>
+              <li><span className="text-matsu font-medium">② 区画残数管理</span>：空き状況・使用率を把握</li>
+              <li><span className="text-matsu font-medium">③ ゆうちょ連携</span>：管理料の口座振替を出力</li>
+              <li><span className="text-matsu font-medium">④ 合祀管理</span>：契約期間の満了後に合祀・請求</li>
+            </ol>
+            <p className="text-[10px] text-hai/80 mt-2 leading-snug">
+              合祀一覧の区画番号から台帳詳細へ移動できます。
+            </p>
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -5,29 +5,35 @@ export interface NavItem {
   path: string;
   icon: 'search' | 'archive' | 'grid' | 'file-text' | 'users' | 'settings' | 'bank';
   requiredRoles: UserRole[];
+  /** 各機能の役割・業務フロー上の位置づけ（ツールチップ／補足表示に使用 #191） */
+  description?: string;
 }
 
 export interface NavGroup {
   label: string;
   items: NavItem[];
+  /** グループの概要（サイドバーのグループ見出し下に表示 #191） */
+  description?: string;
 }
 
 export const NAV_GROUPS: NavGroup[] = [
   {
     label: '業務',
+    description: '日常の台帳・請求・合祀業務',
     items: [
-      { label: '台帳問い合わせ', path: '/plots', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'search' },
-      { label: '合祀管理', path: '/collective-burials', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'archive' },
-      { label: '区画残数管理', path: '/plot-availability', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'grid' },
-      { label: '書類管理', path: '/documents', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'file-text' },
-      { label: 'ゆうちょ連携', path: '/yucho', requiredRoles: ['operator', 'manager', 'admin'], icon: 'bank' },
+      { label: '台帳問い合わせ', path: '/plots', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'search', description: '区画ごとの契約・顧客・請求・入金を管理する基点の画面' },
+      { label: '合祀管理', path: '/collective-burials', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'archive', description: '契約期間の満了後に行う合祀の予定・請求を管理' },
+      { label: '区画残数管理', path: '/plot-availability', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'grid', description: '区画の空き状況・使用率を期別に集計' },
+      { label: '書類管理', path: '/documents', requiredRoles: ['viewer', 'operator', 'manager', 'admin'], icon: 'file-text', description: '契約書・許可証などの書類を発行・管理' },
+      { label: 'ゆうちょ連携', path: '/yucho', requiredRoles: ['operator', 'manager', 'admin'], icon: 'bank', description: '管理料の口座振替データ（CSV）を出力' },
     ],
   },
   {
     label: '管理',
+    description: 'システム設定・権限管理',
     items: [
-      { label: 'スタッフ管理', path: '/staff', requiredRoles: ['manager', 'admin'], icon: 'users' },
-      { label: 'マスタ管理', path: '/masters', requiredRoles: ['admin'], icon: 'settings' },
+      { label: 'スタッフ管理', path: '/staff', requiredRoles: ['manager', 'admin'], icon: 'users', description: '職員アカウントと権限（ロール）を管理' },
+      { label: 'マスタ管理', path: '/masters', requiredRoles: ['admin'], icon: 'settings', description: '宗派・区分などの選択肢マスタを管理' },
     ],
   },
 ];


### PR DESCRIPTION
## 概要

サイドバーから、台帳・区画残数・合祀・請求といった主要機能の**業務フロー上の関係**が読み取れず、新規利用者がつながりを把握しづらい問題に対応する。Closes #191。

## 変更内容

- `NavItem` に `description`（各機能の役割）、`NavGroup` に `description`（グループ概要）を追加。
- 各メニューリンクに役割説明を **`title` ツールチップ**として付与（展開・折りたたみ両対応。折りたたみ時は `aria-label` も「ラベル（説明）」に拡充）。
- グループ見出し（業務／管理）の下に**概要文**を表示。
- サイドバー下部に **「業務の流れ」ヘルプ**を追加し、① 台帳問い合わせ → ② 区画残数管理 → ③ ゆうちょ連携 → ④ 合祀管理 の関係と、合祀一覧→台帳詳細の導線（#188 で実装済み）を明示。

折りたたみ時はアイコンのみのため、フロー説明・グループ概要は展開時のみ表示（ツールチップは常時）。

## テスト

- ESLint clean / `tsc --noEmit` 変更ファイルにエラーなし
- ナビ構造を参照するユニットテストは無し（型へのオプショナル追加・表示の追加のみで既存挙動は不変）

## 受け入れ条件

- [x] 新規利用者が主要4機能の関係を画面だけでおおまかに理解できる（「業務の流れ」ヘルプ＋グループ概要＋各項目ツールチップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
