### PR TITLE
fix: 合祀一覧の当年サマリー金額をサーバ全件集計優先に変更 (#226)

### DIFF
--- a/src/components/collective-burial/ListView.tsx
+++ b/src/components/collective-burial/ListView.tsx
@@ -87,7 +87,9 @@ export default function CollectiveBurialListView({
     search({});
   };
 
-  // 今年の請求対象者サマリ（件数・内訳は yearlyStats を優先、金額は items から集計）
+  // 今年の請求対象者サマリ（件数・金額ともサーバ全件集計の yearlyStats を優先）
+  // items はページ制限（backend デフォルト limit=50）された先頭分のみのため、
+  // items 由来の集計は statsRow 不在時のフォールバックに限定する（#226）
   const currentYearSummary = useMemo(() => {
     const statsRow = yearlyStats?.find(s => s.year === currentYear);
     const itemsThisYear = items.filter(item => {
@@ -100,10 +102,12 @@ export default function CollectiveBurialListView({
     const billedCount = statsRow?.billedCount ?? itemsThisYear.filter(i => i.billingStatus === 'billed').length;
     const paidCount = statsRow?.paidCount ?? itemsThisYear.filter(i => i.billingStatus === 'paid').length;
 
-    const totalAmount = itemsThisYear.reduce((sum, i) => sum + (i.billingAmount ?? 0), 0);
-    const paidAmount = itemsThisYear
-      .filter(i => i.billingStatus === 'paid')
-      .reduce((sum, i) => sum + (i.billingAmount ?? 0), 0);
+    const totalAmount = statsRow?.totalAmount
+      ?? itemsThisYear.reduce((sum, i) => sum + (i.billingAmount ?? 0), 0);
+    const paidAmount = statsRow?.paidAmount
+      ?? itemsThisYear
+        .filter(i => i.billingStatus === 'paid')
+        .reduce((sum, i) => sum + (i.billingAmount ?? 0), 0);
     const outstandingAmount = totalAmount - paidAmount;
 
     const paidRate = totalCount > 0 ? Math.round((paidCount / totalCount) * 100) : 0;

--- a/src/lib/api/collective-burials.ts
+++ b/src/lib/api/collective-burials.ts
@@ -121,6 +121,10 @@ export interface YearlyStats {
   pendingCount: number;
   billedCount: number;
   paidCount: number;
+  /** その年の請求総額（円）。サーバ全件集計（#226） */
+  totalAmount?: number;
+  /** うち billing_status='paid' の入金済額（円）。サーバ全件集計（#226） */
+  paidAmount?: number;
 }
 
 /** 検索パラメータ */
@@ -191,10 +195,10 @@ const mockCollectiveBurials: CollectiveBurialListItem[] = [
 ];
 
 const mockYearlyStats: YearlyStats[] = [
-  { year: 2027, count: 5, pendingCount: 2, billedCount: 2, paidCount: 1 },
-  { year: 2029, count: 8, pendingCount: 6, billedCount: 1, paidCount: 1 },
-  { year: 2034, count: 12, pendingCount: 10, billedCount: 2, paidCount: 0 },
-  { year: 2036, count: 15, pendingCount: 15, billedCount: 0, paidCount: 0 },
+  { year: 2027, count: 5, pendingCount: 2, billedCount: 2, paidCount: 1, totalAmount: 250000, paidAmount: 50000 },
+  { year: 2029, count: 8, pendingCount: 6, billedCount: 1, paidCount: 1, totalAmount: 400000, paidAmount: 50000 },
+  { year: 2034, count: 12, pendingCount: 10, billedCount: 2, paidCount: 0, totalAmount: 600000, paidAmount: 0 },
+  { year: 2036, count: 15, pendingCount: 15, billedCount: 0, paidCount: 0, totalAmount: 750000, paidAmount: 0 },
 ];
 
 // ============================================================


### PR DESCRIPTION
## 概要
合祀一覧の当年サマリーで、件数は全件（サーバ集計）なのに金額（請求総額/入金済額/未収額）は先頭50件分の集計になっていた問題の frontend 側修正。

backend 側は zaitsu82/komine-crm-backend#243（`getStatsByYear` の生SQLに `totalAmount`/`paidAmount` 集計列を追加）で対応・マージ済み。

## 変更内容
- `YearlyStats` 型に `totalAmount` / `paidAmount`（円・optional）を追加
- `ListView.tsx` の `currentYearSummary` で金額も `statsRow` 優先に切替（issue 修正方針どおり、件数と同じ `statsRow?.x ?? itemsフォールバック` パターン）
- `mockYearlyStats` にも金額を追加（モック整合）

## テスト
- `npx tsc --noEmit` clean
- `npm test` 425 passed
- `npm run lint` clean

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)