### PR TITLE
fix: 区画編集の期/区画2段階セレクトを非同期マスタ到着後に初期化 (#220)

### DIFF
--- a/src/__tests__/components/plot-form/basic-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/basic-info-tab.test.tsx
@@ -219,6 +219,82 @@ describe('BasicInfoTab', () => {
     expect(notesInput).toHaveValue('2026年度分は分割払い');
   });
 
+  describe('期/区画 2段階セレクトの初期化（#220）', () => {
+    const sectionNameMasters = [
+      { id: 1, code: 'S1', name: '東1', description: null, sortOrder: 1, isActive: true, period: '第1期' },
+      { id: 2, code: 'S2', name: '西2', description: null, sortOrder: 2, isActive: true, period: '第2期' },
+    ];
+
+    it('マスタが初期レンダー後に到着しても、登録済み areaName から期が復元される', async () => {
+      // 編集画面の実挙動: 初回レンダー時は masterData が空（非同期取得中）
+      const { rerender } = render(
+        <TabHost defaultValues={{
+          physicalPlot: { plotNumber: 'A-001', areaName: '西2', areaSqm: 3.6, notes: null },
+        }}>
+          {(h) => <BasicInfoTab {...h} masterData={emptyMasterData} />}
+        </TabHost>
+      );
+
+      // マスタ未到着の間は期セレクトが未選択
+      // （periodSelect は最初の mock-select。value 空）
+      expect(screen.getAllByTestId('mock-select')[0]).toHaveAttribute('data-value', '');
+
+      // マスタ到着（再レンダー）
+      rerender(
+        <TabHost defaultValues={{
+          physicalPlot: { plotNumber: 'A-001', areaName: '西2', areaSqm: 3.6, notes: null },
+        }}>
+          {(h) => (
+            <BasicInfoTab
+              {...h}
+              masterData={{ ...emptyMasterData, sectionNames: sectionNameMasters }}
+            />
+          )}
+        </TabHost>
+      );
+
+      // areaName='西2' の所属期 '第2期' が自動選択され、区画サブセレクトも表示される
+      const selects = screen.getAllByTestId('mock-select');
+      expect(selects[0]).toHaveAttribute('data-value', '第2期');
+      // サブセレクト（区画）が areaName を保持したまま表示される
+      expect(selects[1]).toHaveAttribute('data-value', '西2');
+    });
+
+    it('マスタが最初から存在する場合も期が選択される', () => {
+      render(
+        <TabHost defaultValues={{
+          physicalPlot: { plotNumber: 'A-001', areaName: '東1', areaSqm: 3.6, notes: null },
+        }}>
+          {(h) => (
+            <BasicInfoTab
+              {...h}
+              masterData={{ ...emptyMasterData, sectionNames: sectionNameMasters }}
+            />
+          )}
+        </TabHost>
+      );
+
+      expect(screen.getAllByTestId('mock-select')[0]).toHaveAttribute('data-value', '第1期');
+    });
+
+    it('areaName がどの期にも属さない（レガシー未正規化）場合は期未選択のまま', () => {
+      render(
+        <TabHost defaultValues={{
+          physicalPlot: { plotNumber: 'A-001', areaName: '1', areaSqm: 3.6, notes: null },
+        }}>
+          {(h) => (
+            <BasicInfoTab
+              {...h}
+              masterData={{ ...emptyMasterData, sectionNames: sectionNameMasters }}
+            />
+          )}
+        </TabHost>
+      );
+
+      expect(screen.getAllByTestId('mock-select')[0]).toHaveAttribute('data-value', '');
+    });
+  });
+
   it('viewMode=trueの場合、契約備考の値が表示用ボックスに表示される（#145）', () => {
     render(
       <TabHost defaultValues={{

--- a/src/components/plot-form/BasicInfoTab.tsx
+++ b/src/components/plot-form/BasicInfoTab.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { PlotTabBaseProps } from './types';
 import { ViewModeField, ViewModeSelect, ViewModeTextarea } from './ViewModeField';
 import { SelectItem } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
-import { useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Gender, PaymentStatus } from '@komine/types';
 import { defaultApplicant } from '@/lib/validations/plot-form';
@@ -32,13 +31,24 @@ export function BasicInfoTab({
   }, [masterData?.sectionNames]);
 
   // 現在のareaNameから所属する期を特定
-  const [selectedPeriod, setSelectedPeriod] = useState<string>(() => {
-    const currentAreaName = watch('physicalPlot.areaName');
-    for (const [period, sections] of Object.entries(sectionsByPeriod)) {
-      if (sections.includes(currentAreaName)) return period;
+  const [selectedPeriod, setSelectedPeriod] = useState<string>('');
+
+  // マスタ（sectionNames）は非同期取得のため、編集画面の初期レンダー時点では
+  // sectionsByPeriod が空で期を導出できない。useState 初期化子はマスタ到着後に
+  // 再実行されないため、マスタ到着後・reset による areaName 後発更新後に
+  // 期を再導出する（#220）。
+  // ユーザーが手動で期を変えたときの areaName クリアは onValueChange 側で行い、
+  // この effect では areaName をクリアしない（自動同期での消失を防ぐ）。
+  const areaName = watch('physicalPlot.areaName');
+  useEffect(() => {
+    if (!areaName) return;
+    const found = Object.entries(sectionsByPeriod).find(([, sections]) =>
+      sections.includes(areaName)
+    )?.[0];
+    if (found) {
+      setSelectedPeriod((prev) => (prev === found ? prev : found));
     }
-    return '';
-  });
+  }, [sectionsByPeriod, areaName]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## 概要
区画編集フォームで『区画（期/区画）』2段階セレクトが初期化されず、既存区画の区画名を表示・編集できない問題を修正。

`selectedPeriod` の useState 初期化子はマスタ（sectionNames）の非同期到着後に再実行されないため、編集画面では常に期未選択＝区画サブセレクト非表示になっていた。

## 変更内容
- `BasicInfoTab.tsx`: `selectedPeriod` を「派生値＋同期 effect」方式に変更
  - マスタ到着後・reset による areaName 後発更新後に、areaName の所属期を再導出
  - effect による自動同期では areaName をクリアしない（issue 指摘の二次被害「期を触ると区画名が消える」は、手動変更時のみのクリアに限定して回避）
- 回帰テスト3件追加
  - マスタが初期レンダー後に到着しても期が復元される（本修正の核心）
  - マスタが最初からある場合の初期化
  - レガシー未正規化 areaName の場合は期未選択のまま（仕様どおり）

## 期待値の注記
本番レガシーデータ（`area_name` が 1-29 等の未正規化値）での期復元は本修正では効かず、backend の正規化（backend #151/#14）が前提（issue 記載のとおり）。

## テスト
- `npx tsc --noEmit` clean
- `npm test` 405 passed（新規3件含む）
- `npm run lint` clean

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)