### PR TITLE
fix: 使用率バーを 100% でクランプしトラック外はみ出しを防止 (#232)

### DIFF
--- a/src/components/plot-availability-management.tsx
+++ b/src/components/plot-availability-management.tsx
@@ -348,7 +348,8 @@ export default function PlotAvailabilityManagement() {
                     <span className="block w-full bg-cha-50 rounded-full h-1.5 mt-1">
                       <span
                         className="block bg-cha h-1.5 rounded-full transition-all duration-500"
-                        style={{ width: `${summary.usageRate}%` }}
+                        // バー幅のみクランプ（テキストは生値を出し 100% 超の異常に気付けるようにする）#232
+                        style={{ width: `${Math.min(summary.usageRate, 100)}%` }}
                       />
                     </span>
                   }
@@ -620,7 +621,8 @@ export default function PlotAvailabilityManagement() {
                                         usageRate >= 60 ? 'bg-cha' :
                                           'bg-matsu'
                                   )}
-                                  style={{ width: `${usageRate}%` }}
+                                  // バー幅のみクランプ（在庫計算バグ #209 で 100% 超が届く）#232
+                                  style={{ width: `${Math.min(usageRate, 100)}%` }}
                                 />
                               </div>
                               <span className="text-xs text-hai w-12">{usageRate}%</span>

--- a/src/components/plot-inventory-list.tsx
+++ b/src/components/plot-inventory-list.tsx
@@ -124,7 +124,7 @@ export default function PlotInventoryList({ onClose }: PlotInventoryListProps) {
             <div className="w-full bg-cha-100 rounded-full h-2 mt-1">
               <div
                 className="bg-cha h-2 rounded-full"
-                style={{ width: `${summary.usageRate}%` }}
+                style={{ width: `${Math.min(summary.usageRate, 100)}%` }}
               />
             </div>
           </div>
@@ -314,7 +314,7 @@ export default function PlotInventoryList({ onClose }: PlotInventoryListProps) {
                                 usageRate >= 60 ? 'bg-cha' :
                                   'bg-matsu'
                           )}
-                          style={{ width: `${usageRate}%` }}
+                          style={{ width: `${Math.min(usageRate, 100)}%` }}
                         />
                       </div>
                       <span className="text-xs text-hai w-12">{usageRate}%</span>


### PR DESCRIPTION
## 概要
区画残数管理の使用率バーが `usageRate > 100%`（backend 在庫計算バグ #209 起因）でトラック外にはみ出して % テキストに被る問題を修正。

## 変更内容
- `plot-availability-management.tsx`: 行バー（:623付近）とサマリーバー（:351付近）を `Math.min(usageRate, 100)` でクランプ
- 旧バリアント `plot-inventory-list.tsx`（:127/:317）も同時修正（issue 記載どおり安全側）
- **% テキストは生値のまま**（100% 超の異常データに気付けるよう、issue 修正方針どおりバー幅のみクランプ）

## 備考
根本は backend #209（契約ステータス無視の在庫計算）の修正が本筋。本 PR は表示の対症療法。

## テスト
- `npx tsc --noEmit` clean / `npm test` 425 passed / `npm run lint` clean

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)