### PR TITLE
fix: 合祀一覧 search() の二重フェッチを解消 (#223)

### DIFF
--- a/src/__tests__/hooks/use-collective-burial-list-fetch.test.ts
+++ b/src/__tests__/hooks/use-collective-burial-list-fetch.test.ts
@@ -1,0 +1,68 @@
+/**
+ * useCollectiveBurialList の二重フェッチ防止テスト（#223）
+ *
+ * search() が setParams と fetchList を同時に呼ぶと、params 変化による
+ * useEffect 再発火と合わせて同一条件の取得が2回走っていた。
+ * 検索1回につきフェッチが1回だけ走ることを保証する。
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useCollectiveBurialList } from '@/hooks/useCollectiveBurials';
+
+const getCollectiveBurialListMock = jest.fn();
+jest.mock('@/lib/api', () => ({
+  getCollectiveBurialList: (...args: unknown[]) => getCollectiveBurialListMock(...args),
+  getCollectiveBurialById: jest.fn(),
+  createCollectiveBurial: jest.fn(),
+  updateCollectiveBurial: jest.fn(),
+  updateBillingStatus: jest.fn(),
+  syncBurialCount: jest.fn(),
+  deleteCollectiveBurial: jest.fn(),
+  getCollectiveBurialStatsByYear: jest.fn(),
+}));
+
+const emptyResponse = {
+  success: true,
+  data: {
+    items: [],
+    pagination: { page: 1, limit: 50, totalCount: 0, totalPages: 0 },
+  },
+};
+
+describe('useCollectiveBurialList 二重フェッチ防止 (#223)', () => {
+  beforeEach(() => {
+    getCollectiveBurialListMock.mockReset();
+    getCollectiveBurialListMock.mockResolvedValue(emptyResponse);
+  });
+
+  it('初回マウントでフェッチは1回だけ走る', async () => {
+    renderHook(() => useCollectiveBurialList());
+
+    await waitFor(() => {
+      expect(getCollectiveBurialListMock).toHaveBeenCalledTimes(1);
+    });
+    // 追加のフェッチが走らないこと
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getCollectiveBurialListMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('search() 1回につきフェッチは1回だけ走る', async () => {
+    const { result } = renderHook(() => useCollectiveBurialList());
+    await waitFor(() => {
+      expect(getCollectiveBurialListMock).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      result.current.search({ search: '田中' });
+    });
+
+    await waitFor(() => {
+      expect(getCollectiveBurialListMock).toHaveBeenCalledTimes(2);
+    });
+    expect(getCollectiveBurialListMock).toHaveBeenLastCalledWith({ search: '田中' });
+
+    // 二重フェッチ（3回目）が走らないこと
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getCollectiveBurialListMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/useCollectiveBurials.ts
+++ b/src/hooks/useCollectiveBurials.ts
@@ -64,11 +64,12 @@ export function useCollectiveBurialList(initialParams?: CollectiveBurialSearchPa
     fetchList();
   }, [fetchList]);
 
-  // 検索パラメータを更新して再取得
+  // 検索パラメータを更新して再取得。
+  // 取得は params 変化 → fetchList 再生成 → useEffect 発火の一本に任せる。
+  // ここで fetchList(newParams) も直接呼ぶと同一条件の二重フェッチになる（#223）
   const search = useCallback((newParams: CollectiveBurialSearchParams) => {
     setParams(newParams);
-    fetchList(newParams);
-  }, [fetchList]);
+  }, []);
 
   // 再取得
   const refresh = useCallback(() => {


### PR DESCRIPTION
## 概要
合祀一覧の検索・フィルタ実行時に同一条件の GET が2本走る問題を修正。

`search(newParams)` が `setParams` と `fetchList(newParams)` を同時に呼ぶため、params 変化による useEffect 再発火と合わせて二重フェッチになっていた。

## 変更内容
- `useCollectiveBurialList` の `search` を `setParams` のみに変更（issue 修正方針どおり）
  - 取得は params 変化 → fetchList 再生成 → useEffect 発火の一本に集約
  - 依存配列が空になり `search` の参照安定性も向上
- 回帰テスト2件追加（初回マウントで1回 / search 1回につきフェッチ1回）

## テスト
- `npx tsc --noEmit` clean / `npm test` 435 passed / `npm run lint` clean

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)