### PR TITLE
feat(mock-banner): 「試験環境」バッジで試験/デモ環境を明示 (#192)

### DIFF
--- a/src/__tests__/components/mock-data-banner.test.tsx
+++ b/src/__tests__/components/mock-data-banner.test.tsx
@@ -11,7 +11,7 @@ jest.mock('@/lib/api/client', () => ({
 import MockDataBanner from '@/components/mock-data-banner';
 
 /**
- * #176: デモデータ表示中バナー
+ * #176 / #192: デモデータ表示中バナー
  */
 describe('MockDataBanner', () => {
   afterEach(() => mockShouldUseMockData.mockReset());
@@ -29,5 +29,14 @@ describe('MockDataBanner', () => {
     expect(
       screen.getByText(/実際の台帳・契約・顧客とは紐づいていません/)
     ).toBeInTheDocument();
+  });
+
+  it('「試験環境」バッジで試験/デモ環境であることを明示する（#192）', () => {
+    mockShouldUseMockData.mockReturnValue(true);
+    render(<MockDataBanner />);
+    const badge = screen.getByText('試験環境');
+    expect(badge).toBeInTheDocument();
+    // ツールチップで本番データでない旨を説明
+    expect(badge).toHaveAttribute('title', expect.stringContaining('本番'));
   });
 });

--- a/src/components/mock-data-banner.tsx
+++ b/src/components/mock-data-banner.tsx
@@ -3,12 +3,17 @@
 import { shouldUseMockData } from '@/lib/api/client';
 
 /**
- * デモ（モック）データ表示中であることを全画面で明示するバナー（#176）
+ * デモ（モック）データ表示中であることを全画面で明示するバナー（#176 / #192）
  *
  * `NEXT_PUBLIC_USE_MOCK_DATA=true` のとき、画面のデータはサンプルで
  * 実際の台帳・契約・顧客とは紐づいていない。台帳と合祀など画面間で
  * データが食い違って「別世界のサンプルに見える」混乱を防ぐため、
  * デモデータであることを常時明示する。本番（フラグ false）では何も描画しない。
+ *
+ * #192: 画面上の「試験」表示が「テスト環境なのか試験用データなのか」曖昧だった点に対応。
+ * 「試験環境」バッジ（ツールチップ付き）で、サンプルデータで動作する試験／デモ環境であり
+ * 本番データではないことを明示する。本番ではバナーごと非表示になるため、本番データを
+ * 試験用と誤解させない。
  */
 export default function MockDataBanner() {
   if (!shouldUseMockData()) return null;
@@ -32,10 +37,16 @@ export default function MockDataBanner() {
           d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
         />
       </svg>
+      <span
+        className="shrink-0 inline-flex items-center rounded-full bg-kohaku-200/70 px-2 py-0.5 text-[10px] md:text-xs font-semibold text-kohaku-dark"
+        title="サンプルデータで動作する試験（デモ）環境です。本番の台帳・契約データではありません。本番環境ではこの表示は出ません。"
+      >
+        試験環境
+      </span>
       <p className="text-[11px] md:text-xs leading-snug">
         <span className="font-semibold">デモデータ表示中</span>
         <span className="ml-2">
-          画面のデータはサンプルです。実際の台帳・契約・顧客とは紐づいていません。
+          画面のデータはサンプル（試験用）です。実際の台帳・契約・顧客とは紐づいていません。本番環境では表示されません。
         </span>
       </p>
     </div>


### PR DESCRIPTION
## 概要

画面上の「試験」バッジが「テスト環境なのか、データ種別（試験用区画）なのか」説明がなく、管理者に意味が伝わらない／本番データが試験用と誤解される懸念に対応する。Closes #192。

## 調査結果

「試験」というバッジ／ラベルは、**フロントエンドのソース・モックデータ（plotType は 自由/吉相/樹林 等）・git 全履歴のいずれにも存在しない**ことを確認（`grep` / `git log -S` pickaxe 済み）。実体のある単一のバッジ文言変更では対応できないため、ユーザー確認のうえ **「試験」＝デモ／試験環境の表示** と解釈し、全画面共通の環境表示である `MockDataBanner` に意味を集約する方針とした。

`MockDataBanner` は `NEXT_PUBLIC_USE_MOCK_DATA=true` のときだけ表示され、**本番環境では描画されない**ため、「本番環境では不要なバッジを非表示」という要件も満たす。

## 変更内容

- バナー先頭に **「試験環境」バッジ**（`title` ツールチップ付き）を追加。「サンプルデータで動作する試験（デモ）環境であり、本番の台帳・契約データではない／本番環境では表示されない」ことを明示。
- バナー本文を「画面のデータはサンプル（試験用）です。… 本番環境では表示されません。」に補強。
- 「試験環境」バッジ表示の単体テストを追加。

## テスト

- `npx jest src/__tests__/components/mock-data-banner.test.tsx` 3 passed
- ESLint clean

## 受け入れ条件

- [x] 「試験」バッジの意味が利用者に明確（＝サンプルデータの試験/デモ環境。ツールチップ＋本文で説明）
- [x] 誤解（本番データが試験用？）を招かない（本番では非表示・本番データではない旨を明示）

## 補足

実画面で別の「試験」表示（実データの区分・ステータス由来など）が残っている場合は、スクリーンショットがあれば追跡できます。その際は本 issue へコメントください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
