### PR TITLE
fix: 区画名マスタの期(period)未入力を送信前に弾く (#227)

### DIFF
--- a/src/__tests__/components/masters-management-section-name.test.tsx
+++ b/src/__tests__/components/masters-management-section-name.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * マスタ管理 区画名（section-name）の期必須チェック（#227）
+ *
+ * 区画名マスタは DB で period が NOT NULL。期未入力のまま送信すると
+ * backend で NOT NULL 違反 → 原因不明の 500 になるため、
+ * フロントで送信前に弾くことを保証する。
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import MastersManagement from '@/components/masters-management';
+
+jest.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({
+    user: { id: 'staff-1', email: 'admin@example.com', name: '管理者', role: 'admin' },
+  }),
+}));
+
+const getAllMastersMock = jest.fn();
+const createMasterItemMock = jest.fn();
+jest.mock('@/lib/api', () => ({
+  getAllMasters: (...args: unknown[]) => getAllMastersMock(...args),
+  createMasterItem: (...args: unknown[]) => createMasterItemMock(...args),
+  updateMasterItem: jest.fn(),
+  deleteMasterItem: jest.fn(),
+}));
+
+jest.mock('@/lib/toast', () => ({
+  showSuccess: jest.fn(),
+  showError: jest.fn(),
+}));
+
+jest.mock('@/hooks/useMasters', () => ({
+  clearMastersCache: jest.fn(),
+}));
+
+// Radix UI Select はJSDOMで動かないため最小モック
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: () => null,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const emptyMasters = {
+  cemeteryType: [],
+  paymentMethod: [],
+  taxType: [],
+  calcType: [],
+  billingType: [],
+  recipientType: [],
+  constructionType: [],
+  sectionName: [],
+};
+
+async function openSectionNameCreateDialog() {
+  const user = userEvent.setup();
+  render(<MastersManagement />);
+
+  // データロード完了後、区画名タブへ切り替え
+  const sectionNameNav = await screen.findByRole('button', { name: /区画名/ });
+  await user.click(sectionNameNav);
+
+  await user.click(screen.getByRole('button', { name: /新規登録/ }));
+  return user;
+}
+
+describe('マスタ管理 区画名の期必須チェック (#227)', () => {
+  beforeEach(() => {
+    getAllMastersMock.mockReset();
+    getAllMastersMock.mockResolvedValue({ success: true, data: emptyMasters });
+    createMasterItemMock.mockReset();
+    createMasterItemMock.mockResolvedValue({
+      success: true,
+      data: { id: 1, code: 'S1', name: '東1', description: null, sortOrder: null, isActive: true, period: '第1期' },
+    });
+  });
+
+  it('期未入力で作成するとエラー表示し、API を呼ばない', async () => {
+    const user = await openSectionNameCreateDialog();
+
+    await user.type(screen.getByLabelText('名称 *'), '東1');
+    await user.click(screen.getByRole('button', { name: '作成' }));
+
+    expect(await screen.findByText('期を入力してください')).toBeInTheDocument();
+    expect(createMasterItemMock).not.toHaveBeenCalled();
+  });
+
+  it('期を入力すれば period 付きで作成 API を呼ぶ', async () => {
+    const user = await openSectionNameCreateDialog();
+
+    await user.type(screen.getByLabelText('名称 *'), '東1');
+    await user.type(screen.getByLabelText('期 *'), '第1期');
+    await user.click(screen.getByRole('button', { name: '作成' }));
+
+    await waitFor(() => {
+      expect(createMasterItemMock).toHaveBeenCalledWith('section-name', {
+        name: '東1',
+        description: null,
+        sortOrder: null,
+        period: '第1期',
+      });
+    });
+  });
+});

--- a/src/components/masters-management.tsx
+++ b/src/components/masters-management.tsx
@@ -121,6 +121,13 @@ export default function MastersManagement() {
       return;
     }
 
+    // 区画名マスタは period が DB で NOT NULL。未入力のまま送ると backend で
+    // NOT NULL 違反 → 原因不明の 500 になるため、送信前に弾く（#227）
+    if (isSectionName && !formData.period.trim()) {
+      setFormError('期を入力してください');
+      return;
+    }
+
     setIsSaving(true);
     setFormError('');
 


### PR DESCRIPTION
## 概要
区画名（section-name）マスタを期未入力で作成すると、backend で NOT NULL 違反 → 原因不明の 500 になる問題のフロント側修正。

## 変更内容
- `masters-management.tsx` の `handleSubmit` に区画名マスタ専用の期必須チェックを追加（issue 修正方針 1)）
  - 未入力時は『期を入力してください』を即時表示し、API を呼ばない
- 回帰テスト2件追加（`masters-management-section-name.test.tsx`）

## スコープ外（backend リポで別途対応）
- issue 修正方針 3)（backend `masterValidation.ts` の section-name 専用スキーマ分岐で 400 VALIDATION_ERROR を返す堅牢化）は backend リポジトリ側で対応予定

## テスト
- `npx tsc --noEmit` clean
- `npm test` 404 passed（新規2件含む）
- `npm run lint` clean

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)