### PR TITLE
fix: エリア/電話見出しの無効なソートアフォーダンスを除去 (#224)

### DIFF
--- a/src/components/plot-registry/PlotTable.tsx
+++ b/src/components/plot-registry/PlotTable.tsx
@@ -102,18 +102,9 @@ export function PlotTable({
                 </div>
                 <ColumnResizer columnKey="plotNumber" onResizeStart={onColumnResizeStart} />
               </th>
-              <th
-                className={cn(
-                  "relative px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200",
-                  "hover:bg-matsu-light",
-                  sortKey === 'areaName' && "bg-matsu-dark"
-                )}
-                onClick={() => onSort('areaName')}
-              >
-                <div className="flex items-center">
-                  <span>エリア</span>
-                  <SortIndicator columnKey="areaName" sortKey={sortKey} sortOrder={sortOrder} />
-                </div>
+              {/* エリア/電話はサーバーソート未対応のためソート不可の見出しにする（#224） */}
+              <th className="relative px-2 py-2 text-left text-xs font-bold text-white">
+                <span>エリア</span>
                 <ColumnResizer columnKey="areaName" onResizeStart={onColumnResizeStart} />
               </th>
               <th
@@ -134,18 +125,8 @@ export function PlotTable({
                 <span>住所</span>
                 <ColumnResizer columnKey="address" onResizeStart={onColumnResizeStart} />
               </th>
-              <th
-                className={cn(
-                  "relative px-2 py-2 text-left text-xs font-bold text-white cursor-pointer transition-all duration-200 hidden lg:table-cell",
-                  "hover:bg-matsu-light",
-                  sortKey === 'phoneNumber' && "bg-matsu-dark"
-                )}
-                onClick={() => onSort('phoneNumber')}
-              >
-                <div className="flex items-center">
-                  <span>電話</span>
-                  <SortIndicator columnKey="phoneNumber" sortKey={sortKey} sortOrder={sortOrder} />
-                </div>
+              <th className="relative px-2 py-2 text-left text-xs font-bold text-white hidden lg:table-cell">
+                <span>電話</span>
                 <ColumnResizer columnKey="phone" onResizeStart={onColumnResizeStart} />
               </th>
               <th className="relative px-2 py-2 text-left text-xs font-bold text-white hidden lg:table-cell">

--- a/src/components/plot-registry/types.ts
+++ b/src/components/plot-registry/types.ts
@@ -2,12 +2,12 @@ import type { PlotListItem } from '@komine/types';
 
 // ===== ソート =====
 
+// サーバーソート対応キーのみ（SERVER_SORT_MAP と一致させる）。
+// areaName/phoneNumber は backend に安定した orderBy 経路が無くソート不能の
+// ため、見出しのソートアフォーダンスごと撤去した（#224）
 export type SortKey =
-  | 'status'
   | 'plotNumber'
   | 'customerName'
-  | 'phoneNumber'
-  | 'areaName'
   | 'contractDate'
   | 'paymentStatus'
   | 'managementFee';


### PR DESCRIPTION
## 概要
区画一覧の『エリア』『電話』見出しがクリック可能でインジケータも動くのに、実際は並びが一切変わらない問題を修正。

`SERVER_SORT_MAP` に両キーが無く sortBy がサーバへ送られず、backend の sortBy switch にも未対応（created_at フォールバック）のため、issue 推奨の **案(2): アフォーダンス除去** を採用。

## 変更内容
- `PlotTable.tsx`: 両見出しから `onClick` / `cursor-pointer` / `hover:bg-matsu-light` / `SortIndicator` を除去し、住所・取扱・許可番号と同じ非ソート見出しに統一（列幅リサイザは維持）
- `types.ts`: `SortKey` から未使用の `'status'` / `'areaName'` / `'phoneNumber'` を削除し `SERVER_SORT_MAP` と型レベルで一致（issue 記載どおり）

## 案(1)（サーバーソート対応）について
backend にエリアの orderBy 追加（`physicalPlot.area_name`）+ 電話のアプリ側ソートが必要で、電話はページネーションと相性が悪いため見送り（issue の分析どおり）。必要になれば backend 対応とセットで再追加。

## テスト
- `npx tsc --noEmit` clean / `npm test` 433 passed / `npm run lint` clean

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)