### PR TITLE
fix: createPlot/updatePlot の戻り型を backend 実体に整合 (#217)

### DIFF
--- a/src/hooks/usePlots.ts
+++ b/src/hooks/usePlots.ts
@@ -11,6 +11,7 @@ import {
   PlotDetailResponse,
   CreatePlotRequest,
   UpdatePlotRequest,
+  CreatePlotResponse,
 } from '@komine/types';
 import {
   getPlots,
@@ -339,8 +340,10 @@ export function usePlotDetail(id: string | null): UsePlotDetailReturn {
 // ===== usePlotMutations: 区画変更フック =====
 
 interface UsePlotMutationsReturn {
-  create: (request: CreatePlotRequest) => Promise<PlotDetailResponse | null>;
-  update: (id: string, request: UpdatePlotRequest) => Promise<PlotDetailResponse | null>;
+  // 作成/更新 API は PlotDetailResponse ではなく CreatePlotResponse 形状を返す（#217）。
+  // フル詳細が必要な場合は getPlotById で再取得する（update は内部で再取得済み）。
+  create: (request: CreatePlotRequest) => Promise<CreatePlotResponse | null>;
+  update: (id: string, request: UpdatePlotRequest) => Promise<CreatePlotResponse | null>;
   remove: (id: string) => Promise<boolean>;
   isLoading: boolean;
   error: string | null;
@@ -350,7 +353,7 @@ export function usePlotMutations(): UsePlotMutationsReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const create = useCallback(async (request: CreatePlotRequest): Promise<PlotDetailResponse | null> => {
+  const create = useCallback(async (request: CreatePlotRequest): Promise<CreatePlotResponse | null> => {
     setIsLoading(true);
     setError(null);
 
@@ -373,7 +376,7 @@ export function usePlotMutations(): UsePlotMutationsReturn {
     }
   }, []);
 
-  const update = useCallback(async (id: string, request: UpdatePlotRequest): Promise<PlotDetailResponse | null> => {
+  const update = useCallback(async (id: string, request: UpdatePlotRequest): Promise<CreatePlotResponse | null> => {
     setIsLoading(true);
     setError(null);
 

--- a/src/lib/api/plots.ts
+++ b/src/lib/api/plots.ts
@@ -10,6 +10,7 @@ import {
   PlotDetailResponse,
   CreatePlotRequest,
   UpdatePlotRequest,
+  CreatePlotResponse,
   PhysicalPlotStatus,
   PaymentStatus,
   ContractStatus,
@@ -322,11 +323,69 @@ async function mockGetPlotById(
 }
 
 /**
+ * PlotDetailResponse → CreatePlotResponse（作成/更新APIのレスポンス形状）変換。
+ * backend の createPlot/updatePlot は PlotDetailResponse ではなく
+ * CreatePlotResponse 形状（primaryCustomer あり・buriedPersons 等なし）を
+ * 返すため、モックも同じ形状に揃える（#217）。
+ */
+function plotDetailToMutationResponse(detail: PlotDetailResponse): CreatePlotResponse {
+  const primaryRole =
+    detail.roles.find((r) => r.role === ContractRole.Contractor) ?? detail.roles[0] ?? null;
+  return {
+    id: detail.id,
+    contractAreaSqm: detail.contractAreaSqm,
+    locationDescription: detail.locationDescription,
+    contractDate: detail.contractDate,
+    price: detail.price,
+    paymentStatus: detail.paymentStatus,
+    reservationDate: detail.reservationDate,
+    acceptanceNumber: detail.acceptanceNumber,
+    permitDate: detail.permitDate,
+    startDate: detail.startDate,
+    agentName: detail.agentName ?? null,
+    notes: detail.contractNotes ?? null,
+    physicalPlot: {
+      id: detail.physicalPlot.id,
+      plotNumber: detail.physicalPlot.plotNumber,
+      areaName: detail.physicalPlot.areaName,
+      areaSqm: detail.physicalPlot.areaSqm,
+      status: detail.physicalPlot.status,
+    },
+    primaryCustomer: primaryRole
+      ? {
+          id: primaryRole.customer.id,
+          name: primaryRole.customer.name,
+          nameKana: primaryRole.customer.nameKana ?? '',
+          phoneNumber: primaryRole.customer.phoneNumber,
+          address: primaryRole.customer.address ?? '',
+          role: primaryRole.role,
+        }
+      : null,
+    roles: detail.roles.map((r) => ({
+      id: r.id,
+      role: r.role,
+      roleStartDate: r.roleStartDate,
+      roleEndDate: r.roleEndDate,
+      notes: r.notes,
+      customer: {
+        id: r.customer.id,
+        name: r.customer.name,
+        nameKana: r.customer.nameKana ?? '',
+        phoneNumber: r.customer.phoneNumber,
+        address: r.customer.address ?? '',
+      },
+    })),
+    createdAt: detail.createdAt,
+    updatedAt: detail.updatedAt,
+  };
+}
+
+/**
  * モック: 区画作成
  */
 async function mockCreatePlot(
   request: CreatePlotRequest
-): Promise<ApiResponse<PlotDetailResponse>> {
+): Promise<ApiResponse<CreatePlotResponse>> {
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   // 簡易的なモック応答
@@ -409,7 +468,7 @@ async function mockCreatePlot(
 
   return {
     success: true,
-    data: detail,
+    data: plotDetailToMutationResponse(detail),
   };
 }
 
@@ -521,30 +580,38 @@ export async function getPlotById(
 
 /**
  * 区画作成
+ *
+ * backend は PlotDetailResponse ではなく CreatePlotResponse 形状
+ * （primaryCustomer あり・buriedPersons/familyContacts 等なし）を返す（#217）。
+ * フル詳細が必要な場合は getPlotById で再取得すること。
  */
 export async function createPlot(
   request: CreatePlotRequest
-): Promise<ApiResponse<PlotDetailResponse>> {
+): Promise<ApiResponse<CreatePlotResponse>> {
   if (shouldUseMockData()) {
     return mockCreatePlot(request);
   }
 
-  return apiPost<PlotDetailResponse>('/plots', request);
+  return apiPost<CreatePlotResponse>('/plots', request);
 }
 
 /**
  * 区画更新
+ *
+ * backend updatePlot のレスポンスも CreatePlotResponse と同形状（#217）。
  */
 export async function updatePlot(
   id: string,
   request: UpdatePlotRequest
-): Promise<ApiResponse<PlotDetailResponse>> {
+): Promise<ApiResponse<CreatePlotResponse>> {
   if (shouldUseMockData()) {
-    // モック実装は簡略化
-    return mockGetPlotById(id);
+    // モック実装は簡略化（詳細を取得して作成/更新レスポンス形状に変換）
+    const detail = await mockGetPlotById(id);
+    if (!detail.success) return detail;
+    return { success: true, data: plotDetailToMutationResponse(detail.data) };
   }
 
-  return apiPut<PlotDetailResponse>(`/plots/${id}`, request);
+  return apiPut<CreatePlotResponse>(`/plots/${id}`, request);
 }
 
 /**


### PR DESCRIPTION
## 概要
`createPlot` の戻り型宣言が `PlotDetailResponse` だが backend は `CreatePlotResponse` 形状を返す型不整合を修正（issue 修正方針 1: 実装変更より影響の小さい「型宣言を実体に合わせる」方向）。

## 変更内容
- `src/lib/api/plots.ts`
  - `createPlot` / `updatePlot` の戻り型を `ApiResponse<CreatePlotResponse>` へ変更（backend `updatePlot.ts` も同形状を返すため共用、issue 記載どおり）
  - モック整合: `plotDetailToMutationResponse`（PlotDetailResponse → CreatePlotResponse 変換）を新設し、`mockCreatePlot` / `updatePlot` モック経路も同形状を返す（issue 修正方針 3）
- `src/hooks/usePlots.ts`: `usePlotMutations` の `create`/`update` 戻り型を `CreatePlotResponse | null` に追随（update は既に `getPlotById` 再取得でフル詳細をキャッシュ済みのため実害なし、issue 記載どおり）

## 影響確認
呼び出し側（`plots/new/page.tsx` / `plots/[id]/edit/page.tsx`）は `response.success` のみ参照しており挙動変更なし。

## テスト
- `npx tsc --noEmit` clean / `npm test` 425 passed / `npm run lint` clean

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)