### PR TITLE
fix: 請求管理サマリーをサーバ全件集計に置換 (#225)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=0a9145a962251b3055c9ad3691fab6ed9e21e6c9
+ARG TYPES_REF=67e6fe7ebf4a18591aca8091678c5f9b28835283
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/components/billing/billing-management.tsx
+++ b/src/components/billing/billing-management.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import {
   Billing,
   BillingCategory,
@@ -8,9 +8,12 @@ import {
   CreateBillingRequest,
   UpdateBillingRequest,
   ListBillingsQuery,
+  BillingSummaryQuery,
+  BillingSummaryResponse,
 } from '@komine/types';
 import {
   getBillings,
+  getBillingSummary,
   createBilling as apiCreate,
   updateBilling as apiUpdate,
   deleteBilling as apiDelete,
@@ -94,13 +97,35 @@ export default function BillingManagement({
     fetchList();
   }, [fetchList]);
 
-  const stats = useMemo(() => {
-    const totalAmount = items.reduce((s, b) => s + b.amount, 0);
-    const paidAmount = items.reduce((s, b) => s + b.paidAmount, 0);
-    const unpaidAmount = totalAmount - paidAmount;
-    const overdueCount = items.filter((b) => b.status === 'overdue').length;
-    return { totalAmount, paidAmount, unpaidAmount, overdueCount };
-  }, [items]);
+  // 上部 StatCard（請求総額/入金済/未入金/延滞件数）はサーバ全件集計を使う。
+  // items はページ分（PAGE_SIZE=50件）しか無く、reduce で出すと50件超で
+  // ページごとに数値が変わり全件総額と誤読される（#225）
+  const [summary, setSummary] = useState<BillingSummaryResponse | null>(null);
+  // 世代カウンタ: フィルタ連続変更時の古いレスポンス上書きを防ぐ（#231）
+  const summaryGenRef = useRef(0);
+
+  const fetchSummary = useCallback(async () => {
+    const myGen = ++summaryGenRef.current;
+    const query: BillingSummaryQuery = {
+      contractPlotId,
+      category: categoryFilter === 'all' ? undefined : categoryFilter,
+      status: statusFilter === 'all' ? undefined : statusFilter,
+    };
+    try {
+      const res = await getBillingSummary(query);
+      if (myGen !== summaryGenRef.current) return;
+      if (res.success) {
+        setSummary(res.data);
+      }
+      // 失敗時は前回値を保持（エラー表示は一覧側に任せる）
+    } catch {
+      // サマリーは補助情報のため握りつぶす（一覧側のエラー表示に任せる）
+    }
+  }, [contractPlotId, categoryFilter, statusFilter]);
+
+  useEffect(() => {
+    fetchSummary();
+  }, [fetchSummary]);
 
   const handleSubmit = async (data: CreateBillingRequest | UpdateBillingRequest) => {
     setIsSaving(true);
@@ -110,7 +135,7 @@ export default function BillingManagement({
         if (res.success) {
           showSuccess('請求を更新しました');
           setShowFormDialog(false);
-          await fetchList();
+          await Promise.all([fetchList(), fetchSummary()]);
         } else {
           showApiError('請求の更新', res.error?.message, res.error?.details);
         }
@@ -119,7 +144,7 @@ export default function BillingManagement({
         if (res.success) {
           showSuccess('請求を登録しました');
           setShowFormDialog(false);
-          await fetchList();
+          await Promise.all([fetchList(), fetchSummary()]);
         } else {
           showApiError('請求の登録', res.error?.message, res.error?.details);
         }
@@ -140,7 +165,7 @@ export default function BillingManagement({
         showSuccess('請求を削除しました');
         setShowDeleteConfirm(false);
         setDeletingTarget(null);
-        await fetchList();
+        await Promise.all([fetchList(), fetchSummary()]);
       } else {
         showApiError('請求の削除', res.error?.message, res.error?.details);
       }
@@ -186,10 +211,11 @@ export default function BillingManagement({
 
         {showHeader && (
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 px-3 md:px-6 py-4">
-            <StatCard label="請求総額" value={formatYen(stats.totalAmount)} theme="sumi" />
-            <StatCard label="入金済" value={formatYen(stats.paidAmount)} theme="matsu" />
-            <StatCard label="未入金" value={formatYen(stats.unpaidAmount)} theme="kohaku" />
-            <StatCard label="延滞件数" value={stats.overdueCount} theme="beni" />
+            {/* サーバ全件集計（#225）。取得前は '--' を表示し、ページ分の合計は出さない */}
+            <StatCard label="請求総額" value={summary ? formatYen(summary.totalAmount) : '--'} theme="sumi" />
+            <StatCard label="入金済" value={summary ? formatYen(summary.paidAmount) : '--'} theme="matsu" />
+            <StatCard label="未入金" value={summary ? formatYen(summary.unpaidAmount) : '--'} theme="kohaku" />
+            <StatCard label="延滞件数" value={summary ? summary.overdueCount : '--'} theme="beni" />
           </div>
         )}
 

--- a/src/lib/api/billings.ts
+++ b/src/lib/api/billings.ts
@@ -13,6 +13,8 @@ import {
   UpdateBillingRequest,
   ListBillingsQuery,
   DeleteBillingResponse,
+  BillingSummaryQuery,
+  BillingSummaryResponse,
   BillingCategory,
   BillingRecordStatus,
 } from '@komine/types';
@@ -43,6 +45,25 @@ export function getBillings(
   query?: ListBillingsQuery
 ): Promise<ApiResponse<BillingsListResponse>> {
   return apiGet<BillingsListResponse>(BASE, queryToParams(query));
+}
+
+/**
+ * 請求サマリー集計取得（フィルタ一致の全件集計）
+ *
+ * 一覧はページネーションされるため、StatCard の合計をページ分の reduce で
+ * 出すと誤読される（#225）。サーバ集計の本 API を使うこと。
+ */
+export function getBillingSummary(
+  query?: BillingSummaryQuery
+): Promise<ApiResponse<BillingSummaryResponse>> {
+  return apiGet<BillingSummaryResponse>(`${BASE}/summary`, {
+    contractPlotId: query?.contractPlotId,
+    customerId: query?.customerId,
+    category: query?.category,
+    status: query?.status,
+    billingDateFrom: query?.billingDateFrom,
+    billingDateTo: query?.billingDateTo,
+  });
 }
 
 export function getBillingById(id: string): Promise<ApiResponse<BillingDetailResponse>> {


### PR DESCRIPTION
## 概要
請求管理画面の上部 StatCard（請求総額/入金済/未入金/延滞件数）が現在ページ分（50件）のみの合計で、ページ送りで数値が変わり全件総額と誤読される問題を、issue の正攻法（backend 集計エンドポイント）で修正。

## 関連 PR（マージ順序）
1. types: zaitsu82/komine-types#33 ✅ マージ済み
2. backend: zaitsu82/komine-crm-backend#251（`GET /billings/summary`）← **本 PR より先にマージ要**（実APIで効くのは backend デプロイ後）
3. frontend: 本 PR

## 変更内容
- `src/lib/api/billings.ts`: `getBillingSummary()` を追加
- `billing-management.tsx`:
  - `stats`（items.reduce の useMemo）→ サーバ全件集計の `summary` state に置換
  - フィルタ変更で再取得（page 非依存）、取得前は `'--'` 表示
  - 作成/更新/削除後は一覧とサマリーを併せて再取得
  - フィルタ連続変更に備えた世代ガード付き（#231 と同パターン）
- `Dockerfile`: `TYPES_REF` を types main（`67e6fe7`）へ bump（types 更新時の bump 規約）

## テスト
- `npx tsc --noEmit` clean / `npm test` 436 passed / `npm run lint` clean

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)