### PR TITLE
feat: サイドバー「業務の流れ」をミニステッパー化

### DIFF
--- a/src/__tests__/components/global-sidebar-workflow.test.tsx
+++ b/src/__tests__/components/global-sidebar-workflow.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * GlobalSidebar 業務の流れステッパーのテスト（#191 改善）
+ *
+ * - WORKFLOW_STEPS の各ステップがリンクとして描画される
+ * - 現在のページに対応するステップが aria-current="page" になる
+ * - 権限のないステップ（viewer の ゆうちょ連携）はリンクにならない
+ * - collapsed 時はステッパー自体を表示しない
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GlobalSidebar from '@/components/layout/GlobalSidebar';
+import { WORKFLOW_STEPS } from '@/config/navigation';
+
+let mockPathname = '/plots';
+let mockRole = 'admin';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+jest.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'staff-1',
+      email: 'test@example.com',
+      name: 'テスト太郎',
+      role: mockRole,
+    },
+  }),
+}));
+
+function renderSidebar(props: Partial<React.ComponentProps<typeof GlobalSidebar>> = {}) {
+  return render(
+    <GlobalSidebar collapsed={false} onToggleCollapse={() => {}} {...props} />
+  );
+}
+
+describe('GlobalSidebar 業務の流れステッパー', () => {
+  beforeEach(() => {
+    mockPathname = '/plots';
+    mockRole = 'admin';
+  });
+
+  it('WORKFLOW_STEPS が業務フロー4画面を順番どおり指す', () => {
+    expect(WORKFLOW_STEPS.map(s => s.path)).toEqual([
+      '/plots',
+      '/plot-availability',
+      '/yucho',
+      '/collective-burials',
+    ]);
+  });
+
+  it('admin では全ステップがリンクとして描画される', () => {
+    renderSidebar();
+    for (const [index, step] of WORKFLOW_STEPS.entries()) {
+      const link = screen.getByRole('link', {
+        name: new RegExp(`業務の流れ ${index + 1}\\. ${step.label}`),
+      });
+      expect(link).toHaveAttribute('href', step.path);
+    }
+  });
+
+  it('現在のページのステップに aria-current="page" が付く', () => {
+    mockPathname = '/plot-availability';
+    renderSidebar();
+    const active = screen.getByRole('link', { name: /業務の流れ 2\. 区画残数管理/ });
+    expect(active).toHaveAttribute('aria-current', 'page');
+    const inactive = screen.getByRole('link', { name: /業務の流れ 1\. 台帳問い合わせ/ });
+    expect(inactive).not.toHaveAttribute('aria-current');
+  });
+
+  it('viewer では権限のない ゆうちょ連携 がリンクにならない（ラベルは表示される）', () => {
+    mockRole = 'viewer';
+    renderSidebar();
+    expect(
+      screen.queryByRole('link', { name: /業務の流れ 3\. ゆうちょ連携/ })
+    ).not.toBeInTheDocument();
+    // ステッパー領域には非リンクのラベルとして残る
+    const stepper = screen.getByRole('list', { name: '業務の流れ' });
+    expect(stepper).toHaveTextContent('ゆうちょ連携');
+  });
+
+  it('collapsed 時はステッパーを表示しない', () => {
+    renderSidebar({ collapsed: true });
+    expect(screen.queryByText('業務の流れ')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/layout/GlobalSidebar.tsx
+++ b/src/components/layout/GlobalSidebar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/contexts/auth-context';
-import { NAV_GROUPS, NavItem, NavGroup } from '@/config/navigation';
+import { NAV_GROUPS, WORKFLOW_STEPS, NavItem, NavGroup } from '@/config/navigation';
 
 function MenuIcon({ icon, className = 'w-5 h-5' }: { icon: NavItem['icon']; className?: string }) {
   const props = { className, fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', 'aria-hidden': true as const };
@@ -132,7 +132,7 @@ export default function GlobalSidebar({
                       {group.label}
                     </p>
                     {group.description && (
-                      <p className="text-[10px] text-hai/80 mt-0.5 normal-case tracking-normal leading-snug">
+                      <p className="text-[10px] text-hai-light mt-0.5 normal-case tracking-normal leading-snug">
                         {group.description}
                       </p>
                     )}
@@ -179,19 +179,56 @@ export default function GlobalSidebar({
           </nav>
         </div>
 
-        {/* 業務フローのヘルプ — 主要機能の関係を新規利用者にも伝える（#191） */}
+        {/* 業務フローのヘルプ — 主要機能の流れをステッパーで示す（#191）。説明はツールチップに退避 */}
         {!collapsed && (
           <div className="border-t border-gin p-4">
-            <p className="text-xs font-semibold text-hai uppercase tracking-wider mb-2">業務の流れ</p>
-            <ol className="space-y-1.5 text-[11px] text-hai leading-snug">
-              <li><span className="text-matsu font-medium">① 台帳問い合わせ</span>：区画ごとに契約・顧客・請求・入金を管理（基点）</li>
-              <li><span className="text-matsu font-medium">② 区画残数管理</span>：空き状況・使用率を把握</li>
-              <li><span className="text-matsu font-medium">③ ゆうちょ連携</span>：管理料の口座振替を出力</li>
-              <li><span className="text-matsu font-medium">④ 合祀管理</span>：契約期間の満了後に合祀・請求</li>
+            <p className="text-xs font-semibold text-hai uppercase tracking-wider mb-3">業務の流れ</p>
+            <ol aria-label="業務の流れ">
+              {WORKFLOW_STEPS.map((step, index) => {
+                const active = isActive(step.path);
+                const accessible = user ? step.requiredRoles.includes(user.role) : false;
+                const stepLabel = `${index + 1}. ${step.label}`;
+                const tooltip = step.description ? `${step.label} — ${step.description}` : step.label;
+
+                return (
+                  <li key={step.path} className="relative pl-7 pb-2.5 last:pb-0">
+                    {/* 接続線 */}
+                    {index < WORKFLOW_STEPS.length - 1 && (
+                      <span className="absolute left-[8px] top-5 bottom-0 w-px bg-gin" aria-hidden="true" />
+                    )}
+                    {/* ステップ番号 */}
+                    <span
+                      className={`absolute left-0 top-0.5 w-[17px] h-[17px] rounded-full flex items-center justify-center text-[10px] font-semibold tabular-nums transition-colors ${active
+                        ? 'bg-matsu text-white shadow-matsu'
+                        : 'bg-white text-hai border border-gin'
+                        }`}
+                      aria-hidden="true"
+                    >
+                      {index + 1}
+                    </span>
+                    {accessible ? (
+                      <Link
+                        href={step.path}
+                        onClick={onMobileClose}
+                        className={`block text-xs leading-[1.4] rounded transition-colors ${focusRing} ${active
+                          ? 'text-matsu font-medium'
+                          : 'text-hai hover:text-matsu'
+                          }`}
+                        title={tooltip}
+                        aria-label={`業務の流れ ${stepLabel}（${step.description ?? ''}）`}
+                        aria-current={active ? 'page' : undefined}
+                      >
+                        {step.label}
+                      </Link>
+                    ) : (
+                      <span className="block text-xs leading-[1.4] text-hai-light" title={tooltip}>
+                        {step.label}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
             </ol>
-            <p className="text-[10px] text-hai/80 mt-2 leading-snug">
-              合祀一覧の区画番号から台帳詳細へ移動できます。
-            </p>
           </div>
         )}
       </div>

--- a/src/components/layout/GlobalSidebar.tsx
+++ b/src/components/layout/GlobalSidebar.tsx
@@ -218,10 +218,13 @@ export default function GlobalSidebar({
                         aria-label={`業務の流れ ${stepLabel}（${step.description ?? ''}）`}
                         aria-current={active ? 'page' : undefined}
                       >
+                        {/* sr-only の番号で textContent をナビ項目と区別（E2E の exact テキスト照合との衝突回避） */}
+                        <span className="sr-only">{index + 1}. </span>
                         {step.label}
                       </Link>
                     ) : (
                       <span className="block text-xs leading-[1.4] text-hai-light" title={tooltip}>
+                        <span className="sr-only">{index + 1}. </span>
                         {step.label}
                       </span>
                     )}

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -39,3 +39,18 @@ export const NAV_GROUPS: NavGroup[] = [
 ];
 
 export const NAV_ITEMS: NavItem[] = NAV_GROUPS.flatMap(g => g.items);
+
+/**
+ * サイドバー下部「業務の流れ」ステッパーの表示順（#191）。
+ * label/description/requiredRoles は NAV_ITEMS から path で引き当て、定義を一元化する。
+ */
+export const WORKFLOW_STEP_PATHS: string[] = [
+  '/plots',
+  '/plot-availability',
+  '/yucho',
+  '/collective-burials',
+];
+
+export const WORKFLOW_STEPS: NavItem[] = WORKFLOW_STEP_PATHS.map(path =>
+  NAV_ITEMS.find(item => item.path === path)
+).filter((item): item is NavItem => item !== undefined);

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -71,8 +71,8 @@ test.describe('サイドバーナビゲーション', () => {
     const sidebar = page.locator('.w-64');
     await expect(sidebar.getByText('台帳問い合わせ', { exact: true })).toBeVisible({ timeout: 20_000 });
 
-    // 合祀管理をクリック（Link要素）
-    const menuLink = sidebar.getByRole('link', { name: '合祀管理' });
+    // 合祀管理をクリック（Link要素）。exact 指定で「業務の流れ」ステッパー側のリンクと区別する
+    const menuLink = sidebar.getByRole('link', { name: '合祀管理', exact: true });
     await menuLink.click();
     await page.waitForTimeout(500);
 


### PR DESCRIPTION
## 概要

#191 で導入したサイドバー下部の「業務の流れ」ヘルプ（静的な箇条書き＋注釈）を、クリック可能な縦型ミニステッパーに改善する。

Refs #191

## Before / After

| Before | After |
|---|---|
| ①〜④の説明文をフル表示した静的リスト＋脚注（テキスト密度が高い） | 番号サークル＋接続線の縦型ステッパー。ラベルのみ表示し、説明はホバーツールチップへ退避 |

## 変更内容

- **`src/config/navigation.ts`**: `WORKFLOW_STEP_PATHS` / `WORKFLOW_STEPS` を追加。ステップの label / description / requiredRoles は `NAV_ITEMS` から path で引き当てて一元化（ナビ定義と二重管理しない）
- **`src/components/layout/GlobalSidebar.tsx`**:
  - 各ステップを実画面へのリンク化（モバイルドロワーでは遷移時にクローズ）
  - 現在ページのステップを matsu 色サークル＋ラベルでハイライト、`aria-current="page"` 付与
  - 権限のないステップ（例: viewer のゆうちょ連携）は非リンクの淡色表示（業務フロー全体は見せたまま）
  - 旧実装の脚注「合祀一覧の区画番号から〜」は削除（ステップのツールチップで代替）
  - **既存バグ修正**: `text-hai/80`・`text-hai/60` は `hai` トークンが `var(--color-hai)` 直値で alpha modifier 非対応のため**サイレントに効かず継承色で描画されていた** → `text-hai-light` に置換（グループ説明文も同修正）
- **テスト追加**: `global-sidebar-workflow.test.tsx`（ステップ順序・リンク描画・aria-current・権限フィルタ・collapsed 非表示の5件）

## 動作確認

- `npx tsc --noEmit` clean / `npm run lint` clean / Jest **443件 pass**（438 + 新規5）
- モックモード（`NEXT_PUBLIC_USE_MOCK_DATA=true`）で Playwright による目視確認:
  - admin: `/plots` でステップ① ハイライト → ステッパーのリンククリックで `/plot-availability` に遷移しステップ② へハイライト移動
  - viewer: ステップ③ ゆうちょ連携が非リンク・淡色になることを確認（`a[aria-label*="ゆうちょ連携"]` が 0 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)