### PR TITLE
fix: date-only整形を本番APIのdatetime形状(@db.Date由来)にも適用

### DIFF
--- a/src/__tests__/lib/format-tz.test.ts
+++ b/src/__tests__/lib/format-tz.test.ts
@@ -1,8 +1,10 @@
 /**
- * formatDate / formatYearMonth の TZ 非依存テスト（#218）
+ * formatDate / formatYearMonth の TZ 非依存テスト（#218 / #250）
  *
- * backend は date-only 値を 'YYYY-MM-DD' で返す。
- * `new Date('YYYY-MM-DD')` は UTC 00:00 としてパースされるため、
+ * backend は date-only 値（@db.Date）を返すが、シリアライズ形状は 2 通りある:
+ *  - 手書き / 旧 backend: 'YYYY-MM-DD'
+ *  - 実 API（Prisma 生 Date → res.json → toISOString）: 'YYYY-MM-DDT00:00:00.000Z'
+ * いずれも `new Date(value)` は UTC 00:00 としてパースされるため、
  * ローカル getter（getFullYear/getMonth/getDate）依存の整形は
  * 負オフセット TZ（米国等）で前日表示になる。
  *
@@ -54,15 +56,63 @@ describe('formatDate の date-only 整形 (#218)', () => {
       spyDate.mockRestore();
     }
   });
+
+  // #250: 実 API は @db.Date を 'YYYY-MM-DDT00:00:00.000Z' で返す。
+  // これも date-only として整形し、ローカル getter を経由しないことを保証する。
+  it('実 API の @db.Date 形状（UTC 深夜 datetime）を date-only として整形する', () => {
+    expect(formatDate('2024-03-15T00:00:00.000Z')).toBe('2024/03/15');
+    expect(formatDate('2006-02-09T00:00:00.000Z')).toBe('2006/02/09');
+    expect(formatDate('2020-01-01T00:00:00.000Z')).toBe('2020/01/01');
+  });
+
+  it('@db.Date 形状入力ではローカル TZ getter を使わない（TZ 非依存の保証 #250）', () => {
+    const spyYear = jest.spyOn(Date.prototype, 'getFullYear');
+    const spyMonth = jest.spyOn(Date.prototype, 'getMonth');
+    const spyDate = jest.spyOn(Date.prototype, 'getDate');
+    try {
+      formatDate('2024-03-15T00:00:00.000Z');
+      formatYearMonth('2024-03-15T00:00:00.000Z');
+      expect(spyYear).not.toHaveBeenCalled();
+      expect(spyMonth).not.toHaveBeenCalled();
+      expect(spyDate).not.toHaveBeenCalled();
+    } finally {
+      spyYear.mockRestore();
+      spyMonth.mockRestore();
+      spyDate.mockRestore();
+    }
+  });
+
+  it('@db.Date 形状で実在しない日付は fallback', () => {
+    expect(formatDate('2024-02-31T00:00:00.000Z')).toBe('-');
+  });
+
+  // 時刻成分を持つ本物のタイムスタンプ（created_at 等）は date-only 扱いしない。
+  // 厳密な T00:00:00.000Z 以外（ミリ秒なし・時刻あり）はローカル整形にフォールバック。
+  it('時刻成分のあるタイムスタンプは従来どおりローカルTZ整形（厳密形状のみ date-only）', () => {
+    const spyDate = jest.spyOn(Date.prototype, 'getDate');
+    try {
+      formatDate('2024-03-15T08:30:00.000Z');
+      formatDate('2024-03-15T00:00:00Z'); // ミリ秒なしは @db.Date 形状ではない
+      expect(spyDate).toHaveBeenCalled();
+    } finally {
+      spyDate.mockRestore();
+    }
+  });
 });
 
-describe('formatYearMonth の date-only 整形 (#218)', () => {
+describe('formatYearMonth の date-only 整形 (#218 / #250)', () => {
   it('date-only 文字列の年月を正しく整形する', () => {
     expect(formatYearMonth('2024-03-01')).toBe('2024/03');
     expect(formatYearMonth('2020-01-01')).toBe('2020/01');
   });
 
+  it('実 API の @db.Date 形状（UTC 深夜 datetime）の年月を正しく整形する', () => {
+    expect(formatYearMonth('2024-03-01T00:00:00.000Z')).toBe('2024/03');
+    expect(formatYearMonth('2020-01-01T00:00:00.000Z')).toBe('2020/01');
+  });
+
   it('date-only 形式で実在しない日付は fallback', () => {
     expect(formatYearMonth('2024-02-31')).toBe('-');
+    expect(formatYearMonth('2024-02-31T00:00:00.000Z')).toBe('-');
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -121,13 +121,30 @@ export function formatBillingMonth(
 const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 /**
- * date-only 文字列（YYYY-MM-DD）から年月日を TZ 非依存で抽出する。
- * `new Date('YYYY-MM-DD')` は UTC 00:00 としてパースされるため、
- * ローカル getter で組み立てると負オフセット TZ では前日になる（#218）。
+ * Prisma `@db.Date` のシリアライズ形状（UTC 深夜 0 時ちょうどの datetime）の判定。
+ * backend は @db.Date を生 Prisma Date で返し、res.json() → toISOString() で
+ * `2024-03-15T00:00:00.000Z`（時刻成分が全て 0 の UTC datetime）になる（#250）。
+ * これは実質 date-only なので date-only として UTC ベースで整形する。
+ * 時刻成分を持つ本物のタイムスタンプ（created_at 等）は厳密形状不一致で対象外。
+ */
+const DB_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})T00:00:00\.000Z$/;
+
+/** date-only として扱う形状（手書き YYYY-MM-DD もしくは @db.Date 由来の UTC 深夜 datetime）か */
+function isDateOnlyShape(value: string): boolean {
+  return DATE_ONLY_RE.test(value) || DB_DATE_RE.test(value);
+}
+
+/**
+ * date-only 表現から年月日を TZ 非依存で抽出する。
+ * 対象は以下の 2 形状:
+ *  - 'YYYY-MM-DD'（手書き / 旧 backend）
+ *  - 'YYYY-MM-DDT00:00:00.000Z'（Prisma @db.Date の実 API シリアライズ形状, #250）
+ * いずれも `new Date(value)` は UTC 00:00 としてパースされるため、
+ * ローカル getter で組み立てると負オフセット TZ では前日になる（#218 / #250）。
  * 実在しない日付（2024-02-31 等）は null。
  */
 function parseDateOnly(value: string): { y: number; m: number; d: number } | null {
-  const match = value.match(DATE_ONLY_RE);
+  const match = value.match(DATE_ONLY_RE) ?? value.match(DB_DATE_RE);
   if (!match) return null;
   const y = Number(match[1]);
   const m = Number(match[2]);
@@ -143,12 +160,13 @@ function parseDateOnly(value: string): { y: number; m: number; d: number } | nul
 /**
  * 日付を「YYYY/MM/DD」（西暦4桁・ゼロ埋め）に統一する。
  * 2桁年や非ゼロ埋めの表記揺れ（#167）を解消する共通フォーマッタ。
- * date-only 文字列は Date を経由せず整形し、TZ による前日ズレを防ぐ（#218）。
+ * date-only 文字列・@db.Date 由来の UTC 深夜 datetime は Date を経由せず整形し、
+ * TZ による前日ズレを防ぐ（#218 / #250）。
  * null / 空 / 不正日付は fallback（既定 "-"）。
  */
 export function formatDate(value: string | Date | null | undefined, fallback: string = DASH): string {
   if (value === null || value === undefined || value === '') return fallback;
-  if (typeof value === 'string' && DATE_ONLY_RE.test(value)) {
+  if (typeof value === 'string' && isDateOnlyShape(value)) {
     const dateOnly = parseDateOnly(value);
     // date-only 形式で実在しない日付（2024-02-31 等）は legacy パーサの
     // 繰り上がり（→ 2024/03/02）に流さず fallback
@@ -167,11 +185,12 @@ export function formatDate(value: string | Date | null | undefined, fallback: st
 /**
  * 年月を「YYYY/MM」（西暦4桁・ゼロ埋め）に統一する。
  * 一覧の契約日など、日を省きたい狭い列向け（2桁年 "06/2" を廃止）。
- * date-only 文字列は Date を経由せず整形し、TZ による前日ズレを防ぐ（#218）。
+ * date-only 文字列・@db.Date 由来の UTC 深夜 datetime は Date を経由せず整形し、
+ * TZ による前日ズレを防ぐ（#218 / #250）。
  */
 export function formatYearMonth(value: string | Date | null | undefined, fallback: string = DASH): string {
   if (value === null || value === undefined || value === '') return fallback;
-  if (typeof value === 'string' && DATE_ONLY_RE.test(value)) {
+  if (typeof value === 'string' && isDateOnlyShape(value)) {
     const dateOnly = parseDateOnly(value);
     if (dateOnly === null) return fallback;
     return `${dateOnly.y}/${String(dateOnly.m).padStart(2, '0')}`;


### PR DESCRIPTION
## 問題

`#218` で導入した date-only 整形（`formatDate` / `formatYearMonth`）が本番 API データで発火せず実質 no-op になっていた。

- `src/lib/format.ts`
- `DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/` にマッチした時だけ Date 非経由で整形する設計だった。
- しかし backend は `@db.Date` を生 Prisma `Date` で返し、`res.json()` → `toISOString()` で `2024-03-15T00:00:00.000Z`（datetime）になる。
- これは `DATE_ONLY_RE` 非マッチのため、従来の `new Date(value)` + ローカル getter にフォールバック。
- 結果、負オフセット TZ（米国等）で**契約日・生年月日・命日・埋葬日**等が前日表示になる「@db.Date 由来のローカル TZ 前日ずれ」がライブデータで未解消だった。
- `format-tz.test` は手書き `'YYYY-MM-DD'` を渡していたため通過してしまい、実 API 形状を未検証だった。

## 原因

backend(@db.Date) → JSON シリアライズ形状（`YYYY-MM-DDT00:00:00.000Z`）を date-only として認識していなかった。

## 修正内容

- `@db.Date` のシリアライズ形状（UTC 深夜 0 時ちょうどの datetime, **厳密に** `T00:00:00.000Z`）を判定する `DB_DATE_RE` と `isDateOnlyShape()` を追加。
- `parseDateOnly` を `DATE_ONLY_RE` と `DB_DATE_RE` の両形状に対応させ、UTC ベースで年月日を抽出（TZ 非依存）。
- `formatDate` / `formatYearMonth` の date-only 判定を `isDateOnlyShape()` に置換。
- 時刻成分を持つ本物のタイムスタンプ（`created_at` 等、ミリ秒なし・時刻ありを含む）は厳密形状不一致で**従来どおりローカル整形を維持**。`formatDateTime` のような時刻表示関数は変更なし。
- `format-tz.test` に実 API datetime 形状の入力ケース（整形結果・ローカル getter 不使用の保証・不正日付 fallback・時刻ありはローカル整形維持）を追加してリグレッション固定。

## テスト結果

- `npm test`: 33 suites / **456 passed**
- `npm run lint`: エラーなし

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)