### PR TITLE
fix: パスワード変更リクエストに confirmPassword を追加（backend契約と一致） (#229)

### DIFF
--- a/src/__tests__/components/profile-page-password.test.tsx
+++ b/src/__tests__/components/profile-page-password.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * ProfilePage パスワード変更フォームのテスト（#229）
+ *
+ * backend changePasswordSchema は confirmPassword を必須にしているため、
+ * フロントが confirmPassword を送らないと常に 400 になる。
+ * リクエストに confirmPassword が含まれることを回帰テストで保証する。
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ProfilePage from '@/components/profile-page';
+
+const changePasswordMock = jest.fn();
+const updateProfileMock = jest.fn();
+
+jest.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'staff-1',
+      email: 'test@example.com',
+      name: 'テスト太郎',
+      role: 'operator',
+    },
+    changePassword: (...args: unknown[]) => changePasswordMock(...args),
+    updateProfile: (...args: unknown[]) => updateProfileMock(...args),
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/components/theme-switcher', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('ProfilePage パスワード変更 (#229)', () => {
+  beforeEach(() => {
+    changePasswordMock.mockReset();
+    changePasswordMock.mockResolvedValue({ success: true });
+  });
+
+  async function fillAndSubmit(current: string, next: string, confirm: string) {
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText('現在のパスワード'), current);
+    await user.type(screen.getByLabelText('新しいパスワード'), next);
+    await user.type(screen.getByLabelText('新しいパスワード（確認）'), confirm);
+    await user.click(screen.getByRole('button', { name: 'パスワードを変更' }));
+  }
+
+  it('changePassword に confirmPassword を含めて送信する', async () => {
+    render(<ProfilePage onBack={() => {}} />);
+    await fillAndSubmit('OldPass123', 'NewPass123', 'NewPass123');
+
+    await waitFor(() => {
+      expect(changePasswordMock).toHaveBeenCalledWith({
+        currentPassword: 'OldPass123',
+        newPassword: 'NewPass123',
+        confirmPassword: 'NewPass123',
+      });
+    });
+  });
+
+  it('大文字・小文字・数字を含まないパスワードはサーバに送らず即時エラー', async () => {
+    render(<ProfilePage onBack={() => {}} />);
+    await fillAndSubmit('OldPass123', 'alllowercase1', 'alllowercase1');
+
+    expect(
+      screen.getByText('新しいパスワードは大文字、小文字、数字を含む必要があります')
+    ).toBeInTheDocument();
+    expect(changePasswordMock).not.toHaveBeenCalled();
+  });
+
+  it('確認パスワード不一致はサーバに送らず即時エラー', async () => {
+    render(<ProfilePage onBack={() => {}} />);
+    await fillAndSubmit('OldPass123', 'NewPass123', 'NewPass124');
+
+    expect(screen.getByText('新しいパスワードが一致しません')).toBeInTheDocument();
+    expect(changePasswordMock).not.toHaveBeenCalled();
+  });
+
+  it('成功時は入力フィールドがクリアされる', async () => {
+    render(<ProfilePage onBack={() => {}} />);
+    await fillAndSubmit('OldPass123', 'NewPass123', 'NewPass123');
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('現在のパスワード')).toHaveValue('');
+      expect(screen.getByLabelText('新しいパスワード')).toHaveValue('');
+      expect(screen.getByLabelText('新しいパスワード（確認）')).toHaveValue('');
+    });
+  });
+});

--- a/src/components/profile-page.tsx
+++ b/src/components/profile-page.tsx
@@ -107,8 +107,19 @@ export default function ProfilePage({ onBack }: ProfilePageProps) {
       return;
     }
 
+    // backend passwordSchema（authValidation.ts）と同条件で即時フィードバック
     if (newPassword.length < 8) {
       setPasswordError('新しいパスワードは8文字以上で入力してください');
+      return;
+    }
+
+    if (newPassword.length > 128) {
+      setPasswordError('新しいパスワードは128文字以下で入力してください');
+      return;
+    }
+
+    if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(newPassword)) {
+      setPasswordError('新しいパスワードは大文字、小文字、数字を含む必要があります');
       return;
     }
 
@@ -117,7 +128,7 @@ export default function ProfilePage({ onBack }: ProfilePageProps) {
       return;
     }
 
-    const result = await changePassword({ currentPassword, newPassword });
+    const result = await changePassword({ currentPassword, newPassword, confirmPassword });
 
     if (result.success) {
       setCurrentPassword('');
@@ -329,7 +340,7 @@ export default function ProfilePage({ onBack }: ProfilePageProps) {
                     className="mt-1"
                     autoComplete="new-password"
                   />
-                  <p className="text-xs text-hai mt-1">8文字以上で入力してください</p>
+                  <p className="text-xs text-hai mt-1">8文字以上で、大文字・小文字・数字を含めてください</p>
                 </div>
                 <div>
                   <Label htmlFor="confirm-password">新しいパスワード（確認）</Label>

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -116,6 +116,8 @@ export interface BackendCurrentUserResponse {
 export interface ChangePasswordRequest {
   currentPassword: string;
   newPassword: string;
+  /** backend changePasswordSchema で必須（欠落すると 400 VALIDATION_ERROR）#229 */
+  confirmPassword: string;
 }
 
 export interface UpdateProfileRequest {


### PR DESCRIPTION
## 概要
本番（非モック）環境でパスワード変更が常に 400 エラーになる問題を修正。

backend の `changePasswordSchema` は `confirmPassword` を必須にしているが、フロントは `{ currentPassword, newPassword }` しか送っておらず、validate ミドルウェアがコントローラ到達前に弾いていた（案A: フロント側を契約一致させる、issue推奨の最小修正）。

## 変更内容
- `ChangePasswordRequest`（`src/lib/api/types.ts`）に `confirmPassword: string` を追加
- `profile-page.tsx` の `handlePasswordSubmit` で `confirmPassword` を同梱して送信
- フロント側バリデーションを backend `passwordSchema` と同条件に強化（max 128 / 大文字・小文字・数字必須）→ サーバ 400 前に即時フィードバック（issue の二次指摘対応）
- パスワード入力欄のヒントテキストを要件に合わせて更新
- 回帰テスト4件追加（`profile-page-password.test.tsx`）
  - **confirmPassword がリクエストに含まれること**（#229 の核心）
  - 強度不足/不一致は送信前に弾くこと、成功時のフィールドクリア

## スコープ外
- backend `authRoutes.test.ts` の validate no-op モック解消（backend側の回帰テスト）は backend リポで別途対応

## テスト
- `npx tsc --noEmit` clean
- `npm test` 406 passed（新規4件含む）
- `npm run lint` clean

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)