### PR TITLE
fix: マスタ書き込みのモックモードガードを追加 (#228)

### DIFF
--- a/src/__tests__/components/masters-management-section-name.test.tsx
+++ b/src/__tests__/components/masters-management-section-name.test.tsx
@@ -20,11 +20,13 @@ jest.mock('@/contexts/auth-context', () => ({
 
 const getAllMastersMock = jest.fn();
 const createMasterItemMock = jest.fn();
+const shouldUseMockDataMock = jest.fn(() => false);
 jest.mock('@/lib/api', () => ({
   getAllMasters: (...args: unknown[]) => getAllMastersMock(...args),
   createMasterItem: (...args: unknown[]) => createMasterItemMock(...args),
   updateMasterItem: jest.fn(),
   deleteMasterItem: jest.fn(),
+  shouldUseMockData: () => shouldUseMockDataMock(),
 }));
 
 jest.mock('@/lib/toast', () => ({
@@ -104,5 +106,25 @@ describe('マスタ管理 区画名の期必須チェック (#227)', () => {
         period: '第1期',
       });
     });
+  });
+});
+
+describe('マスタ管理 モックモードの書き込みガード (#228)', () => {
+  beforeEach(() => {
+    getAllMastersMock.mockReset();
+    getAllMastersMock.mockResolvedValue({ success: true, data: emptyMasters });
+    createMasterItemMock.mockReset();
+    shouldUseMockDataMock.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    shouldUseMockDataMock.mockReturnValue(false);
+  });
+
+  it('モックモードでは新規登録ボタンが無効化される', async () => {
+    render(<MastersManagement />);
+
+    const createButton = await screen.findByRole('button', { name: /新規登録/ });
+    expect(createButton).toBeDisabled();
   });
 });

--- a/src/components/masters-management.tsx
+++ b/src/components/masters-management.tsx
@@ -18,6 +18,7 @@ import {
   createMasterItem,
   updateMasterItem,
   deleteMasterItem,
+  shouldUseMockData,
   MasterItem,
   SectionNameMasterItem,
   AllMastersData,
@@ -95,6 +96,10 @@ export default function MastersManagement() {
   const currentItems = (mastersData?.[selectedType.dataKey] as MasterItem[] | undefined) ?? [];
 
   const isSectionName = selectedType.key === 'section-name';
+
+  // モックモードではマスタの書き込みができない（取得系が静的モックを返すため
+  // 反映されない）。ボタンを無効化して MockDataBanner と整合させる（#228）
+  const isMockReadonly = shouldUseMockData();
 
   const handleOpenCreate = () => {
     setEditingItem(null);
@@ -273,7 +278,13 @@ export default function MastersManagement() {
             <div className="flex-1 min-w-0">
               {isAdmin && (
                 <div className="mb-3 flex justify-end">
-                  <Button onClick={handleOpenCreate} size="sm" className="cursor-pointer">
+                  <Button
+                    onClick={handleOpenCreate}
+                    size="sm"
+                    className="cursor-pointer"
+                    disabled={isMockReadonly}
+                    title={isMockReadonly ? 'デモ（試験）環境ではマスタの変更はできません' : undefined}
+                  >
                     <Plus className="w-4 h-4 mr-1" />
                     新規登録
                   </Button>
@@ -333,6 +344,7 @@ export default function MastersManagement() {
                                   variant="outline"
                                   size="sm"
                                   className="text-xs px-2 md:px-3"
+                                  disabled={isMockReadonly}
                                 >
                                   編集
                                 </Button>
@@ -344,6 +356,7 @@ export default function MastersManagement() {
                                   variant="outline"
                                   size="sm"
                                   className="text-beni hover:text-beni-dark hover:bg-beni-50 text-xs px-2 md:px-3"
+                                  disabled={isMockReadonly}
                                 >
                                   削除
                                 </Button>

--- a/src/lib/api/masters.ts
+++ b/src/lib/api/masters.ts
@@ -304,10 +304,27 @@ export interface UpdateMasterRequest {
   period?: string;
 }
 
+// モックモードでは書き込みを行わず明示的に失敗を返す。
+// 取得系（getAllMasters 等）が静的モックを返すため、実 backend に書いても
+// 一覧へ反映されず「成功表示なのに変わらない」整合崩れになる（#228）。
+// staff.ts のような可変モックストアが無い以上、擬似成功より失敗が安全。
+function mockReadonlyError<T>(): ApiResponse<T> {
+  return {
+    success: false,
+    error: {
+      code: 'MOCK_READONLY',
+      message: 'デモ（試験）環境ではマスタの変更はできません',
+    },
+  };
+}
+
 export async function createMasterItem(
   masterType: MasterType,
   data: CreateMasterRequest,
 ): Promise<ApiResponse<MasterItem>> {
+  if (shouldUseMockData()) {
+    return mockReadonlyError<MasterItem>();
+  }
   return apiPost<MasterItem>(`/masters/${masterType}`, data);
 }
 
@@ -316,6 +333,9 @@ export async function updateMasterItem(
   id: number,
   data: UpdateMasterRequest,
 ): Promise<ApiResponse<MasterItem>> {
+  if (shouldUseMockData()) {
+    return mockReadonlyError<MasterItem>();
+  }
   return apiPut<MasterItem>(`/masters/${masterType}/${id}`, data);
 }
 
@@ -323,5 +343,8 @@ export async function deleteMasterItem(
   masterType: MasterType,
   id: number,
 ): Promise<ApiResponse<{ message: string }>> {
+  if (shouldUseMockData()) {
+    return mockReadonlyError<{ message: string }>();
+  }
   return apiDelete<{ message: string }>(`/masters/${masterType}/${id}`);
 }


### PR DESCRIPTION
## 概要
マスタの作成/更新/削除がモックデータモードを無視して実 backend を叩き、デモ環境で「保存成功表示なのに一覧に反映されない」問題を修正。

## 変更内容
- `masters.ts` の `createMasterItem` / `updateMasterItem` / `deleteMasterItem` 冒頭に `shouldUseMockData()` ガードを追加し、`MOCK_READONLY` エラーを明示返却（issue 修正方針どおり。可変モックストアが無いため擬似成功より失敗が安全）
  - エラーメッセージは既存の `formError` / `showError` 経路でそのまま表示される
- 補強: `masters-management.tsx` の新規登録・編集・削除ボタンをモックモードで `disabled` 化（layout 既設の MockDataBanner #176/#192 と整合）
- テスト追加 + 既存テストのモック整合

## テスト
- `npx tsc --noEmit` clean / `npm test` 426 passed / `npm run lint` clean

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)