### PR TITLE
fix: 書類ダウンロードボタンの表示条件を templateType ベースに変更 (#230)

### DIFF
--- a/src/__tests__/lib/api/documents-can-regenerate.test.ts
+++ b/src/__tests__/lib/api/documents-can-regenerate.test.ts
@@ -1,0 +1,31 @@
+/**
+ * canRegenerateDocument のテスト（#230）
+ *
+ * 書類ダウンロードボタンの表示条件。本番（非モック）では backend が
+ * fileName を返さないため、fileName ではなく templateType ベースで
+ * 再生成可否を判定することを保証する。
+ */
+
+import { DOCUMENT_TEMPLATE_TYPES } from '@komine/types/api';
+import { canRegenerateDocument } from '@/lib/api/documents';
+
+describe('canRegenerateDocument (#230)', () => {
+  it.each(DOCUMENT_TEMPLATE_TYPES.map((t) => [t]))(
+    'テンプレートタイプ %s は再生成可能',
+    (templateType) => {
+      expect(canRegenerateDocument(templateType)).toBe(true);
+    }
+  );
+
+  it('templateType が null のとき再生成不可', () => {
+    expect(canRegenerateDocument(null)).toBe(false);
+  });
+
+  it('templateType が空文字のとき再生成不可', () => {
+    expect(canRegenerateDocument('')).toBe(false);
+  });
+
+  it('未知の templateType は再生成不可', () => {
+    expect(canRegenerateDocument('unknown-template')).toBe(false);
+  });
+});

--- a/src/components/document-detail-view.tsx
+++ b/src/components/document-detail-view.tsx
@@ -7,6 +7,7 @@
 import { Button } from '@/components/ui/button';
 import {
   useDocumentDetail,
+  canRegenerateDocument,
   DOCUMENT_TYPE_LABELS,
   DOCUMENT_STATUS_LABELS,
   DOCUMENT_STATUS_COLORS,
@@ -117,8 +118,13 @@ export function DocumentDetailView({
             <Edit className="mr-2 h-4 w-4" />
             編集
           </Button>
-          {data.fileName && (
-            <Button variant="outline" size="sm" onClick={() => onDownload(documentId)}>
+          {canRegenerateDocument(data.templateType) && (
+            <Button
+              variant="outline"
+              size="sm"
+              title="PDFを再生成してダウンロード"
+              onClick={() => onDownload(documentId)}
+            >
               <Download className="mr-2 h-4 w-4" />
               ダウンロード
             </Button>

--- a/src/components/document-list-view.tsx
+++ b/src/components/document-list-view.tsx
@@ -17,6 +17,7 @@ import {
 import {
   useDocumentList,
   DocumentListItem,
+  canRegenerateDocument,
   DOCUMENT_TYPE_LABELS,
   DOCUMENT_STATUS_LABELS,
   DOCUMENT_STATUS_COLORS,
@@ -252,10 +253,11 @@ export function DocumentListView({
                       >
                         <Eye className="h-4 w-4" />
                       </Button>
-                      {doc.fileName && (
+                      {canRegenerateDocument(doc.templateType) && (
                         <Button
                           variant="ghost"
                           size="sm"
+                          title="PDFを再生成してダウンロード"
                           onClick={(e) => {
                             e.stopPropagation();
                             onDownload(doc.id);

--- a/src/hooks/useDocuments.ts
+++ b/src/hooks/useDocuments.ts
@@ -21,6 +21,7 @@ import {
   regenerateDocumentPdf,
   generatePdf,
   downloadPdfFromBase64,
+  canRegenerateDocument,
   DOCUMENT_TYPE_LABELS,
   DOCUMENT_STATUS_LABELS,
   DOCUMENT_STATUS_COLORS,
@@ -37,7 +38,7 @@ interface DocumentListParams extends DocumentSearchParams {
 
 // 型のエクスポート
 export type { DocumentListItem, DocumentDetail, CreateDocumentRequest, UpdateDocumentRequest, GeneratePdfRequest };
-export { DOCUMENT_TYPE_LABELS, DOCUMENT_STATUS_LABELS, DOCUMENT_STATUS_COLORS };
+export { canRegenerateDocument, DOCUMENT_TYPE_LABELS, DOCUMENT_STATUS_LABELS, DOCUMENT_STATUS_COLORS };
 
 // 一覧取得フック
 export function useDocumentList(initialParams?: Partial<DocumentListParams>) {

--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -2,6 +2,7 @@
  * 書類管理API
  */
 
+import { DOCUMENT_TEMPLATE_TYPES } from '@komine/types/api';
 import { ApiResponse } from './types';
 import { apiGet, apiPost, apiPut, apiDelete, shouldUseMockData, API_CONFIG } from './client';
 
@@ -137,6 +138,21 @@ export interface UpdateDocumentRequest {
   status?: DocumentStatus;
   templateData?: Record<string, unknown>;
   notes?: string;
+}
+
+/**
+ * 書類が template_data からPDF再生成（=ダウンロード）可能かを判定する。
+ *
+ * ダウンロードボタンの実処理は `regenerateDocumentPdf`（template_data からの
+ * 再生成）なので、表示可否は fileName の有無ではなく templateType の有無で
+ * 判定する。backend の regenerate-pdf も同じ判定
+ * （`isDocumentTemplateType` = DOCUMENT_TEMPLATE_TYPES）を行う（#230）。
+ */
+export function canRegenerateDocument(templateType: string | null): boolean {
+  return (
+    !!templateType &&
+    (DOCUMENT_TEMPLATE_TYPES as readonly string[]).includes(templateType)
+  );
 }
 
 // ダウンロードURLレスポンス
@@ -624,12 +640,7 @@ async function mockRegenerateDocumentPdf(id: string): Promise<ApiResponse<Genera
     };
   }
 
-  if (
-    !doc.templateType ||
-    !['invoice', 'postcard', 'permit', 'payment-guide'].includes(
-      doc.templateType
-    )
-  ) {
+  if (!canRegenerateDocument(doc.templateType)) {
     return {
       success: false,
       error: {


### PR DESCRIPTION
## 概要
本番（非モック）環境で全書類のダウンロードボタンが表示されない問題を修正。

backend は list/detail レスポンスに `fileName` を含めず、DB の `file_name` 列に書く経路も無いため、`doc.fileName` による表示判定は本番で恒久 false だった。ボタンの実処理（`regenerateDocumentPdf` = `template_data` からの再生成）は正常に動くため、表示条件を「再生成可能か」= templateType ベースに変更した。

## 変更内容
- `canRegenerateDocument(templateType)` を `src/lib/api/documents.ts` に新設
  - `@komine/types` の `DOCUMENT_TEMPLATE_TYPES` に基づく判定
  - backend `regenerate-pdf` の `isDocumentTemplateType` と同一基準
- `document-list-view.tsx` / `document-detail-view.tsx` の表示条件を `doc.fileName` → `canRegenerateDocument(doc.templateType)` に差し替え
- ボタンに「PDFを再生成してダウンロード」ツールチップ追加（処理実体との意味ねじれ解消）
- `mockRegenerateDocumentPdf` の inline 判定も同ヘルパーに統一
- 単体テスト追加（全テンプレートタイプ + null/空/未知）

## スコープ外
- backend の `fileName`/`fileSize`/`mimeType` 返却（型整合）— backend 側で対応（#198 の WIP と調整）
- 添付ファイルの実体ダウンロード — backend #198 に委ねる

## テスト
- `npx tsc --noEmit` clean
- `npm test` 411 passed（新規9件含む）
- `npm run lint` clean

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)