### PR TITLE
fix: データ取得フック群に世代ガードを横断導入（古いレスポンスの上書き防止） (#231/#221)

### DIFF
--- a/src/__tests__/hooks/async-hooks-stale-guard.test.ts
+++ b/src/__tests__/hooks/async-hooks-stale-guard.test.ts
@@ -1,0 +1,98 @@
+/**
+ * データ取得フックの世代ガードテスト（#231/#221）
+ *
+ * 連続操作時に先発の遅いレスポンスが後発の速いレスポンスを
+ * 上書きしない（リクエスト順序逆転対策）ことを保証する。
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAsyncData } from '@/hooks/useAsyncData';
+import { useAsyncList } from '@/hooks/useAsyncList';
+import type { ApiResponse } from '@/lib/api/types';
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('useAsyncData 世代ガード (#231)', () => {
+  it('先発の遅いレスポンスが後発の結果を上書きしない', async () => {
+    const d1 = deferred<ApiResponse<string>>();
+    const d2 = deferred<ApiResponse<string>>();
+    const fetchFn = jest
+      .fn<Promise<ApiResponse<string>>, []>()
+      .mockReturnValueOnce(d1.promise)
+      .mockReturnValueOnce(d2.promise);
+
+    const { result } = renderHook(() => useAsyncData<string>(fetchFn));
+
+    // 初回フェッチ（世代1 = d1）が in-flight のまま refetch（世代2 = d2）
+    act(() => {
+      void result.current.refetch();
+    });
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(2));
+
+    // 後発（世代2）が先に解決 → 反映される
+    await act(async () => {
+      d2.resolve({ success: true, data: 'newer' });
+    });
+    expect(result.current.data).toBe('newer');
+    expect(result.current.isLoading).toBe(false);
+
+    // 先発（世代1）が遅れて解決 → 破棄され、上書きされない
+    await act(async () => {
+      d1.resolve({ success: true, data: 'stale' });
+    });
+    expect(result.current.data).toBe('newer');
+    expect(result.current.isLoading).toBe(false);
+  });
+});
+
+describe('useAsyncList 世代ガード (#231/#221)', () => {
+  type Item = string;
+  const page = (items: Item[]): ApiResponse<{
+    items: Item[];
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }> => ({
+    success: true,
+    data: {
+      items,
+      pagination: { page: 1, limit: 20, total: items.length, totalPages: 1 },
+    },
+  });
+
+  it('検索条件変更後、古い条件のレスポンスで items が上書きされない', async () => {
+    const d1 = deferred<ReturnType<typeof page>>();
+    const d2 = deferred<ReturnType<typeof page>>();
+    const fetchFn = jest
+      .fn()
+      .mockReturnValueOnce(d1.promise)
+      .mockReturnValueOnce(d2.promise);
+
+    const { result } = renderHook(() => useAsyncList<Item>(fetchFn));
+
+    // 初回フェッチ（世代1）が in-flight のまま検索条件変更（世代2）
+    act(() => {
+      result.current.setSearch('柳');
+    });
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(2));
+
+    // 後発（世代2 = 新しい検索結果）が先に解決
+    await act(async () => {
+      d2.resolve(page(['柳田一郎']));
+    });
+    expect(result.current.items).toEqual(['柳田一郎']);
+    expect(result.current.isLoading).toBe(false);
+
+    // 先発（世代1 = 全件）が遅れて解決 → 破棄される
+    await act(async () => {
+      d1.resolve(page(['山田太郎', '佐藤花子']));
+    });
+    expect(result.current.items).toEqual(['柳田一郎']);
+    expect(result.current.total).toBe(1);
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/components/plot-availability-management.tsx
+++ b/src/components/plot-availability-management.tsx
@@ -91,9 +91,14 @@ export default function PlotAvailabilityManagement() {
   }, [viewMode, setSectionsStatus]);
 
   // 検索クエリの反映
+  // デバウンス: 入力が params に直結しており 1 キーストロークごとに
+  // sections/areas の 2 本フェッチが走るため、300ms 待ってから反映（#231）
   useEffect(() => {
-    setSectionsSearch(searchQuery);
-    setAreasSearch(searchQuery);
+    const timer = setTimeout(() => {
+      setSectionsSearch(searchQuery);
+      setAreasSearch(searchQuery);
+    }, 300);
+    return () => clearTimeout(timer);
   }, [searchQuery, setSectionsSearch, setAreasSearch]);
 
   // ソートの反映

--- a/src/components/plot-registry/index.tsx
+++ b/src/components/plot-registry/index.tsx
@@ -9,7 +9,7 @@
  * 状態・データ取得はこの index に集約し、表示は責務別の子コンポーネントに委譲する。
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { PaymentStatus, PhysicalPlotStatus, type PlotListItem } from '@komine/types';
 import { getPlots, getGraveClassifications } from '@/lib/api/plots';
 import type { PlotSearchParams } from '@/lib/api/plots';
@@ -134,8 +134,13 @@ export default function PlotRegistry({
   const [totalItems, setTotalItems] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
 
+  // 世代カウンタ: 検索・フィルタ・ページャの連続操作時に先発の遅いレスポンスが
+  // 後発の結果を上書きするのを防ぐ（リクエスト順序逆転対策 #221/#231）
+  const requestSeqRef = useRef(0);
+
   // サーバーサイドデータ取得
   const fetchPlots = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
     setIsLoading(true);
     setError(null);
     try {
@@ -182,6 +187,8 @@ export default function PlotRegistry({
       }
 
       const response = await getPlots(params);
+      // 最新リクエスト以外の結果は破棄
+      if (seq !== requestSeqRef.current) return;
       if (response.success) {
         setPlots(response.data.items);
         setTotalItems(response.data.total);
@@ -190,9 +197,13 @@ export default function PlotRegistry({
         setError(response.error?.message || 'データの取得に失敗しました');
       }
     } catch {
+      if (seq !== requestSeqRef.current) return;
       setError('ネットワークエラーが発生しました');
     } finally {
-      setIsLoading(false);
+      // 古いリクエストの finally で isLoading を落とさない
+      if (seq === requestSeqRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [currentPage, itemsPerPage, searchQuery, activeTab, sortKey, sortOrder, filterStatus, filterPaymentStatus, filterAreaName, filterGraveKind, filterGraveKubun, filterGraveType]);
 

--- a/src/hooks/useAsyncData.ts
+++ b/src/hooks/useAsyncData.ts
@@ -53,6 +53,9 @@ export function useAsyncData<T>(
   const [error, setError] = useState<string | null>(null);
   const fetchFnRef = useRef(fetchFn);
   const isMountedRef = useRef(true);
+  // 世代カウンタ: 連続操作時に先発の遅いレスポンスが後発の結果を
+  // 上書きするのを防ぐ（リクエスト順序逆転対策 #231）
+  const genRef = useRef(0);
 
   // fetchFnの参照を更新
   useEffect(() => {
@@ -90,6 +93,8 @@ export function useAsyncData<T>(
 
   // データ取得関数
   const fetchData = useCallback(async () => {
+    const myGen = ++genRef.current;
+
     // キャッシュから取得を試みる
     const cachedData = getFromCache();
     if (cachedData !== null) {
@@ -104,7 +109,8 @@ export function useAsyncData<T>(
     try {
       const response = await fetchFnRef.current();
 
-      if (!isMountedRef.current) return;
+      // 最新リクエスト以外の結果は破棄（アンマウント後も含む）
+      if (myGen !== genRef.current || !isMountedRef.current) return;
 
       if (response.success) {
         setData(response.data);
@@ -115,11 +121,12 @@ export function useAsyncData<T>(
         setData(null);
       }
     } catch (err) {
-      if (!isMountedRef.current) return;
+      if (myGen !== genRef.current || !isMountedRef.current) return;
       setError(err instanceof Error ? err.message : 'Unknown error');
       setData(null);
     } finally {
-      if (isMountedRef.current) {
+      // 古いリクエストの finally で isLoading を落とさない
+      if (myGen === genRef.current && isMountedRef.current) {
         setIsLoading(false);
       }
     }

--- a/src/hooks/useAsyncList.ts
+++ b/src/hooks/useAsyncList.ts
@@ -106,6 +106,9 @@ export function useAsyncList<T, P extends ListParams = ListParams>(
   const fetchFnRef = useRef(fetchFn);
   const isMountedRef = useRef(true);
   const initialParamsRef = useRef(initialParams);
+  // 世代カウンタ: 連続操作時に先発の遅いレスポンスが後発の結果を
+  // 上書きするのを防ぐ（リクエスト順序逆転対策 #231）
+  const genRef = useRef(0);
 
   // fetchFnの参照を更新
   useEffect(() => {
@@ -114,13 +117,15 @@ export function useAsyncList<T, P extends ListParams = ListParams>(
 
   // データ取得関数
   const fetchData = useCallback(async (currentParams: P) => {
+    const myGen = ++genRef.current;
     setIsLoading(true);
     setError(null);
 
     try {
       const response = await fetchFnRef.current(currentParams);
 
-      if (!isMountedRef.current) return;
+      // 最新リクエスト以外の結果は破棄（アンマウント後も含む）
+      if (myGen !== genRef.current || !isMountedRef.current) return;
 
       if (response.success) {
         setItems(response.data.items);
@@ -134,13 +139,14 @@ export function useAsyncList<T, P extends ListParams = ListParams>(
         setTotalPages(0);
       }
     } catch (err) {
-      if (!isMountedRef.current) return;
+      if (myGen !== genRef.current || !isMountedRef.current) return;
       setError(err instanceof Error ? err.message : 'Unknown error');
       setItems([]);
       setTotal(0);
       setTotalPages(0);
     } finally {
-      if (isMountedRef.current) {
+      // 古いリクエストの finally で isLoading を落とさない
+      if (myGen === genRef.current && isMountedRef.current) {
         setIsLoading(false);
       }
     }

--- a/src/hooks/useCollectiveBurials.ts
+++ b/src/hooks/useCollectiveBurials.ts
@@ -2,7 +2,7 @@
  * 合祀管理用カスタムフック
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import {
   getCollectiveBurialList,
   getCollectiveBurialById,
@@ -32,23 +32,30 @@ export function useCollectiveBurialList(initialParams?: CollectiveBurialSearchPa
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [params, setParams] = useState<CollectiveBurialSearchParams>(initialParams || {});
+  // 世代カウンタ: 検索の連続操作時に先発の遅いレスポンスによる上書きを防ぐ（#231）
+  const genRef = useRef(0);
 
   const fetchList = useCallback(async (searchParams?: CollectiveBurialSearchParams) => {
+    const myGen = ++genRef.current;
     setIsLoading(true);
     setError(null);
 
     try {
       const response = await getCollectiveBurialList(searchParams || params);
 
+      if (myGen !== genRef.current) return;
       if (response.success) {
         setData(response.data);
       } else {
         setError(response.error?.message || '合祀一覧の取得に失敗しました');
       }
     } catch {
+      if (myGen !== genRef.current) return;
       setError('合祀一覧の取得中にエラーが発生しました');
     } finally {
-      setIsLoading(false);
+      if (myGen === genRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [params]);
 
@@ -88,7 +95,11 @@ export function useCollectiveBurialDetail(id: string | null) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 世代カウンタ: id 切替の連続操作時の上書きを防ぐ（#231）
+  const genRef = useRef(0);
+
   const fetchDetail = useCallback(async () => {
+    const myGen = ++genRef.current;
     if (!id) {
       setData(null);
       return;
@@ -100,15 +111,19 @@ export function useCollectiveBurialDetail(id: string | null) {
     try {
       const response = await getCollectiveBurialById(id);
 
+      if (myGen !== genRef.current) return;
       if (response.success) {
         setData(response.data);
       } else {
         setError(response.error?.message || '合祀詳細の取得に失敗しました');
       }
     } catch {
+      if (myGen !== genRef.current) return;
       setError('合祀詳細の取得中にエラーが発生しました');
     } finally {
-      setIsLoading(false);
+      if (myGen === genRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [id]);
 

--- a/src/hooks/useDocuments.ts
+++ b/src/hooks/useDocuments.ts
@@ -2,7 +2,7 @@
  * 書類管理用カスタムフック
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   DocumentListItem,
   DocumentDetail,
@@ -53,21 +53,30 @@ export function useDocumentList(initialParams?: Partial<DocumentListParams>) {
     ...initialParams,
   });
 
+  // 世代カウンタ: 検索・フィルタの連続操作時に先発の遅いレスポンスによる
+  // 上書きを防ぐ（#231）
+  const genRef = useRef(0);
+
   const fetchData = useCallback(async () => {
+    const myGen = ++genRef.current;
     setIsLoading(true);
     setError(null);
     try {
       const response = await getDocuments(params);
+      if (myGen !== genRef.current) return;
       if (response.success) {
         setData(response.data);
       } else {
         setError(response.error?.message || 'データの取得に失敗しました');
       }
     } catch (err) {
+      if (myGen !== genRef.current) return;
       setError('データの取得に失敗しました');
       console.error('Error fetching documents:', err);
     } finally {
-      setIsLoading(false);
+      if (myGen === genRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [params]);
 
@@ -104,7 +113,11 @@ export function useDocumentDetail(id: string | null) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 世代カウンタ: id 切替の連続操作時の上書きを防ぐ（#231）
+  const genRef = useRef(0);
+
   const fetchData = useCallback(async () => {
+    const myGen = ++genRef.current;
     if (!id) {
       setData(null);
       return;
@@ -114,16 +127,20 @@ export function useDocumentDetail(id: string | null) {
     setError(null);
     try {
       const response = await getDocumentById(id);
+      if (myGen !== genRef.current) return;
       if (response.success) {
         setData(response.data);
       } else {
         setError(response.error?.message || 'データの取得に失敗しました');
       }
     } catch (err) {
+      if (myGen !== genRef.current) return;
       setError('データの取得に失敗しました');
       console.error('Error fetching document detail:', err);
     } finally {
-      setIsLoading(false);
+      if (myGen === genRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [id]);
 

--- a/src/hooks/usePlotInventory.ts
+++ b/src/hooks/usePlotInventory.ts
@@ -4,7 +4,7 @@
  * 区画在庫管理フック
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { PlotPeriod } from '@/types/plot-constants';
 import {
   getInventorySummary,
@@ -88,22 +88,29 @@ export function usePlotInventorySummary(
   const [summary, setSummary] = useState<InventorySummary | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // 世代カウンタ: 先発の遅いレスポンスによる上書きを防ぐ（#231）
+  const genRef = useRef(0);
 
   const fetchSummary = useCallback(async () => {
+    const myGen = ++genRef.current;
     setIsLoading(true);
     setError(null);
 
     try {
       const response = await getInventorySummary();
+      if (myGen !== genRef.current) return;
       if (response.success) {
         setSummary(response.data);
       } else {
         setError(response.error?.message || 'サマリーの取得に失敗しました');
       }
     } catch {
+      if (myGen !== genRef.current) return;
       setError('ネットワークエラーが発生しました');
     } finally {
-      setIsLoading(false);
+      if (myGen === genRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 
@@ -132,22 +139,29 @@ export function usePlotInventoryPeriods(
   const [periods, setPeriods] = useState<PeriodSummary[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // 世代カウンタ: 期切替の連続操作時の上書きを防ぐ（#231）
+  const genRef = useRef(0);
 
   const fetchPeriods = useCallback(async () => {
+    const myGen = ++genRef.current;
     setIsLoading(true);
     setError(null);
 
     try {
       const response = await getInventoryPeriods(period);
+      if (myGen !== genRef.current) return;
       if (response.success) {
         setPeriods(response.data.periods);
       } else {
         setError(response.error?.message || '期別サマリーの取得に失敗しました');
       }
     } catch {
+      if (myGen !== genRef.current) return;
       setError('ネットワークエラーが発生しました');
     } finally {
-      setIsLoading(false);
+      if (myGen === genRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [period]);
 
@@ -186,12 +200,18 @@ export function usePlotInventorySections(
     ...initialParams,
   });
 
+  // 世代カウンタ: 検索（キーストロークごとにフェッチ）・期切替・ソートの
+  // 連続操作時に古い結果での上書きを防ぐ（#231）
+  const genRef = useRef(0);
+
   const fetchSections = useCallback(async () => {
+    const myGen = ++genRef.current;
     setIsLoading(true);
     setError(null);
 
     try {
       const response = await getInventorySections(params);
+      if (myGen !== genRef.current) return;
       if (response.success) {
         setItems(response.data.items);
         setTotal(response.data.pagination.total);
@@ -200,9 +220,12 @@ export function usePlotInventorySections(
         setError(response.error?.message || 'セクション別集計の取得に失敗しました');
       }
     } catch {
+      if (myGen !== genRef.current) return;
       setError('ネットワークエラーが発生しました');
     } finally {
-      setIsLoading(false);
+      if (myGen === genRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [params]);
 
@@ -279,12 +302,17 @@ export function usePlotInventoryAreas(
     ...initialParams,
   });
 
+  // 世代カウンタ: 検索・期切替・ソートの連続操作時の上書きを防ぐ（#231）
+  const genRef = useRef(0);
+
   const fetchAreas = useCallback(async () => {
+    const myGen = ++genRef.current;
     setIsLoading(true);
     setError(null);
 
     try {
       const response = await getInventoryAreas(params);
+      if (myGen !== genRef.current) return;
       if (response.success) {
         setItems(response.data.items);
         setTotal(response.data.pagination.total);
@@ -293,9 +321,12 @@ export function usePlotInventoryAreas(
         setError(response.error?.message || '面積別集計の取得に失敗しました');
       }
     } catch {
+      if (myGen !== genRef.current) return;
       setError('ネットワークエラーが発生しました');
     } finally {
-      setIsLoading(false);
+      if (myGen === genRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [params]);
 

--- a/src/hooks/usePlots.ts
+++ b/src/hooks/usePlots.ts
@@ -120,6 +120,10 @@ export function usePlots(options: UsePlotsOptions = {}): UsePlotsReturn {
   // キャッシュ復元済みフラグ（初回フェッチ時のローディング制御に使用）
   const restoredFromCache = useRef(initialState !== null);
 
+  // 世代カウンタ: 検索・タブ・ページングの連続操作時に先発の遅いレスポンスが
+  // 後発の結果を上書きするのを防ぐ（リクエスト順序逆転対策 #231）
+  const genRef = useRef(0);
+
   // サーバーサイドデータ取得
   const fetchPlots = useCallback(async () => {
     // TTL内の有効なキャッシュがあればフェッチをスキップ
@@ -127,6 +131,7 @@ export function usePlots(options: UsePlotsOptions = {}): UsePlotsReturn {
       restoredFromCache.current = false;
       return;
     }
+    const myGen = ++genRef.current;
     setIsLoading(true);
     setError(null);
 
@@ -148,6 +153,9 @@ export function usePlots(options: UsePlotsOptions = {}): UsePlotsReturn {
 
       const response = await getPlots(params);
 
+      // 最新リクエスト以外の結果は破棄
+      if (myGen !== genRef.current) return;
+
       if (response.success) {
         setPlots(response.data.items);
         setTotal(response.data.total);
@@ -167,10 +175,14 @@ export function usePlots(options: UsePlotsOptions = {}): UsePlotsReturn {
         setPlots([]);
       }
     } catch {
+      if (myGen !== genRef.current) return;
       setError('データの取得に失敗しました');
       setPlots([]);
     } finally {
-      setIsLoading(false);
+      // 古いリクエストの finally で isLoading を落とさない
+      if (myGen === genRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [page, limit, searchQuery, areaName, aiueoTab]);
 


### PR DESCRIPTION
## 概要
データ取得フック群に「世代ガード（リクエスト順序逆転対策）」が無く、連続操作時に先発の遅いレスポンスが後発の結果を上書きする問題を、#231 の修正方針どおり共通パターンで一括修正。

## 変更内容
世代カウンタ方式（`const myGen = ++genRef.current` を採番し、await 後の全 setState を `if (myGen !== genRef.current) return` でガード）を以下へ導入:

| 対象 | 実害経路 |
|---|---|
| `useAsyncData` / `useAsyncList`（正準フック） | ゆうちょ画面の年度切替 ほか |
| `usePlots` | 区画一覧の検索・あいうえおタブ・ページング |
| `usePlotInventory`（4フック） | 区画残数管理の検索・期切替・ソート |
| `useDocuments`（一覧・詳細） | 書類一覧の検索・フィルタ |
| `useCollectiveBurials`（一覧・詳細） | 合祀一覧の検索 |
| `plot-registry/index.tsx fetchPlots` | #221 のスコープ（単調増加 requestSeqRef 方式） |

- `finally` の `setIsLoading(false)` も同ガード下に配置（issue 指摘の「古いデータで確定表示されたまま固定」を防止）
- 補助: `plot-availability-management.tsx` の検索入力に 300ms デバウンス（1キーストロークごとの2本フェッチを削減、issue 修正方針 2)）

## テスト
- 回帰テスト2件追加（`async-hooks-stale-guard.test.ts`: 先発の遅いレスポンスが破棄され、後発の結果が保持されること）
- `npx tsc --noEmit` clean
- `npm test` 422 passed
- `npm run lint` clean

Closes #231
Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)