### PR TITLE
feat(plots): レガシー移行値を「整備中」明示し検索文言を是正（暫定 #164 #166 #182）

### DIFF
--- a/src/__tests__/lib/legacy-plot-display.test.ts
+++ b/src/__tests__/lib/legacy-plot-display.test.ts
@@ -1,0 +1,51 @@
+import {
+  isLegacyPlotNumber,
+  isLegacyAreaName,
+} from '@/lib/legacy-plot-display';
+
+/**
+ * #164/#166/#182: レガシー移行値の判定。
+ * 正規化済みの業務値は false（＝整備中表示を出さない）になることが重要。
+ */
+describe('isLegacyPlotNumber (#164)', () => {
+  it('legacy-101 / unknown-xxx / bare legacy はレガシー', () => {
+    expect(isLegacyPlotNumber('legacy-101')).toBe(true);
+    expect(isLegacyPlotNumber('unknown-999')).toBe(true);
+    expect(isLegacyPlotNumber('legacy')).toBe(true); // 集計のセクション抽出結果
+    expect(isLegacyPlotNumber('LEGACY-5')).toBe(true); // 大小無視
+  });
+
+  it('業務区画番号（A-56 等）はレガシーではない', () => {
+    expect(isLegacyPlotNumber('A-56')).toBe(false);
+    expect(isLegacyPlotNumber('第1期-A-12')).toBe(false);
+    expect(isLegacyPlotNumber('123')).toBe(false);
+  });
+
+  it('null / undefined / 空は false', () => {
+    expect(isLegacyPlotNumber(null)).toBe(false);
+    expect(isLegacyPlotNumber(undefined)).toBe(false);
+    expect(isLegacyPlotNumber('')).toBe(false);
+  });
+});
+
+describe('isLegacyAreaName (#166)', () => {
+  it('chiku_cd-area_cd（数字-数字）/ unknown はレガシー', () => {
+    expect(isLegacyAreaName('1-29')).toBe(true);
+    expect(isLegacyAreaName('10-3')).toBe(true);
+    expect(isLegacyAreaName('unknown-123')).toBe(true);
+    expect(isLegacyAreaName('unknown')).toBe(true);
+  });
+
+  it('正式な期・区画名はレガシーではない', () => {
+    expect(isLegacyAreaName('第1期')).toBe(false);
+    expect(isLegacyAreaName('第3期樹林部')).toBe(false);
+    expect(isLegacyAreaName('A')).toBe(false);
+    expect(isLegacyAreaName('1.5')).toBe(false); // 小数の区画名はハイフンでないので対象外
+  });
+
+  it('null / undefined / 空は false', () => {
+    expect(isLegacyAreaName(null)).toBe(false);
+    expect(isLegacyAreaName(undefined)).toBe(false);
+    expect(isLegacyAreaName('')).toBe(false);
+  });
+});

--- a/src/components/legacy-aware-value.tsx
+++ b/src/components/legacy-aware-value.tsx
@@ -1,0 +1,56 @@
+import { cn } from '@/lib/utils';
+import {
+  isLegacyPlotNumber,
+  isLegacyAreaName,
+  LEGACY_VALUE_NOTE,
+} from '@/lib/legacy-plot-display';
+
+interface LegacyAwareValueProps {
+  value?: string | null;
+  /** plotNumber=区画番号/セクション, areaName=エリア/期 */
+  kind: 'plotNumber' | 'areaName';
+  className?: string;
+  emptyText?: string;
+}
+
+/**
+ * 区画番号・エリア値を表示し、レガシー移行値（legacy-101 / 1-29 等）の場合は
+ * 淡色・斜体＋ツールチップで「整備中」であることを示す（#164/#166/#182 暫定）。
+ * 正規化済みの値はそのまま表示する。
+ */
+export function LegacyAwareValue({
+  value,
+  kind,
+  className,
+  emptyText = '-',
+}: LegacyAwareValueProps) {
+  if (!value) return <span className={className}>{emptyText}</span>;
+
+  const isLegacy =
+    kind === 'plotNumber' ? isLegacyPlotNumber(value) : isLegacyAreaName(value);
+
+  if (!isLegacy) return <span className={className}>{value}</span>;
+
+  return (
+    <span className={cn('text-hai italic', className)} title={LEGACY_VALUE_NOTE}>
+      {value}
+    </span>
+  );
+}
+
+/**
+ * レガシー移行値が画面に含まれる場合に表示する注記。淡色・斜体の値の意味を補う。
+ * 表示するかどうかは呼び出し側で判定する（含まれない＝正規化済みなら出さない）。
+ */
+export function LegacyValueNote({ className }: { className?: string }) {
+  return (
+    <p className={cn('flex items-center gap-1.5 text-xs text-hai', className)}>
+      <span className="inline-flex shrink-0 items-center rounded-full border border-kohaku-200 bg-kohaku-50 px-1.5 py-0.5 text-[10px] font-medium text-kohaku-dark">
+        整備中
+      </span>
+      <span className="leading-snug">
+        淡色・斜体の区画番号／エリアはレガシー移行値です。正式な区画番号・区画名は整備中（要確認）です。
+      </span>
+    </p>
+  );
+}

--- a/src/components/plot-availability-management.tsx
+++ b/src/components/plot-availability-management.tsx
@@ -21,6 +21,8 @@ import {
   AVAILABILITY_STATUS_LABELS,
 } from '@/types/plot-constants';
 import PageHeader from '@/components/page-header';
+import { LegacyAwareValue, LegacyValueNote } from '@/components/legacy-aware-value';
+import { isLegacyPlotNumber, isLegacyAreaName } from '@/lib/legacy-plot-display';
 import {
   usePlotInventorySummary,
   usePlotInventoryPeriods,
@@ -439,7 +441,7 @@ export default function PlotAvailabilityManagement() {
               <Input
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder={displayMode === 'section' ? "区画名、期で検索..." : "面積、タイプ、期で検索..."}
+                placeholder={displayMode === 'section' ? "区画名・コードで検索…（期マスタ整備中）" : "面積・タイプ・コードで検索…（期マスタ整備中）"}
                 className="flex-1 sm:max-w-md"
               />
               <Button
@@ -586,11 +588,11 @@ export default function PlotAvailabilityManagement() {
                               "px-2 md:px-3 py-0.5 md:py-1 rounded-full text-xs font-medium",
                               periodColors[item.period as keyof typeof periodColors]
                             )}>
-                              {item.period}
+                              <LegacyAwareValue value={item.period} kind="areaName" emptyText="-" />
                             </span>
                           </td>
                           <td className="px-2 md:px-4 py-2 md:py-3 text-xs md:text-sm font-semibold text-sumi">
-                            {item.section}
+                            <LegacyAwareValue value={item.section} kind="plotNumber" emptyText="-" />
                             {item.category && (
                               <span className="ml-1 md:ml-2 text-xs text-hai font-normal">({item.category})</span>
                             )}
@@ -894,6 +896,11 @@ export default function PlotAvailabilityManagement() {
 
           {/* フッター情報（凡例）— 状況（残数）と使用率（%）は別軸である点を明示（#183） */}
           <div className="mt-5 text-sm text-hai bg-white rounded-elegant-lg p-4 border border-gin space-y-3">
+            {/* レガシー移行値が含まれる場合の注記（#182）*/}
+            {(displayData.some((it) => isLegacyPlotNumber(it.section) || isLegacyAreaName(it.period)) ||
+              displayAreaData.some((it) => isLegacyAreaName(it.period))) && (
+              <LegacyValueNote className="border-b border-gin pb-2" />
+            )}
             {/* 状況バッジの判定基準（残数の絶対値）*/}
             <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
               <span className="text-xs font-semibold text-sumi shrink-0">状況（残数で判定）</span>

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -26,6 +26,8 @@ import type { MasterItem, TaxTypeMasterItem } from '@/lib/api/masters';
 import { resolveMasterName, LEGACY_FEE_CODE_MAP } from '@/lib/master-resolve';
 import { getPlotSizeLabel } from '@/types/plot-constants';
 import { isEmptyDisplayValue, EMPTY_LABELS, type EmptyKind } from '@/lib/empty-display';
+import { LegacyAwareValue, LegacyValueNote } from '@/components/legacy-aware-value';
+import { isLegacyPlotNumber, isLegacyAreaName } from '@/lib/legacy-plot-display';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -314,8 +316,16 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
     <div className="space-y-4">
       {/* 区画情報 */}
       <Section title="区画情報">
-        <InfoField label="区画番号" value={plot.physicalPlot.plotNumber} />
-        <InfoField label="エリア" value={plot.physicalPlot.areaName} />
+        <InfoField
+          label="区画番号"
+          value={plot.physicalPlot.plotNumber}
+          hint={isLegacyPlotNumber(plot.physicalPlot.plotNumber) ? '整備中（レガシー移行値・要確認）' : undefined}
+        />
+        <InfoField
+          label="エリア"
+          value={plot.physicalPlot.areaName}
+          hint={isLegacyAreaName(plot.physicalPlot.areaName) ? '整備中（レガシー移行値・要確認）' : undefined}
+        />
         <InfoField
           label="物理区画面積 (㎡)"
           value={plot.physicalPlot.areaSqm?.toString()}
@@ -870,7 +880,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
         </svg>
         <span className="text-sumi font-medium truncate">
-          {plot.physicalPlot.plotNumber}
+          <LegacyAwareValue value={plot.physicalPlot.plotNumber} kind="plotNumber" />
         </span>
       </nav>
 
@@ -878,8 +888,11 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-4 md:mb-6 bg-white border border-gin rounded-elegant-lg shadow-elegant-sm p-4 md:p-5">
         <div className="min-w-0">
           <h2 className="text-lg md:text-2xl font-bold text-sumi truncate">
-            {plot.physicalPlot.plotNumber} - {plot.physicalPlot.areaName}
+            <LegacyAwareValue value={plot.physicalPlot.plotNumber} kind="plotNumber" /> - <LegacyAwareValue value={plot.physicalPlot.areaName} kind="areaName" />
           </h2>
+          {(isLegacyPlotNumber(plot.physicalPlot.plotNumber) || isLegacyAreaName(plot.physicalPlot.areaName)) && (
+            <LegacyValueNote className="mt-1" />
+          )}
           {primaryCustomer && (
             <p className="text-hai mt-1 text-sm md:text-base truncate">
               契約者: {primaryCustomer.name}

--- a/src/components/plot-list-table.tsx
+++ b/src/components/plot-list-table.tsx
@@ -16,6 +16,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { StatusBadge, type StatusBadgeProps } from '@/components/ui/status-badge';
 import { Switch } from '@/components/ui/switch';
 import { EmptyState } from '@/components/ui/empty-state';
+import { LegacyAwareValue, LegacyValueNote } from '@/components/legacy-aware-value';
+import { isLegacyPlotNumber, isLegacyAreaName } from '@/lib/legacy-plot-display';
 import { cn } from '@/lib/utils';
 
 // ===== 型定義 =====
@@ -371,10 +373,13 @@ export default function PlotListTable({
       )}
 
       {/* 件数表示 */}
-      <div className="mx-3 md:mx-6 mt-3 md:mt-4 flex items-center justify-between">
+      <div className="mx-3 md:mx-6 mt-3 md:mt-4 flex flex-col gap-2">
         <p className="text-sm text-hai">
           検索結果: <span className="font-bold text-sumi text-lg">{total}</span> 件
         </p>
+        {plots.some((p) => isLegacyPlotNumber(p.plotNumber) || isLegacyAreaName(p.areaName)) && (
+          <LegacyValueNote />
+        )}
       </div>
 
       {/* テーブル */}
@@ -546,10 +551,10 @@ export default function PlotListTable({
                         </div>
                       </td>
                       <td className="px-2 md:px-4 py-2 md:py-3 whitespace-nowrap text-sm text-sumi hidden sm:table-cell">
-                        {plot.areaName || '-'}
+                        <LegacyAwareValue value={plot.areaName} kind="areaName" />
                       </td>
                       <td className="px-2 md:px-4 py-2 md:py-3 whitespace-nowrap text-sm font-semibold text-sumi tabular-nums">
-                        {plot.plotNumber || '-'}
+                        <LegacyAwareValue value={plot.plotNumber} kind="plotNumber" />
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap text-sm text-sumi hidden sm:table-cell">
                         {contractYear}

--- a/src/lib/legacy-plot-display.ts
+++ b/src/lib/legacy-plot-display.ts
@@ -1,0 +1,35 @@
+/**
+ * レガシー移行値の判定（#164 / #166 / #182 の暫定対応）
+ *
+ * レガシーDB移行で、物理区画に内部値がそのまま格納されている:
+ * - plot_number = `legacy-{grave_cd}`（例 legacy-101）。区画残数の集計では
+ *   セクション抽出により bare `legacy` になることもある
+ * - area_name  = `{chiku_cd}-{area_cd}`（例 1-29）、または `unknown-{grave_cd}`
+ *
+ * 正式な区画番号・区画名（SectionNameMaster の期＋区画名）への正規化は
+ * 業務マッピング確定待ち（#151 / #14）。それまでの暫定として、未正規化値を
+ * 「整備中（要確認）」と明示し、信頼できる業務番号と誤認させないようにする。
+ *
+ * バックエンドで area_name / plot_number が正規化されれば判定は自然に false になり、
+ * 画面上の「整備中」表示も消える（自己無効化）。
+ */
+
+export const LEGACY_VALUE_NOTE =
+  '正式な区画番号・区画名は整備中です（レガシー移行値・要確認）';
+
+// legacy-101 / unknown-xxx / 集計上の bare 'legacy'・'unknown'
+const LEGACY_NUMBER_RE = /^(legacy|unknown)(-|$)/i;
+// chiku_cd-area_cd（数字-数字, 例 1-29）/ unknown-...
+const LEGACY_AREA_RE = /^(\d+-\d+|unknown(-|$))/i;
+
+/** plot_number（区画番号・セクション）がレガシー内部値か */
+export function isLegacyPlotNumber(value?: string | null): boolean {
+  if (!value) return false;
+  return LEGACY_NUMBER_RE.test(value.trim());
+}
+
+/** area_name（エリア・期）がレガシー内部コードか */
+export function isLegacyAreaName(value?: string | null): boolean {
+  if (!value) return false;
+  return LEGACY_AREA_RE.test(value.trim());
+}


### PR DESCRIPTION
## 概要

業務確認待ち #164 / #166 / #182 の **フロント単独で今すぐできる暫定対応**。レガシー移行で未正規化のまま表示されている区画番号・エリア（`legacy-101` / `1-29` 等）が、信頼できる業務番号と誤認されないよう画面で明示する。

本質的な修正（`area_name`→正式な期・`plot_number`→業務番号への正規化）は業務マッピング確定後のバックエンド対応（#151 / #14）。本 PR は表示上の暫定明示に限定し、**3 issue は close せず Refs 紐付け**。

## 変更内容

- **判定ロジック** `src/lib/legacy-plot-display.ts`（テスト付き）
  - `isLegacyPlotNumber`: `legacy-101` / `unknown-*` / 集計上の bare `legacy`
  - `isLegacyAreaName`: `1-29`（chiku_cd-area_cd）/ `unknown-*`
  - 正規化済みの業務値（`A-56`・`第1期` 等）は **false** → 後でバックエンドが正規化すれば表示は自然に元へ戻る（自己無効化）
- **表示コンポーネント** `LegacyAwareValue` / `LegacyValueNote`
  - レガシー値を淡色・斜体＋ツールチップ表示、画面にレガシー値が含まれるときだけ注記を表示
- **区画一覧**（plot-list-table）: エリア・区画番号セルを置換＋条件付き注記
- **区画詳細**（plot-detail-view）: タイトル・パンくず・区画番号/エリアの InfoField hint で「整備中」明示
- **区画残数管理**（plot-availability-management）:
  - **#182**: 検索プレースホルダー是正（「区画名、期で検索…」→「区画名・コードで検索…（期マスタ整備中）」）
  - 期・区画列を置換＋条件付き注記

## 影響範囲・安全性

- モックデータ（`A-001`/`第1期`/section `A` 等）は legacy 判定に**ヒットしない**ため、モックモードの E2E・スクショでは従来どおりの表示（注記も出ない）。実データのレガシー値でのみ「整備中」明示が有効化。
- 既存の該当コンポーネントのユニットテストは無し。旧プレースホルダー文言を参照するテストも無し。

## テスト

- `npx jest src/__tests__/lib/legacy-plot-display.test.ts` 6 passed
- ESLint clean / `tsc --noEmit` 変更ファイルにエラーなし

## 残作業（本 PR 範囲外・各 issue にコメント済み）

- 正式な区画番号・期・区画名への正規化（`chiku_cd→期`、`grave_mei→業務番号` の業務マッピング確定後にバックエンドで実施）→ #151 / #14
- それにより #164/#166/#182 および集計不一致 #173 が本質解消

Refs #164 #166 #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
