### PR TITLE
test(e2e): 主要画面の smoke テストを追加 (#140)

### DIFF
--- a/tests/smoke-screens.spec.ts
+++ b/tests/smoke-screens.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * 主要画面の smoke E2Eテスト（#140）
+ *
+ * これまで専用 E2E が無かった画面について、認証後にルートへ遷移し
+ * ページが（バックエンド無しのモックモードでも）クラッシュせず主要な
+ * 見出しを描画することを確認する。表示確認中心の軽量テスト。
+ *
+ * - すべて admin の storageState を使用（/masters は admin 限定のため）
+ * - viewport は 1280x720（playwright.config.ts）のため DesktopOnlyGate は発動しない
+ * - /payments は未実装ルートのためスコープ外
+ * - /yucho は API モック未実装だが、PageHeader は取得結果に依存せず描画され、
+ *   データ取得は useAsyncData がエラーを握るため、見出しの表示のみ確認する
+ */
+import { test, expect } from '@playwright/test';
+import { storageStatePath } from './config/test-accounts';
+
+test.describe('主要画面 smoke（#140）', () => {
+  test.use({ storageState: storageStatePath('admin') });
+
+  const TIMEOUT = 20_000;
+
+  test('140-1: 区画残数管理が表示される', async ({ page }) => {
+    await page.goto('/plot-availability');
+    await expect(page.getByText('区画残数管理').first()).toBeVisible({ timeout: TIMEOUT });
+  });
+
+  test('140-2: 書類管理（一覧/テンプレート）が表示される', async ({ page }) => {
+    await page.goto('/documents');
+    await expect(page.getByText('書類管理').first()).toBeVisible({ timeout: TIMEOUT });
+  });
+
+  test('140-3: 区画別書類が表示される', async ({ page }) => {
+    await page.goto('/plots/mock-plot-1/documents');
+    // 顧客名ありなら「○○ 様の書類」、無ければ「書類管理」。いずれも「書類」を含む
+    await expect(page.getByText(/書類/).first()).toBeVisible({ timeout: TIMEOUT });
+  });
+
+  test('140-4: マスタ管理（admin）が表示される', async ({ page }) => {
+    await page.goto('/masters');
+    await expect(page.getByText('マスタ管理').first()).toBeVisible({ timeout: TIMEOUT });
+  });
+
+  test('140-5: アカウント設定（プロフィール）が表示される', async ({ page }) => {
+    await page.goto('/profile');
+    await expect(page.getByText('アカウント設定').first()).toBeVisible({ timeout: TIMEOUT });
+  });
+
+  test('140-6: ゆうちょ連携の見出しが表示される', async ({ page }) => {
+    await page.goto('/yucho');
+    await expect(page.getByText('ゆうちょ連携').first()).toBeVisible({ timeout: TIMEOUT });
+  });
+});


### PR DESCRIPTION
## 概要

これまで専用 E2E が無かった主要画面に、CI のモックモードで実行可能な **smoke テスト**（表示確認中心）を追加する。Refs #140。

## 追加テスト（`tests/smoke-screens.spec.ts`）

| # | ルート | 確認内容 |
|---|---|---|
| 140-1 | `/plot-availability` | 「区画残数管理」見出し表示 |
| 140-2 | `/documents` | 「書類管理」見出し表示 |
| 140-3 | `/plots/[id]/documents` | 「書類」見出し表示（`mock-plot-1`） |
| 140-4 | `/masters` | 「マスタ管理」見出し表示（admin 限定） |
| 140-5 | `/profile` | 「アカウント設定」見出し表示 |
| 140-6 | `/yucho` | 「ゆうちょ連携」見出し表示 |

- すべて **admin の storageState** を使用（`/masters` が admin 限定のため一本化）。
- viewport は 1280×720（既定）のため `DesktopOnlyGate`（768px 未満ガード）は発動せず、PC 版コンポーネントを検証。
- **`/yucho`** は API モックが未実装だが、`PageHeader` は取得結果に依存せず描画され、データ取得は `useAsyncData` がエラーを握るため、見出しの表示のみ確認（クラッシュしないことの担保）。

## スコープ・残課題（issue にも記載）

- **`/payments`（入金管理）** は**ルート未実装**のためスコープ外。
- `/yucho` は API モックが無く、CSV 抽出・出力までの操作系 E2E は**実 API モード限定**。今回は smoke（表示）のみ。今後 `src/lib/api/yucho.ts` にモックを足せば操作系も CI 化可能。
- ロール別アクセス（manager/operator/viewer）の網羅は既存 `role-access.spec.ts` の範囲。本 PR は表示 smoke に限定。

issue #140 のチェックボックスのうち「各画面の smoke test（表示・主要操作）」を表示中心で前進。完全クローズは操作系 E2E と `/yucho` モック化が残るため、進捗として Refs 紐付け（自動クローズはしない）。

## テスト

- `tsc --noEmit` / ESLint clean
- E2E は本 CI（モックモード）で実行・確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
