### PR TITLE
fix: 更新プレビューの配列差分を id 突合に変更 (#222)

### DIFF
--- a/src/__tests__/components/plot-form/preview-helper.test.ts
+++ b/src/__tests__/components/plot-form/preview-helper.test.ts
@@ -1,0 +1,126 @@
+/**
+ * previewHelper buildPlotDiffSections の配列差分テスト（#222）
+ *
+ * 配列差分は index でなく id で突合すること（中間削除・並べ替えで
+ * 別レコード同士を比較して誤った差分を表示しない）を保証する。
+ */
+
+import { buildPlotDiffSections } from '@/components/plot-form/previewHelper';
+import { defaultPlotFormData } from '@/lib/validations/plot-form';
+import type { PlotFormData } from '@/lib/validations/plot-form';
+
+type BuriedPerson = NonNullable<PlotFormData['buriedPersons']>[number];
+
+function makeBuriedPerson(overrides: Partial<BuriedPerson>): BuriedPerson {
+  return {
+    name: '',
+    nameKana: null,
+    relationship: null,
+    birthDate: null,
+    deathDate: null,
+    gender: null,
+    burialDate: null,
+    posthumousName: null,
+    reportDate: null,
+    religion: null,
+    deathPlace: null,
+    causeOfDeath: null,
+    chiefMournerName: null,
+    chiefMournerRelationship: null,
+    notes: null,
+    ...overrides,
+  } as BuriedPerson;
+}
+
+function makeFormData(buriedPersons: BuriedPerson[]): PlotFormData {
+  return {
+    ...defaultPlotFormData,
+    buriedPersons,
+  } as PlotFormData;
+}
+
+const personA = makeBuriedPerson({ id: 'bp-1', name: '甲野一郎', deathDate: '2020-01-01' });
+const personB = makeBuriedPerson({ id: 'bp-2', name: '乙野二郎', deathDate: '2021-02-02' });
+const personC = makeBuriedPerson({ id: 'bp-3', name: '丙野三郎', deathDate: '2022-03-03' });
+
+describe('buildPlotDiffSections 配列差分の id 突合 (#222)', () => {
+  it('中間要素の削除は「削除」のみ表示し、後続要素を変更扱いしない', () => {
+    const original = makeFormData([personA, personB, personC]);
+    // useFieldArray.remove で B を削除 → C が前詰め
+    const current = makeFormData([personA, personC]);
+
+    const sections = buildPlotDiffSections(original, current);
+    const buriedSections = sections.filter((s) => s.title.startsWith('埋葬者'));
+
+    expect(buriedSections).toHaveLength(1);
+    expect(buriedSections[0].title).toBe('埋葬者 2（削除）');
+    expect(buriedSections[0].items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: '氏名', before: '乙野二郎', after: '' }),
+      ])
+    );
+  });
+
+  it('並べ替えのみでは差分を出さない', () => {
+    const original = makeFormData([personA, personB]);
+    const current = makeFormData([personB, personA]);
+
+    const sections = buildPlotDiffSections(original, current);
+    expect(sections.filter((s) => s.title.startsWith('埋葬者'))).toHaveLength(0);
+  });
+
+  it('id 無しの新規要素は表示位置の連番で「追加」と表示する', () => {
+    const newPerson = makeBuriedPerson({ name: '新規四郎' }); // id 無し
+    const original = makeFormData([personA]);
+    const current = makeFormData([personA, newPerson]);
+
+    const sections = buildPlotDiffSections(original, current);
+    const buriedSections = sections.filter((s) => s.title.startsWith('埋葬者'));
+
+    expect(buriedSections).toHaveLength(1);
+    expect(buriedSections[0].title).toBe('埋葬者 2（追加）');
+    expect(buriedSections[0].items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: '氏名', before: '', after: '新規四郎' }),
+      ])
+    );
+  });
+
+  it('同一 id の内容変更はフィールド差分のみ表示する', () => {
+    const changed = { ...personB, name: '乙野次郎' };
+    const original = makeFormData([personA, personB]);
+    const current = makeFormData([personA, changed]);
+
+    const sections = buildPlotDiffSections(original, current);
+    const buriedSections = sections.filter((s) => s.title.startsWith('埋葬者'));
+
+    expect(buriedSections).toHaveLength(1);
+    expect(buriedSections[0].title).toBe('埋葬者 2');
+    expect(buriedSections[0].items).toEqual([
+      { label: '氏名', before: '乙野二郎', after: '乙野次郎' },
+    ]);
+  });
+
+  it('中間削除と内容変更が同時でも、変更は同一 id 同士で比較される', () => {
+    // B を削除しつつ C の名前を変更
+    const changedC = { ...personC, name: '丙野参郎' };
+    const original = makeFormData([personA, personB, personC]);
+    const current = makeFormData([personA, changedC]);
+
+    const sections = buildPlotDiffSections(original, current);
+    const buriedSections = sections.filter((s) => s.title.startsWith('埋葬者'));
+
+    // C の変更（current 表示位置 2）と B の削除（original 表示位置 2）
+    expect(buriedSections).toHaveLength(2);
+    const changeSection = buriedSections.find((s) => s.title === '埋葬者 2');
+    expect(changeSection?.items).toEqual([
+      { label: '氏名', before: '丙野三郎', after: '丙野参郎' },
+    ]);
+    const deleteSection = buriedSections.find((s) => s.title === '埋葬者 2（削除）');
+    expect(deleteSection?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: '氏名', before: '乙野二郎', after: '' }),
+      ])
+    );
+  });
+});

--- a/src/components/plot-form/previewHelper.ts
+++ b/src/components/plot-form/previewHelper.ts
@@ -259,21 +259,36 @@ function buildArrayDiffSections(
   currentArr: Record<string, unknown>[] | undefined,
   fields: ArrayFieldDef[],
 ): PreviewDiffSection[] {
+  // 中間削除や並べ替えで original[i] と current[i] が別レコードになるため、
+  // インデックスではなく id で突合する（backend updatePlot の id 突合と同じ基準）。
+  // id を持たない current 要素は新規追加分として扱う（#222）。
   const sections: PreviewDiffSection[] = [];
-  const origLen = originalArr?.length || 0;
-  const currLen = currentArr?.length || 0;
-  const maxLen = Math.max(origLen, currLen);
+  const originals = originalArr ?? [];
+  const currents = currentArr ?? [];
 
   const fmt = (f: ArrayFieldDef, v: unknown): string =>
     f.format ? f.format(v) : String(v ?? '');
 
-  for (let i = 0; i < maxLen; i++) {
-    const orig = originalArr?.[i];
-    const curr = currentArr?.[i];
+  const getId = (item: Record<string, unknown>): string | undefined =>
+    typeof item.id === 'string' && item.id !== '' ? item.id : undefined;
+
+  const origById = new Map<string, Record<string, unknown>>();
+  for (const orig of originals) {
+    const id = getId(orig);
+    if (id) origById.set(id, orig);
+  }
+  const currentIds = new Set(
+    currents.map(getId).filter((id): id is string => !!id),
+  );
+
+  // 追加・変更: current の表示順で連番を振る
+  currents.forEach((curr, i) => {
+    const id = getId(curr);
+    const orig = id ? origById.get(id) : undefined;
     const items: PreviewDiffItem[] = [];
 
-    if (!orig && curr) {
-      // 新規追加
+    if (!orig) {
+      // 新規追加（id 無し、または original に存在しない id）
       for (const f of fields) {
         const val = fmt(f, curr[f.key]);
         if (val) {
@@ -283,19 +298,8 @@ function buildArrayDiffSections(
       if (items.length > 0) {
         sections.push({ title: `${sectionLabel} ${i + 1}（追加）`, items });
       }
-    } else if (orig && !curr) {
-      // 削除
-      for (const f of fields) {
-        const val = fmt(f, orig[f.key]);
-        if (val) {
-          items.push({ label: f.label, before: val, after: '' });
-        }
-      }
-      if (items.length > 0) {
-        sections.push({ title: `${sectionLabel} ${i + 1}（削除）`, items });
-      }
-    } else if (orig && curr) {
-      // 既存の変更
+    } else {
+      // 既存の変更（同一 id 同士でフィールド比較）
       for (const f of fields) {
         const before = fmt(f, orig[f.key]);
         const after = fmt(f, curr[f.key]);
@@ -307,7 +311,25 @@ function buildArrayDiffSections(
         sections.push({ title: `${sectionLabel} ${i + 1}`, items });
       }
     }
-  }
+  });
+
+  // 削除: current に id が残っていない original（編集前の表示順で連番）
+  // ※ original はサーバ取得データのため id を持つ前提。id 無しの original は
+  //   突合不能なので削除判定の対象外とする
+  originals.forEach((orig, i) => {
+    const id = getId(orig);
+    if (!id || currentIds.has(id)) return;
+    const items: PreviewDiffItem[] = [];
+    for (const f of fields) {
+      const val = fmt(f, orig[f.key]);
+      if (val) {
+        items.push({ label: f.label, before: val, after: '' });
+      }
+    }
+    if (items.length > 0) {
+      sections.push({ title: `${sectionLabel} ${i + 1}（削除）`, items });
+    }
+  });
 
   return sections;
 }


### PR DESCRIPTION
## 概要
更新プレビューの配列差分（家族連絡先・埋葬者・工事情報）が配列インデックス突合のため、中間削除・並べ替えで誤った差分を表示する問題を修正。

## 変更内容
- `previewHelper.ts` の `buildArrayDiffSections` を id ベースのマッチングに変更（issue 修正方針どおり）
  - 既存 id 同士でフィールド差分比較（backend `updatePlot` の id 突合と同一基準）
  - id 無しの current 要素 → 「追加」（current 表示位置の連番）
  - current に無い original の id → 「削除」（編集前の表示位置の連番）
  - 並べ替えのみは差分なし
- 単体テスト5件追加（`preview-helper.test.ts`、これまでテスト無しだったモジュール）
  - issue 記載の「中間削除」「並べ替え」ケースを含む

## テスト
- `npx tsc --noEmit` clean
- `npm test` 420 passed（新規5件含む）
- `npm run lint` clean

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)