### PR TITLE
feat: Dockerfile 追加 + standalone 出力（ローカル/コンテナ運用対応）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+.git
+.github
+coverage
+playwright-report
+test-results
+e2e
+*.log
+.env*
+Dockerfile
+.dockerignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,93 @@
+# syntax=docker/dockerfile:1
+# ============================================
+# Stage 0: Build @komine/types
+# ============================================
+FROM node:20-alpine AS types
+
+RUN apk add --no-cache git
+
+WORKDIR /packages/types
+
+# TYPES_REF: ビルドする @komine/types の git ref (commit SHA 固定)
+# backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
+# セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
+# types 更新時はこの値を明示的に更新する。
+ARG TYPES_REF=0a9145a962251b3055c9ad3691fab6ed9e21e6c9
+
+RUN git clone https://github.com/zaitsu82/komine-types.git . && \
+    git checkout ${TYPES_REF} && \
+    npm ci && \
+    npm run build
+
+# ============================================
+# Stage 1: Dependencies
+# ============================================
+FROM node:20-alpine AS deps
+
+WORKDIR /app
+
+# npm_config_install_links: file:依存（@komine/types）を常に実体コピーで解決する
+# （backend Dockerfile と同方式。詳細: zaitsu82/komine-crm-backend#60）
+ENV npm_config_install_links=true
+
+# @komine/types パッケージを配置（file:../packages/types の解決用）
+COPY --from=types /packages/types /packages/types
+
+COPY package*.json ./
+RUN npm ci
+
+# ============================================
+# Stage 2: Build
+# ============================================
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+ENV npm_config_install_links=true
+COPY --from=types /packages/types /packages/types
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# NEXT_PUBLIC_* はビルド時にクライアントコードへ埋め込まれる。
+# デプロイ先ごとに --build-arg で渡す（値を変えたら再ビルドが必要）。
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL} \
+    NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL} \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY} \
+    NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+# ============================================
+# Stage 3: Production (next.config.ts の output: 'standalone' を使用)
+# ============================================
+FROM node:20-alpine AS production
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0 \
+    NEXT_TELEMETRY_DISABLED=1
+
+# next/image の本番画像最適化に sharp が必要（standalone 出力には含まれないため個別導入）
+RUN npm install --no-save --no-package-lock sharp
+
+# セキュリティ: non-root ユーザーで実行
+RUN addgroup -g 1001 nodejs && adduser -D -u 1001 -G nodejs nextjs
+
+# standalone サーバ + 静的アセット + public を配置
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
+
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import path from "path";
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@komine/types'],
+  // Docker 運用（komine-local のローカルサーバ / 将来の ECS）用に自己完結サーバを出力する。
+  // Vercel のビルドには影響しない（Vercel は出力を独自に扱う）。
+  output: 'standalone',
   // 画面右下の Next.js Dev Tools / 開発インジケータを非表示にする (#189)。
   // 本番ビルドでは元々出ないが、非本番ビルド配信時にも管理画面へ出さないため明示的に無効化。
   devIndicators: false,


### PR DESCRIPTION
## 概要

運用方針のピボット（AWS → **事務所サーバ1台のローカル運用**、2026-06 決定）に伴い、frontend をコンテナ化可能にする。`komine-local`（docker-compose 一式）から `build: ../komine-crm-frontend` で参照される。

なお `komine-infra` の `deploy-frontend.yml` は元々 Dockerfile の存在を前提にしており（未作成だった）、AWS 構成に戻る場合もこの Dockerfile がそのまま使える。

## 変更内容

- **Dockerfile**（新規）: backend と同方式の multi-stage
  - Stage 0: `@komine/types` を **commit SHA 固定**で git clone → build（main 追従によるサプライチェーン汚染対策、backend #60 と同方式）
  - `npm_config_install_links=true` で `file:../packages/types` を実体コピー解決
  - production は standalone 出力 + non-root（uid 1001）+ HEALTHCHECK
  - `next/image` 用に **sharp を同梱**（standalone には含まれないため。アプリ挙動の変更なし）
  - `NEXT_PUBLIC_*` は `--build-arg` で注入（ビルド時埋め込み）
- **next.config.ts**: `output: 'standalone'` を追加（**Vercel ビルドには影響しない**）
- **.dockerignore**（新規）

## ⚠️ 運用メモ

- `TYPES_REF` は komine-types main の最新 SHA（`0a9145a`）で固定。**types 更新時は backend の Dockerfile 同様このピンの更新が必要**。
- Docker 環境がこの作業環境に無いため、**初回ビルド検証はサーバセットアップ時に実施**（komine-local/docs/setup.md 手順6）。問題があれば follow-up で直す。

## 検証

- 既存テスト・lint への影響なし（アプリコードの変更は next.config.ts の output 追加のみ）
- Vercel preview ビルドが green ならこの構成変更が Vercel 互換であることの確認になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)