### PR TITLE
fix: types #31/#32 フォローアップ（終納請求年月の表示整合 + TYPES_REF bump）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=67e6fe7ebf4a18591aca8091678c5f9b28835283
+ARG TYPES_REF=d4055528467e8f154204acc1be4d2d9a2e8913f4
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/__tests__/lib/validations/plot-form.test.ts
+++ b/src/__tests__/lib/validations/plot-form.test.ts
@@ -535,6 +535,28 @@ describe('plot-form.ts - Zodスキーマバリデーション', () => {
       const result = plotFormSchema.safeParse(data);
       expect(result.success).toBe(true);
     });
+
+    it('レガシー形式の終納請求年月（2024-04 等）でも保存できる（types #31）', () => {
+      const data = validPlotFormData();
+      data.managementFee = {
+        calculationType: null,
+        taxType: null,
+        billingType: null,
+        billingYears: null,
+        area: null,
+        billingMonth: null,
+        managementFee: '5000',
+        unitPrice: null,
+        lastBillingMonth: '2024-04',
+        paymentMethod: null,
+      };
+      const result = plotFormSchema.safeParse(data);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // yearMonthSchema の preprocess で正規化された値が出力される
+        expect(result.data.managementFee?.lastBillingMonth).toBe('2024年4月');
+      }
+    });
   });
 
   describe('plotUpdateFormSchema', () => {
@@ -1270,6 +1292,28 @@ describe('plotDetailToFormData', () => {
     expect(formData.managementFee).toBeDefined();
     expect(formData.managementFee!.managementFee).toBe('5000');
     expect(formData.managementFee!.billingMonth).toBe('4');
+  });
+
+  it('レガシー形式の lastBillingMonth は読み込み時に正規化される（types #31）', () => {
+    const detail = makePlotDetail({
+      managementFee: {
+        calculationType: null,
+        taxType: null,
+        billingType: null,
+        billingYears: null,
+        area: null,
+        billingMonth: null,
+        managementFee: '5000',
+        unitPrice: null,
+        lastBillingMonth: '2024-04',
+        paymentMethod: null,
+      },
+    });
+    const formData = plotDetailToFormData(detail);
+
+    expect(formData.managementFee!.lastBillingMonth).toBe('2024年4月');
+    // 正規化後のフォームデータが検証を通る（保存ブロックの回帰確認）
+    expect(plotFormSchema.safeParse(formData).success).toBe(true);
   });
 
   it('familyContactsを正しくマッピングする', () => {

--- a/src/components/plot-form/FeeInfoTab.tsx
+++ b/src/components/plot-form/FeeInfoTab.tsx
@@ -281,7 +281,7 @@ export function FeeInfoTab({
               viewMode={viewMode}
               register={register('managementFee.lastBillingMonth')}
               error={errors.managementFee?.lastBillingMonth?.message}
-              placeholder="2024-04"
+              placeholder="2024年4月"
             />
 
             <ViewModeSelect

--- a/src/lib/validations/plot-form.ts
+++ b/src/lib/validations/plot-form.ts
@@ -64,6 +64,19 @@ import type {
   PlotFormData,
   PlotUpdateFormData,
 } from '@komine/types/validations';
+import { normalizeYearMonth } from '@komine/types/validations';
+
+/**
+ * 終納請求年月の表示用正規化（types #31）。
+ * レガシー移行データ（'2024-04'/'202404' 等）をフォーム初期値の時点で
+ * 'YYYY年M月' に寄せる。バリデーション側（yearMonthSchema の preprocess）
+ * でも正規化されるため保存は通るが、入力欄の表示も統一する。
+ */
+function normalizeLastBillingMonth(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const normalized = normalizeYearMonth(value);
+  return typeof normalized === 'string' ? normalized : value;
+}
 
 // ===== デフォルト値 =====
 
@@ -644,7 +657,7 @@ export function plotDetailToFormData(detail: PlotDetailResponse): PlotFormData {
         billingMonth: detail.managementFee.billingMonth,
         managementFee: detail.managementFee.managementFee,
         unitPrice: detail.managementFee.unitPrice,
-        lastBillingMonth: detail.managementFee.lastBillingMonth,
+        lastBillingMonth: normalizeLastBillingMonth(detail.managementFee.lastBillingMonth),
         paymentMethod: detail.managementFee.paymentMethod,
       }
       : null,


### PR DESCRIPTION
## 概要
types 側の root fix 2件のフロント反映。

- zaitsu82/komine-types#34（#32: 封筒書・封筒台の generate-pdf 400 → discriminated union に追加）
- zaitsu82/komine-types#35（#31: 終納請求年月の表記揺れ正規化 → 管理料区画の保存不能解消）

## 変更内容
- `FeeInfoTab.tsx`: 『終納請求年月』プレースホルダを `2024-04` → `2024年4月`（issue #31 修正方針 (B)）
- `plot-form.ts`: `plotDetailToFormData` でレガシー値を `normalizeYearMonth`（@komine/types から import）で読み込み時に表示正規化
- `Dockerfile`: `TYPES_REF` を `d405552`（types main）へ bump — **これにより封筒PDF修正（#32）も本番ビルドに反映される**
- 回帰テスト2件追加
  - `plotFormSchema` がレガシー形式 `2024-04` を受理し `2024年4月` に正規化（保存ブロックの回帰）
  - `plotDetailToFormData` の読み込み時正規化

## テスト
- `npx tsc --noEmit` clean / `npm test` 438 passed / `npm run lint` clean

Refs zaitsu82/komine-types#31 / zaitsu82/komine-types#32

🤖 Generated with [Claude Code](https://claude.com/claude-code)