### PR TITLE
fix: 無効化マスタの取得経路をフロントに通し名称解決・編集フォームの旧コード化を解消 (#238)

### DIFF
--- a/src/__tests__/components/masters-management-inactive.test.tsx
+++ b/src/__tests__/components/masters-management-inactive.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * マスタ管理 無効マスタの表示・再有効化（#238）
+ *
+ * - 一覧は include_inactive 付きで取得し、無効マスタも表示する
+ *   （表示しないと無効化したマスタを再有効化できない）
+ * - 編集ダイアログの有効トグルで isActive を更新できる
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import MastersManagement from '@/components/masters-management';
+
+jest.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({
+    user: { id: 'staff-1', email: 'admin@example.com', name: '管理者', role: 'admin' },
+  }),
+}));
+
+const getAllMastersMock = jest.fn();
+const updateMasterItemMock = jest.fn();
+jest.mock('@/lib/api', () => ({
+  getAllMasters: (...args: unknown[]) => getAllMastersMock(...args),
+  createMasterItem: jest.fn(),
+  updateMasterItem: (...args: unknown[]) => updateMasterItemMock(...args),
+  deleteMasterItem: jest.fn(),
+  shouldUseMockData: () => false,
+}));
+
+jest.mock('@/lib/toast', () => ({
+  showSuccess: jest.fn(),
+  showError: jest.fn(),
+}));
+
+jest.mock('@/hooks/useMasters', () => ({
+  clearMastersCache: jest.fn(),
+}));
+
+// Radix UI Select はJSDOMで動かないため最小モック
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: () => null,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Radix UI Switch も最小モック（role/aria-checked のみ再現）
+jest.mock('@/components/ui/switch', () => ({
+  Switch: ({
+    checked,
+    onCheckedChange,
+    id,
+  }: {
+    checked: boolean;
+    onCheckedChange: (checked: boolean) => void;
+    id?: string;
+  }) => (
+    <button
+      type="button"
+      id={id}
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+    />
+  ),
+}));
+
+const masters = {
+  cemeteryType: [
+    { id: 1, code: 'GENERAL', name: '一般墓地', description: null, sortOrder: 1, isActive: true },
+    { id: 2, code: 'OLD', name: '旧タイプ', description: null, sortOrder: 2, isActive: false },
+  ],
+  paymentMethod: [],
+  taxType: [],
+  calcType: [],
+  billingType: [],
+  recipientType: [],
+  constructionType: [],
+  sectionName: [],
+};
+
+describe('マスタ管理 無効マスタの表示・再有効化 (#238)', () => {
+  beforeEach(() => {
+    getAllMastersMock.mockReset();
+    getAllMastersMock.mockResolvedValue({ success: true, data: masters });
+    updateMasterItemMock.mockReset();
+    updateMasterItemMock.mockResolvedValue({
+      success: true,
+      data: { id: 2, code: 'OLD', name: '旧タイプ', description: null, sortOrder: 2, isActive: true },
+    });
+  });
+
+  it('include_inactive 付きで取得し、無効マスタも一覧に表示する', async () => {
+    render(<MastersManagement />);
+
+    // 無効マスタが一覧に出る（バッジ「無効」付き）
+    expect(await screen.findByText('旧タイプ')).toBeInTheDocument();
+    expect(screen.getByText('無効')).toBeInTheDocument();
+    expect(getAllMastersMock).toHaveBeenCalledWith({ includeInactive: true });
+  });
+
+  it('編集ダイアログの有効トグルで isActive を更新できる', async () => {
+    const user = userEvent.setup();
+    render(<MastersManagement />);
+
+    await screen.findByText('旧タイプ');
+    // 2行目（無効マスタ）の編集を開く
+    await user.click(screen.getAllByRole('button', { name: '編集' })[1]);
+
+    // 無効状態で開く → トグルで有効化
+    const toggle = screen.getByRole('switch');
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    await user.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(updateMasterItemMock).toHaveBeenCalledWith(
+        'cemetery-type',
+        2,
+        expect.objectContaining({ isActive: true }),
+      );
+    });
+  });
+
+  it('新規作成ダイアログには有効トグルを出さない（新規は常に有効で作成）', async () => {
+    const user = userEvent.setup();
+    render(<MastersManagement />);
+
+    await screen.findByText('旧タイプ');
+    await user.click(screen.getByRole('button', { name: /新規登録/ }));
+
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/plot-form/master-fallback-select-item.test.tsx
+++ b/src/__tests__/components/plot-form/master-fallback-select-item.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * MasterFallbackSelectItem（#238）
+ *
+ * 無効化済みマスタや未 remap の旧コードを参照する既存データを編集すると
+ * Select トリガーが空表示になる問題に対し、現在値を表す SelectItem を
+ * 1件だけ補完描画することを保証する（保存値は元のまま）。
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MasterFallbackSelectItem } from '@/components/plot-form/ViewModeField';
+import type { MasterItem } from '@/lib/api';
+
+// Radix UI Select はJSDOMで動かないため最小モック
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: () => null,
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <div data-testid="fallback-item" data-value={value}>
+      {children}
+    </div>
+  ),
+}));
+
+// 無効を含む全件マスタ（useMasters().allMasters 相当）
+const masters: MasterItem[] = [
+  { id: 1, code: 'AREA', name: '面積×単価', description: null, sortOrder: 1, isActive: true },
+  { id: 2, code: 'FIXED', name: '任意設定', description: null, sortOrder: 2, isActive: false },
+];
+
+describe('MasterFallbackSelectItem (#238)', () => {
+  it('値が空なら何も描画しない', () => {
+    const { container } = render(<MasterFallbackSelectItem value="" masters={masters} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('active マスタの code がそのまま現在値なら補完しない（通常の選択肢で表示される）', () => {
+    const { container } = render(<MasterFallbackSelectItem value="AREA" masters={masters} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('無効化済みマスタの code は「名称（無効）」で補完する', () => {
+    render(<MasterFallbackSelectItem value="FIXED" masters={masters} />);
+    const item = screen.getByTestId('fallback-item');
+    expect(item).toHaveTextContent('任意設定（無効）');
+    // 保存値は元のまま（表示のみの補完）
+    expect(item).toHaveAttribute('data-value', 'FIXED');
+  });
+
+  it('旧int値は legacyMap で active マスタへ解決し「名称（旧コード）」で補完する', () => {
+    render(
+      <MasterFallbackSelectItem value="0" masters={masters} legacyMap={{ '0': 'AREA' }} />,
+    );
+    const item = screen.getByTestId('fallback-item');
+    expect(item).toHaveTextContent('面積×単価（旧コード）');
+    expect(item).toHaveAttribute('data-value', '0');
+  });
+
+  it('旧int値が無効化済みマスタへ解決された場合は「名称（無効）」', () => {
+    render(
+      <MasterFallbackSelectItem value="9" masters={masters} legacyMap={{ '9': 'FIXED' }} />,
+    );
+    expect(screen.getByTestId('fallback-item')).toHaveTextContent('任意設定（無効）');
+  });
+
+  it('マスタに存在しない値は「値（既存値）」で補完する', () => {
+    render(<MasterFallbackSelectItem value="UNKNOWN" masters={masters} />);
+    expect(screen.getByTestId('fallback-item')).toHaveTextContent('UNKNOWN（既存値）');
+  });
+
+  it('matchBy=name: active マスタの名称なら補完しない（続柄は名称を保存）', () => {
+    const { container } = render(
+      <MasterFallbackSelectItem value="面積×単価" masters={masters} matchBy="name" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('matchBy=name: 無効化済みマスタの名称は「名称（無効）」で補完する', () => {
+    render(<MasterFallbackSelectItem value="任意設定" masters={masters} matchBy="name" />);
+    const item = screen.getByTestId('fallback-item');
+    expect(item).toHaveTextContent('任意設定（無効）');
+    expect(item).toHaveAttribute('data-value', '任意設定');
+  });
+});

--- a/src/__tests__/hooks/use-masters-inactive.test.ts
+++ b/src/__tests__/hooks/use-masters-inactive.test.ts
@@ -1,0 +1,71 @@
+/**
+ * useMasters の2系統アクセサ（#238）
+ *
+ * 無効化済みマスタを参照する既存データの名称解決を維持するため、
+ * include_inactive 付きで全件取得し、
+ * - 既存の個別アクセサ（フォーム選択肢用）は active のみ
+ * - allMasters（名称解決用）は無効を含む全件
+ * を返すことを保証する。
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { useMasters, clearMastersCache } from '@/hooks/useMasters';
+import type { AllMastersData } from '@/lib/api';
+
+const getAllMastersMock = jest.fn();
+jest.mock('@/lib/api', () => ({
+  getAllMasters: (...args: unknown[]) => getAllMastersMock(...args),
+  // useMasters.ts が import する個別取得関数（本テストでは未使用）
+  getCemeteryTypes: jest.fn(),
+  getPaymentMethods: jest.fn(),
+  getTaxTypes: jest.fn(),
+  getCalcTypes: jest.fn(),
+  getBillingTypes: jest.fn(),
+  getRecipientTypes: jest.fn(),
+  getConstructionTypes: jest.fn(),
+  getSectionNames: jest.fn(),
+  getContractors: jest.fn(),
+}));
+
+const mastersData: AllMastersData = {
+  cemeteryType: [],
+  paymentMethod: [],
+  taxType: [],
+  calcType: [
+    { id: 1, code: 'AREA', name: '面積×単価', description: null, sortOrder: 1, isActive: true },
+    { id: 2, code: 'FIXED', name: '任意設定', description: null, sortOrder: 2, isActive: false },
+  ],
+  billingType: [],
+  recipientType: [],
+  constructionType: [],
+  sectionName: [],
+  relationship: [],
+  contractor: [],
+  direction: [],
+  position: [],
+};
+
+describe('useMasters 2系統アクセサ (#238)', () => {
+  beforeEach(() => {
+    clearMastersCache();
+    getAllMastersMock.mockReset();
+    getAllMastersMock.mockResolvedValue({ success: true, data: mastersData });
+  });
+
+  it('include_inactive 付きで全件取得する', async () => {
+    const { result } = renderHook(() => useMasters());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getAllMastersMock).toHaveBeenCalledWith({ includeInactive: true });
+  });
+
+  it('個別アクセサは active のみ、allMasters は無効を含む全件を返す', async () => {
+    const { result } = renderHook(() => useMasters());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // フォーム選択肢用: 無効マスタは含まない
+    expect(result.current.calcTypes.map((m) => m.code)).toEqual(['AREA']);
+    // 名称解決用: 無効マスタも含む
+    expect(result.current.allMasters.calcTypes.map((m) => m.code)).toEqual(['AREA', 'FIXED']);
+  });
+});

--- a/src/components/masters-management.tsx
+++ b/src/components/masters-management.tsx
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import { Plus } from 'lucide-react';
 import { useAuth } from '@/contexts/auth-context';
 import {
@@ -68,7 +69,7 @@ export default function MastersManagement() {
   // Dialog state
   const [showDialog, setShowDialog] = useState(false);
   const [editingItem, setEditingItem] = useState<MasterItem | null>(null);
-  const [formData, setFormData] = useState({ name: '', description: '', sortOrder: '', period: '' });
+  const [formData, setFormData] = useState({ name: '', description: '', sortOrder: '', period: '', isActive: true });
   const [formError, setFormError] = useState('');
   const [isSaving, setIsSaving] = useState(false);
 
@@ -80,7 +81,8 @@ export default function MastersManagement() {
   const fetchData = useCallback(async () => {
     setIsLoading(true);
     setLoadError(null);
-    const response = await getAllMasters();
+    // 無効マスタも一覧に出す（#238: 出さないと無効化したマスタを再有効化できない）
+    const response = await getAllMasters({ includeInactive: true });
     if (response.success) {
       setMastersData(response.data);
     } else {
@@ -103,7 +105,7 @@ export default function MastersManagement() {
 
   const handleOpenCreate = () => {
     setEditingItem(null);
-    setFormData({ name: '', description: '', sortOrder: '', period: '' });
+    setFormData({ name: '', description: '', sortOrder: '', period: '', isActive: true });
     setFormError('');
     setShowDialog(true);
   };
@@ -115,6 +117,7 @@ export default function MastersManagement() {
       description: item.description || '',
       sortOrder: item.sortOrder?.toString() || '',
       period: isSectionName ? (item as SectionNameMasterItem).period || '' : '',
+      isActive: item.isActive,
     });
     setFormError('');
     setShowDialog(true);
@@ -140,6 +143,8 @@ export default function MastersManagement() {
       name: formData.name.trim(),
       description: formData.description.trim() || null,
       sortOrder: formData.sortOrder ? parseInt(formData.sortOrder, 10) : null,
+      // 論理無効化トグルは編集時のみ（#238）。新規作成は backend デフォルト（有効）
+      ...(editingItem ? { isActive: formData.isActive } : {}),
       ...(isSectionName && formData.period.trim() ? { period: formData.period.trim() } : {}),
     };
 
@@ -317,7 +322,7 @@ export default function MastersManagement() {
                       </tr>
                     ) : (
                       currentItems.map((item) => (
-                        <tr key={item.id} className="hover:bg-shiro">
+                        <tr key={item.id} className={`hover:bg-shiro ${item.isActive ? '' : 'opacity-60'}`}>
                           <td className="px-2 md:px-4 py-2 md:py-3 text-sm font-medium text-sumi">{item.name}</td>
                           {isSectionName && (
                             <td className="px-2 md:px-4 py-2 md:py-3 text-sm text-hai">
@@ -432,6 +437,22 @@ export default function MastersManagement() {
                   placeholder="数値"
                 />
               </div>
+              {/* 論理無効化トグル（#238）。削除と違い既存データの表示は維持される */}
+              {editingItem && (
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <Label htmlFor="isActive">有効</Label>
+                    <p className="text-xs text-hai mt-0.5">
+                      無効にすると新規入力の選択肢から外れます（既存データの表示は維持されます）
+                    </p>
+                  </div>
+                  <Switch
+                    id="isActive"
+                    checked={formData.isActive}
+                    onCheckedChange={(checked) => setFormData({ ...formData, isActive: checked })}
+                  />
+                </div>
+              )}
             </div>
 
             <div className="flex justify-end gap-3 mt-6">

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -788,8 +788,10 @@ function ConstructionInfoTab({
 export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRestore }: PlotDetailViewProps) {
   const { user } = useAuth();
   const { plot, isLoading, error, refresh } = usePlotDetail(plotId);
+  // 名称解決は無効化済みマスタを含む全件で行う（#238: 無効化しても既存データの表示を維持）
+  const { allMasters } = useMasters();
   const { calcTypes, taxTypes, billingTypes, paymentMethods, contractors, directions, positions } =
-    useMasters();
+    allMasters;
   const feeMasters: FeeMasters = { calcTypes, taxTypes, billingTypes, paymentMethods };
 
   // #180: 請求・入金タブの件数バッジ用。子コンポーネントが内部 fetch する構造のため

--- a/src/components/plot-form/BurialInfoTab.tsx
+++ b/src/components/plot-form/BurialInfoTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { BurialInfoTabProps, getDefaultBuriedPerson } from './types';
-import { ViewModeField, ViewModeSelect } from './ViewModeField';
+import { MasterFallbackSelectItem, ViewModeField, ViewModeSelect } from './ViewModeField';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -229,8 +229,6 @@ export function BurialInfoTab({
                   <div>
                     {(() => {
                       const currentValue = watch(`buriedPersons.${index}.relationship`) || '';
-                      const hasLegacyValue =
-                        currentValue && !relationships.some((r) => r.name === currentValue);
                       return (
                         <ViewModeSelect
                           label="続柄"
@@ -245,11 +243,12 @@ export function BurialInfoTab({
                               {r.name}
                             </SelectItem>
                           ))}
-                          {hasLegacyValue && (
-                            <SelectItem key="legacy" value={currentValue}>
-                              {currentValue}（既存値）
-                            </SelectItem>
-                          )}
+                          {/* 無効化済み・未登録の既存値はフォールバック表示（#238）。続柄は名称を保存 */}
+                          <MasterFallbackSelectItem
+                            value={currentValue}
+                            masters={masterData?.all?.relationships ?? relationships}
+                            matchBy="name"
+                          />
                         </ViewModeSelect>
                       );
                     })()}

--- a/src/components/plot-form/ConstructionInfoTab.tsx
+++ b/src/components/plot-form/ConstructionInfoTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { ConstructionInfoTabProps, getDefaultConstructionInfo } from './types';
-import { ViewModeSelect } from './ViewModeField';
+import { MasterFallbackSelectItem, ViewModeSelect } from './ViewModeField';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -20,10 +20,12 @@ export function ConstructionInfoTab({
 }: ConstructionInfoTabProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const contractors = masterData?.contractors ?? [];
+  // 名称解決は無効を含む全件で行う（#238: 無効化済み業者を参照する既存工事の表示維持）
+  const allContractors = masterData?.all?.contractors ?? contractors;
 
   const getContractorLabel = (value: string | null | undefined): string => {
     if (!value) return '未入力';
-    const master = contractors.find((c) => c.code === value);
+    const master = allContractors.find((c) => c.code === value);
     return master ? master.name : value;
   };
 
@@ -106,8 +108,6 @@ export function ConstructionInfoTab({
                     <div>
                       {(() => {
                         const currentValue = watch(`constructionInfos.${index}.contractor`) || '';
-                        const hasLegacyValue =
-                          currentValue && !contractors.some((c) => c.code === currentValue);
                         return (
                           <ViewModeSelect
                             label="業者名"
@@ -122,11 +122,11 @@ export function ConstructionInfoTab({
                                 {c.name}
                               </SelectItem>
                             ))}
-                            {hasLegacyValue && (
-                              <SelectItem key="legacy" value={currentValue}>
-                                {currentValue}（既存値）
-                              </SelectItem>
-                            )}
+                            {/* 無効化済み・未登録の既存値はフォールバック表示（#238） */}
+                            <MasterFallbackSelectItem
+                              value={currentValue}
+                              masters={allContractors}
+                            />
                           </ViewModeSelect>
                         );
                       })()}

--- a/src/components/plot-form/ContactsTab.tsx
+++ b/src/components/plot-form/ContactsTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ContactsTabProps, getDefaultContact } from './types';
-import { ViewModeSelect } from './ViewModeField';
+import { MasterFallbackSelectItem, ViewModeSelect } from './ViewModeField';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -146,8 +146,6 @@ export function ContactsTab({
                 <div>
                   {(() => {
                     const currentValue = watch(`familyContacts.${index}.relationship`) || '';
-                    const hasLegacyValue =
-                      currentValue && !relationships.some((r) => r.name === currentValue);
                     return (
                       <ViewModeSelect
                         label="続柄"
@@ -161,11 +159,12 @@ export function ContactsTab({
                             {r.name}
                           </SelectItem>
                         ))}
-                        {hasLegacyValue && (
-                          <SelectItem key="legacy" value={currentValue}>
-                            {currentValue}（既存値）
-                          </SelectItem>
-                        )}
+                        {/* 無効化済み・未登録の既存値はフォールバック表示（#238）。続柄は名称を保存 */}
+                        <MasterFallbackSelectItem
+                          value={currentValue}
+                          masters={masterData?.all?.relationships ?? relationships}
+                          matchBy="name"
+                        />
                       </ViewModeSelect>
                     );
                   })()}

--- a/src/components/plot-form/FeeInfoTab.tsx
+++ b/src/components/plot-form/FeeInfoTab.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { PlotTabBaseProps } from './types';
-import { ViewModeField, ViewModeSelect } from './ViewModeField';
+import { MasterFallbackSelectItem, ViewModeField, ViewModeSelect } from './ViewModeField';
 import { SelectItem } from '@/components/ui/select';
+import { LEGACY_FEE_CODE_MAP } from '@/lib/master-resolve';
 
 export function FeeInfoTab({
   register,
@@ -92,6 +93,11 @@ export function FeeInfoTab({
                   {item.name}
                 </SelectItem>
               ))}
+              <MasterFallbackSelectItem
+                value={watch('usageFee.calculationType')}
+                masters={masterData?.all?.calcTypes ?? []}
+                legacyMap={LEGACY_FEE_CODE_MAP.calc}
+              />
             </ViewModeSelect>
 
             <ViewModeSelect
@@ -106,6 +112,11 @@ export function FeeInfoTab({
                   {item.name}
                 </SelectItem>
               ))}
+              <MasterFallbackSelectItem
+                value={watch('usageFee.taxType')}
+                masters={masterData?.all?.taxTypes ?? []}
+                legacyMap={LEGACY_FEE_CODE_MAP.tax}
+              />
             </ViewModeSelect>
 
             <ViewModeSelect
@@ -120,6 +131,11 @@ export function FeeInfoTab({
                   {item.name}
                 </SelectItem>
               ))}
+              <MasterFallbackSelectItem
+                value={watch('usageFee.billingType')}
+                masters={masterData?.all?.billingTypes ?? []}
+                legacyMap={LEGACY_FEE_CODE_MAP.billing}
+              />
             </ViewModeSelect>
 
             <ViewModeField
@@ -166,6 +182,11 @@ export function FeeInfoTab({
                   {item.name}
                 </SelectItem>
               ))}
+              {/* 送付方法（旧 shiharai）は旧コードの意味が不明なため legacyMap 無し（#177 と同方針） */}
+              <MasterFallbackSelectItem
+                value={watch('usageFee.paymentMethod')}
+                masters={masterData?.all?.paymentMethods ?? []}
+              />
             </ViewModeSelect>
           </div>
         )}
@@ -206,6 +227,11 @@ export function FeeInfoTab({
                   {item.name}
                 </SelectItem>
               ))}
+              <MasterFallbackSelectItem
+                value={watch('managementFee.calculationType')}
+                masters={masterData?.all?.calcTypes ?? []}
+                legacyMap={LEGACY_FEE_CODE_MAP.calc}
+              />
             </ViewModeSelect>
 
             <ViewModeSelect
@@ -220,6 +246,11 @@ export function FeeInfoTab({
                   {item.name}
                 </SelectItem>
               ))}
+              <MasterFallbackSelectItem
+                value={watch('managementFee.taxType')}
+                masters={masterData?.all?.taxTypes ?? []}
+                legacyMap={LEGACY_FEE_CODE_MAP.tax}
+              />
             </ViewModeSelect>
 
             <ViewModeSelect
@@ -234,6 +265,11 @@ export function FeeInfoTab({
                   {item.name}
                 </SelectItem>
               ))}
+              <MasterFallbackSelectItem
+                value={watch('managementFee.billingType')}
+                masters={masterData?.all?.billingTypes ?? []}
+                legacyMap={LEGACY_FEE_CODE_MAP.billing}
+              />
             </ViewModeSelect>
 
             <ViewModeField
@@ -296,6 +332,11 @@ export function FeeInfoTab({
                   {item.name}
                 </SelectItem>
               ))}
+              {/* 送付方法（旧 shiharai）は旧コードの意味が不明なため legacyMap 無し（#177 と同方針） */}
+              <MasterFallbackSelectItem
+                value={watch('managementFee.paymentMethod')}
+                masters={masterData?.all?.paymentMethods ?? []}
+              />
             </ViewModeSelect>
           </div>
         )}

--- a/src/components/plot-form/ViewModeField.tsx
+++ b/src/components/plot-form/ViewModeField.tsx
@@ -2,8 +2,9 @@
 
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { UseFormRegisterReturn } from 'react-hook-form';
+import type { MasterItem } from '@/lib/api';
 
 interface ViewModeFieldProps {
   label: string;
@@ -101,6 +102,57 @@ export function ViewModeSelect({
       )}
     </div>
   );
+}
+
+interface MasterFallbackSelectItemProps {
+  /** フォームの現在値（master code / 旧int文字列 / 名称） */
+  value: string | null | undefined;
+  /** 無効を含む全件マスタ（useMasters().allMasters / masterData.all） */
+  masters: ReadonlyArray<MasterItem>;
+  /** 旧int値 → master code の正規化マップ（料金系のみ。LEGACY_FEE_CODE_MAP） */
+  legacyMap?: Record<string, string>;
+  /** 選択肢 value の照合キー。relationship は名称を保存するため 'name' */
+  matchBy?: 'code' | 'name';
+}
+
+/**
+ * 既存値が active マスタの選択肢に無い場合の補完 SelectItem（#238）。
+ *
+ * 無効化済みマスタや未 remap の旧コードを参照する既存データを編集すると、
+ * Select のトリガーが空表示になり「見えない値を誤って選び直す」事故につながる。
+ * 現在値を表す SelectItem を1件だけ補完描画してこれを防ぐ。
+ * RHF が元値を保持するため、未操作なら保存値は変わらない（表示のみの補完）。
+ *
+ * ラベル: 無効マスタ → 「名称（無効）」 / 旧int値で解決 → 「名称（旧コード）」 /
+ * マスタに存在しない値 → 「値（既存値）」
+ */
+export function MasterFallbackSelectItem({
+  value,
+  masters,
+  legacyMap,
+  matchBy = 'code',
+}: MasterFallbackSelectItemProps) {
+  if (!value) return null;
+
+  // 旧int値はマスタ code へ正規化してから照合する（master-resolve と同じ規約）
+  const normalized = legacyMap?.[value] ?? value;
+  const match =
+    matchBy === 'name'
+      ? masters.find((m) => m.name === normalized)
+      : masters.find((m) => m.code === normalized || m.id.toString() === normalized);
+
+  // 現在値がそのまま active 選択肢に存在する場合のみ補完不要。
+  // 旧int値は active マスタへ解決できても選択肢の value(code) と一致しないため補完が要る。
+  const optionValue = match ? (matchBy === 'name' ? match.name : match.code) : null;
+  if (match?.isActive && optionValue === value) return null;
+
+  const label = !match
+    ? `${value}（既存値）`
+    : !match.isActive
+      ? `${match.name}（無効）`
+      : `${match.name}（旧コード）`;
+
+  return <SelectItem value={value}>{label}</SelectItem>;
 }
 
 interface ViewModeTextareaProps {

--- a/src/components/plot-form/index.tsx
+++ b/src/components/plot-form/index.tsx
@@ -34,6 +34,7 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     sectionNames,
     relationships,
     contractors,
+    allMasters,
     isLoading: isMasterLoading,
   } = useMasters();
 
@@ -45,6 +46,8 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     sectionNames,
     relationships,
     contractors,
+    // 無効を含む全件。既存値のフォールバック表示に使用（#238）
+    all: allMasters,
     isLoading: isMasterLoading,
   };
 
@@ -449,8 +452,8 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
           onConfirm={handleConfirmSubmit}
           title={isEditing ? '更新内容の確認' : '登録内容の確認'}
           description={isEditing ? '以下の項目が変更されます' : '以下の内容で登録します'}
-          sections={!isEditing ? buildPlotPreviewSections(previewData, { contractors }) : undefined}
-          diffSections={isEditing && initialFormData ? buildPlotDiffSections(initialFormData, previewData, { contractors }) : undefined}
+          sections={!isEditing ? buildPlotPreviewSections(previewData, { contractors: allMasters?.contractors ?? contractors }) : undefined}
+          diffSections={isEditing && initialFormData ? buildPlotDiffSections(initialFormData, previewData, { contractors: allMasters?.contractors ?? contractors }) : undefined}
           confirmText={isEditing ? '確認して更新' : '確認して登録'}
           isLoading={isLoading}
           size="xl"

--- a/src/components/plot-form/types.ts
+++ b/src/components/plot-form/types.ts
@@ -2,8 +2,10 @@ import { UseFormRegister, UseFormWatch, UseFormSetValue, Control, FieldErrors, U
 import type { PlotDetailResponse } from '@komine/types';
 import type { PlotFormData, FamilyContactFormData, BuriedPersonFormData, ConstructionInfoFormData } from '@/lib/validations/plot-form';
 import { MasterItem, TaxTypeMasterItem, SectionNameMasterItem } from '@/lib/api';
+import type { MasterLists } from '@/hooks/useMasters';
 
 export interface MasterData {
+  // フォーム選択肢用: active のみ（無効マスタは新規選択不可）
   calcTypes: MasterItem[];
   taxTypes: TaxTypeMasterItem[];
   billingTypes: MasterItem[];
@@ -11,6 +13,8 @@ export interface MasterData {
   sectionNames: SectionNameMasterItem[];
   relationships: MasterItem[];
   contractors: MasterItem[];
+  /** 名称解決・無効値フォールバック用: 無効を含む全件（#238） */
+  all?: MasterLists;
   isLoading: boolean;
 }
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -19,6 +19,7 @@ export {
 // マスタフック
 export {
   useMasters,
+  type MasterLists,
   useMasterData,
   useCemeteryTypes,
   usePaymentMethods,

--- a/src/hooks/useMasters.ts
+++ b/src/hooks/useMasters.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   getAllMasters,
   getCemeteryTypes,
@@ -17,6 +17,22 @@ import {
   SectionNameMasterItem,
   AllMastersData,
 } from '@/lib/api';
+
+// マスタ一覧のグループ型（useMasters の返却単位）
+export interface MasterLists {
+  cemeteryTypes: MasterItem[];
+  paymentMethods: MasterItem[];
+  taxTypes: TaxTypeMasterItem[];
+  calcTypes: MasterItem[];
+  billingTypes: MasterItem[];
+  recipientTypes: MasterItem[];
+  constructionTypes: MasterItem[];
+  sectionNames: SectionNameMasterItem[];
+  relationships: MasterItem[];
+  contractors: MasterItem[];
+  directions: MasterItem[];
+  positions: MasterItem[];
+}
 
 // マスタデータの状態型
 interface MastersState {
@@ -93,7 +109,9 @@ export function useMasters(options?: { skipCache?: boolean }) {
     fetchingRef.current = true;
     setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
-    const response = await getAllMasters();
+    // #238: 無効化済みマスタを参照する既存データの名称解決を維持するため全件取得する。
+    // フォーム選択肢用の active 絞り込みはクライアント側（下記アクセサ）で行う。
+    const response = await getAllMasters({ includeInactive: true });
 
     fetchingRef.current = false;
 
@@ -141,19 +159,40 @@ export function useMasters(options?: { skipCache?: boolean }) {
     });
   }, []);
 
-  // 便利なアクセサ
-  const cemeteryTypes = state.data?.cemeteryType || [];
-  const paymentMethods = state.data?.paymentMethod || [];
-  const taxTypes = state.data?.taxType || [];
-  const calcTypes = state.data?.calcType || [];
-  const billingTypes = state.data?.billingType || [];
-  const recipientTypes = state.data?.recipientType || [];
-  const constructionTypes = state.data?.constructionType || [];
-  const sectionNames = state.data?.sectionName || [];
-  const relationships = state.data?.relationship || [];
-  const contractors = state.data?.contractor || [];
-  const directions = state.data?.direction || [];
-  const positions = state.data?.position || [];
+  // 便利なアクセサ（#238: 2系統）
+  // - allMasters: 無効を含む全件。名称解決（resolveMasterName 等）用
+  // - 既存の個別アクセサ: active のみ。フォーム選択肢用（無効マスタは新規選択不可）
+  const { allMasters, activeMasters } = useMemo(() => {
+    const all: MasterLists = {
+      cemeteryTypes: state.data?.cemeteryType || [],
+      paymentMethods: state.data?.paymentMethod || [],
+      taxTypes: state.data?.taxType || [],
+      calcTypes: state.data?.calcType || [],
+      billingTypes: state.data?.billingType || [],
+      recipientTypes: state.data?.recipientType || [],
+      constructionTypes: state.data?.constructionType || [],
+      sectionNames: state.data?.sectionName || [],
+      relationships: state.data?.relationship || [],
+      contractors: state.data?.contractor || [],
+      directions: state.data?.direction || [],
+      positions: state.data?.position || [],
+    };
+    const active: MasterLists = {
+      cemeteryTypes: all.cemeteryTypes.filter((m) => m.isActive),
+      paymentMethods: all.paymentMethods.filter((m) => m.isActive),
+      taxTypes: all.taxTypes.filter((m) => m.isActive),
+      calcTypes: all.calcTypes.filter((m) => m.isActive),
+      billingTypes: all.billingTypes.filter((m) => m.isActive),
+      recipientTypes: all.recipientTypes.filter((m) => m.isActive),
+      constructionTypes: all.constructionTypes.filter((m) => m.isActive),
+      sectionNames: all.sectionNames.filter((m) => m.isActive),
+      relationships: all.relationships.filter((m) => m.isActive),
+      contractors: all.contractors.filter((m) => m.isActive),
+      directions: all.directions.filter((m) => m.isActive),
+      positions: all.positions.filter((m) => m.isActive),
+    };
+    return { allMasters: all, activeMasters: active };
+  }, [state.data]);
 
   return {
     // 状態
@@ -162,19 +201,22 @@ export function useMasters(options?: { skipCache?: boolean }) {
     error: state.error,
     lastFetched: state.lastFetched,
 
-    // 個別マスタデータ
-    cemeteryTypes,
-    paymentMethods,
-    taxTypes,
-    calcTypes,
-    billingTypes,
-    recipientTypes,
-    constructionTypes,
-    sectionNames,
-    relationships,
-    contractors,
-    directions,
-    positions,
+    // 個別マスタデータ（フォーム選択肢用: active のみ）
+    cemeteryTypes: activeMasters.cemeteryTypes,
+    paymentMethods: activeMasters.paymentMethods,
+    taxTypes: activeMasters.taxTypes,
+    calcTypes: activeMasters.calcTypes,
+    billingTypes: activeMasters.billingTypes,
+    recipientTypes: activeMasters.recipientTypes,
+    constructionTypes: activeMasters.constructionTypes,
+    sectionNames: activeMasters.sectionNames,
+    relationships: activeMasters.relationships,
+    contractors: activeMasters.contractors,
+    directions: activeMasters.directions,
+    positions: activeMasters.positions,
+
+    // 名称解決用: 無効化済みを含む全件（#238）
+    allMasters,
 
     // アクション
     refresh,

--- a/src/lib/api/masters.ts
+++ b/src/lib/api/masters.ts
@@ -133,10 +133,22 @@ const mockMasterData: AllMastersData = {
   ],
 };
 
+// マスタ取得オプション
+export interface GetMastersOptions {
+  /**
+   * 無効（is_active=false）マスタも含めて取得する（#238）。
+   * 名称解決（無効化済みマスタを参照する既存データの表示維持）と
+   * マスタ管理画面（無効マスタの再有効化）で使用。既定は active のみ。
+   */
+  includeInactive?: boolean;
+}
+
 /**
  * 全マスタデータを一括取得
  */
-export async function getAllMasters(): Promise<ApiResponse<AllMastersData>> {
+export async function getAllMasters(
+  options?: GetMastersOptions,
+): Promise<ApiResponse<AllMastersData>> {
   if (shouldUseMockData()) {
     if (process.env.NODE_ENV === 'development') console.log('[API] Using mock data for getAllMasters');
     return {
@@ -145,7 +157,10 @@ export async function getAllMasters(): Promise<ApiResponse<AllMastersData>> {
     };
   }
 
-  const response = await apiGet<AllMastersData>('/masters/all');
+  const response = await apiGet<AllMastersData>(
+    '/masters/all',
+    options?.includeInactive ? { include_inactive: 'true' } : undefined,
+  );
   return response;
 }
 


### PR DESCRIPTION
## 概要

backend issue zaitsu82/komine-crm-backend#238 のフロント側縦串対応。backend 側（全マスタGETへの `?include_inactive=true` 追加）は backend PR zaitsu82/komine-crm-backend#258 でマージ済み。

マスタの論理無効化（`is_active=false`）は API で可能なのに無効マスタを取得する経路がフロントに無く、無効化した瞬間に参照中の全過去データの名称解決が「旧コード:X」に化け、編集フォームの該当 Select が空表示になる問題を解消する。

## 修正内容

### 取得層（修正方針2: 2系統分離）
- `lib/api/masters.ts`: `getAllMasters({ includeInactive })` を追加（backend `?include_inactive=true` に対応）
- `hooks/useMasters.ts`: 全件取得に切替え、2系統のアクセサを返す
  - **既存の個別アクセサ**（`calcTypes` 等・フォーム選択肢用）: active のみ — 従来挙動を維持し、無効マスタは新規入力で選べない
  - **`allMasters`**（名称解決用）: 無効を含む全件

### 名称解決（区画詳細）
- `plot-detail-view.tsx`: `resolveMasterName` / 業者名解決へ `allMasters` を渡す → マスタを無効化しても既存データの名称表示が維持される

### 編集フォーム（修正方針3: 無効値の補完描画）
- `MasterFallbackSelectItem` を新設（`plot-form/ViewModeField.tsx`）: 既存値が active 選択肢に無い場合のみ SelectItem を1件補完。RHF が元値を保持するため**未操作なら保存値は変わらない**（表示のみの補完）
  - 無効化済みマスタ →「名称**（無効）**」
  - 旧int値（legacyMap で解決）→「名称**（旧コード）**」
  - マスタに存在しない値 →「値**（既存値）**」
- 適用箇所:
  - `FeeInfoTab` の8セレクト（計算区分/税区分/請求区分/送付方法 × 使用料/管理料）— 従来フォールバック皆無で空表示になっていた
  - `ContactsTab` / `BurialInfoTab`（続柄・name照合）/ `ConstructionInfoTab`（業者・code照合）— 既存の「（既存値）」手書きフォールバックをヘルパに統一。無効化済み業者は raw code でなく名称で表示されるように

### マスタ管理画面（修正方針4: トグル追加）
- 一覧を `include_inactive` で全件表示（**従来は無効化するとマスタが一覧から消えて再有効化不能だった**）。無効行は減光表示
- 編集ダイアログに「有効」トグルを追加（無効バッジは表示されるのに無効化操作が UI に無い非対称を解消）。新規作成は常に有効のためトグル非表示
- backend #231 の削除409「先に無効化してください」への導線がこれで成立する

## テスト
- 新規: `master-fallback-select-item.test.tsx`（ラベル分岐8ケース）/ `use-masters-inactive.test.ts`（2系統アクセサ）/ `masters-management-inactive.test.tsx`（無効マスタ表示・トグル更新・新規時非表示）
- 全 **451 テスト pass**、`tsc --noEmit` clean、`npm run lint` clean

## 備考
- types 変更なし（クエリパラメータ追加のみでレスポンス型不変）
- モックデータは全件 active のため、モックモードの表示は不変
- 区画詳細・フォームのマスタ取得が1リクエストのまま（全件取得+クライアント側 active 絞り込み）

Closes zaitsu82/komine-crm-backend#238

🤖 Generated with [Claude Code](https://claude.com/claude-code)