### PR TITLE
fix: date-only 表示の TZ 前日ズレを解消（Date 非経由の整形） (#218)

### DIFF
--- a/src/__tests__/lib/format-tz.test.ts
+++ b/src/__tests__/lib/format-tz.test.ts
@@ -1,0 +1,68 @@
+/**
+ * formatDate / formatYearMonth の TZ 非依存テスト（#218）
+ *
+ * backend は date-only 値を 'YYYY-MM-DD' で返す。
+ * `new Date('YYYY-MM-DD')` は UTC 00:00 としてパースされるため、
+ * ローカル getter（getFullYear/getMonth/getDate）依存の整形は
+ * 負オフセット TZ（米国等）で前日表示になる。
+ *
+ * Jest プロセスでは実行時に TZ を切り替えられない（V8 がキャッシュ）ため、
+ * 「date-only 入力ではローカル getter を一切使わない」ことをスパイで保証する。
+ * ローカル getter を使わなければ、どの TZ でも結果は同一になる。
+ */
+
+import { formatDate, formatYearMonth } from '@/lib/format';
+
+describe('formatDate の date-only 整形 (#218)', () => {
+  it('date-only 文字列を正しく整形する', () => {
+    expect(formatDate('2006-02-09')).toBe('2006/02/09');
+    expect(formatDate('2020-01-01')).toBe('2020/01/01');
+    expect(formatDate('2024-12-31')).toBe('2024/12/31');
+  });
+
+  it('date-only 入力ではローカル TZ getter を使わない（TZ 非依存の保証）', () => {
+    const spyYear = jest.spyOn(Date.prototype, 'getFullYear');
+    const spyMonth = jest.spyOn(Date.prototype, 'getMonth');
+    const spyDate = jest.spyOn(Date.prototype, 'getDate');
+    try {
+      formatDate('2006-02-09');
+      formatYearMonth('2024-03-01');
+      expect(spyYear).not.toHaveBeenCalled();
+      expect(spyMonth).not.toHaveBeenCalled();
+      expect(spyDate).not.toHaveBeenCalled();
+    } finally {
+      spyYear.mockRestore();
+      spyMonth.mockRestore();
+      spyDate.mockRestore();
+    }
+  });
+
+  it('date-only 形式で実在しない日付は fallback（legacy パーサの繰り上がりに流さない）', () => {
+    expect(formatDate('2024-02-31')).toBe('-');
+    expect(formatDate('2024-13-01')).toBe('-');
+    expect(formatDate('2024-00-10')).toBe('-');
+  });
+
+  it('datetime 文字列・Date インスタンスは従来どおりローカルTZで整形', () => {
+    expect(formatDate(new Date(2024, 5, 15))).toBe('2024/06/15');
+    // datetime はローカル getter 経由（時刻成分が意味を持つケース）
+    const spyDate = jest.spyOn(Date.prototype, 'getDate');
+    try {
+      formatDate('2024-06-15T12:00:00Z');
+      expect(spyDate).toHaveBeenCalled();
+    } finally {
+      spyDate.mockRestore();
+    }
+  });
+});
+
+describe('formatYearMonth の date-only 整形 (#218)', () => {
+  it('date-only 文字列の年月を正しく整形する', () => {
+    expect(formatYearMonth('2024-03-01')).toBe('2024/03');
+    expect(formatYearMonth('2020-01-01')).toBe('2020/01');
+  });
+
+  it('date-only 形式で実在しない日付は fallback', () => {
+    expect(formatYearMonth('2024-02-31')).toBe('-');
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -117,13 +117,45 @@ export function formatBillingMonth(
   return trimmed;
 }
 
+/** date-only 文字列（YYYY-MM-DD）の形式判定 */
+const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * date-only 文字列（YYYY-MM-DD）から年月日を TZ 非依存で抽出する。
+ * `new Date('YYYY-MM-DD')` は UTC 00:00 としてパースされるため、
+ * ローカル getter で組み立てると負オフセット TZ では前日になる（#218）。
+ * 実在しない日付（2024-02-31 等）は null。
+ */
+function parseDateOnly(value: string): { y: number; m: number; d: number } | null {
+  const match = value.match(DATE_ONLY_RE);
+  if (!match) return null;
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  // UTC で往復させて実在日付か検証（TZ の影響を受けない）
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  if (dt.getUTCFullYear() !== y || dt.getUTCMonth() !== m - 1 || dt.getUTCDate() !== d) {
+    return null;
+  }
+  return { y, m, d };
+}
+
 /**
  * 日付を「YYYY/MM/DD」（西暦4桁・ゼロ埋め）に統一する。
  * 2桁年や非ゼロ埋めの表記揺れ（#167）を解消する共通フォーマッタ。
+ * date-only 文字列は Date を経由せず整形し、TZ による前日ズレを防ぐ（#218）。
  * null / 空 / 不正日付は fallback（既定 "-"）。
  */
 export function formatDate(value: string | Date | null | undefined, fallback: string = DASH): string {
   if (value === null || value === undefined || value === '') return fallback;
+  if (typeof value === 'string' && DATE_ONLY_RE.test(value)) {
+    const dateOnly = parseDateOnly(value);
+    // date-only 形式で実在しない日付（2024-02-31 等）は legacy パーサの
+    // 繰り上がり（→ 2024/03/02）に流さず fallback
+    if (dateOnly === null) return fallback;
+    return `${dateOnly.y}/${String(dateOnly.m).padStart(2, '0')}/${String(dateOnly.d).padStart(2, '0')}`;
+  }
+  // datetime 文字列・Date インスタンスは時刻成分が意味を持つため従来どおりローカルTZで整形
   const d = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(d.getTime())) return fallback;
   const y = d.getFullYear();
@@ -135,9 +167,15 @@ export function formatDate(value: string | Date | null | undefined, fallback: st
 /**
  * 年月を「YYYY/MM」（西暦4桁・ゼロ埋め）に統一する。
  * 一覧の契約日など、日を省きたい狭い列向け（2桁年 "06/2" を廃止）。
+ * date-only 文字列は Date を経由せず整形し、TZ による前日ズレを防ぐ（#218）。
  */
 export function formatYearMonth(value: string | Date | null | undefined, fallback: string = DASH): string {
   if (value === null || value === undefined || value === '') return fallback;
+  if (typeof value === 'string' && DATE_ONLY_RE.test(value)) {
+    const dateOnly = parseDateOnly(value);
+    if (dateOnly === null) return fallback;
+    return `${dateOnly.y}/${String(dateOnly.m).padStart(2, '0')}`;
+  }
   const d = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(d.getTime())) return fallback;
   const y = d.getFullYear();


### PR DESCRIPTION
## 概要
`formatDate` / `formatYearMonth` が date-only 文字列（'YYYY-MM-DD'）を `new Date()` + ローカル getter で整形しており、負オフセット TZ（米国等）で契約日・命日・生年月日等が前日表示になる問題を修正。

## 変更内容
- `parseDateOnly` ヘルパを `format.ts` に追加（issue 修正方針どおり）
  - date-only 文字列は正規表現で年月日を直接抽出（Date のローカル getter 非経由）
  - 実在性は `Date.UTC` 往復で検証（TZ 非依存）
- date-only 形式で実在しない日付（`2024-02-31` 等）は fallback を返す（V8 legacy パーサの繰り上がり `2024/03/02` を防止）
- datetime 文字列・Date インスタンスは従来どおりローカル TZ 整形（挙動維持）

## テスト
- 回帰テスト追加（`format-tz.test.ts`）
  - Jest プロセスは実行時 TZ 切替不可（V8 キャッシュ）のため、**date-only 入力でローカル getter（getFullYear/getMonth/getDate）が呼ばれないことをスパイで保証**する方式（getter 非使用 = どの TZ でも同一結果）
- `npx tsc --noEmit` clean / `npm test` 431 passed / `npm run lint` clean

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)