### PR TITLE
fix: 直 fetch の blob/FormData 経路にトークンリフレッシュを共通化 (#256)

### DIFF
--- a/src/__tests__/lib/api/fetch-with-token-refresh.test.ts
+++ b/src/__tests__/lib/api/fetch-with-token-refresh.test.ts
@@ -1,0 +1,107 @@
+/**
+ * fetchWithTokenRefresh のテスト（#256）
+ *
+ * blob 取得等で apiRequest を使えない直 fetch にも、共有クライアントと同じ
+ * トークンリフレッシュ（期限間近の先行リフレッシュ・401 時の一度きり再試行）を
+ * 提供することを固定する。getDocumentFile / uploadDocumentFile / exportYuchoCsv
+ * が利用する。
+ */
+
+import {
+  fetchWithTokenRefresh,
+  setTokenRefreshCallback,
+  setTokenExpiresAt,
+  clearAllTokens,
+} from '@/lib/api/client';
+
+// jsdom には Response が無いため最小限のスタブを使う
+const mockResponse = (status: number): Response =>
+  ({ status, ok: status >= 200 && status < 300 }) as Response;
+
+describe('fetchWithTokenRefresh (#256)', () => {
+  const originalFetch = global.fetch;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    clearAllTokens();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    // 他テストへ漏れないようコールバックを無効化
+    setTokenRefreshCallback(() => Promise.resolve(false));
+    clearAllTokens();
+  });
+
+  it('200 応答ならリフレッシュせず 1 回だけ fetch する', async () => {
+    const onRefresh = jest.fn().mockResolvedValue(true);
+    setTokenRefreshCallback(onRefresh);
+    fetchMock.mockResolvedValue(mockResponse(200));
+
+    const res = await fetchWithTokenRefresh('http://api/test', { method: 'GET' });
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onRefresh).not.toHaveBeenCalled();
+    // HttpOnly Cookie 送信のため credentials: 'include' が必ず付くこと
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://api/test',
+      expect.objectContaining({ credentials: 'include', method: 'GET' })
+    );
+  });
+
+  it('401 応答なら一度リフレッシュして再 fetch する', async () => {
+    const onRefresh = jest.fn().mockResolvedValue(true);
+    setTokenRefreshCallback(onRefresh);
+    fetchMock
+      .mockResolvedValueOnce(mockResponse(401))
+      .mockResolvedValueOnce(mockResponse(200));
+
+    const res = await fetchWithTokenRefresh('http://api/test');
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.status).toBe(200);
+  });
+
+  it('リフレッシュ失敗時は再試行せず 401 をそのまま返す', async () => {
+    const onRefresh = jest.fn().mockResolvedValue(false);
+    setTokenRefreshCallback(onRefresh);
+    fetchMock.mockResolvedValue(mockResponse(401));
+
+    const res = await fetchWithTokenRefresh('http://api/test');
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(401);
+  });
+
+  it('再試行後も 401 なら無限ループせずそのまま返す', async () => {
+    const onRefresh = jest.fn().mockResolvedValue(true);
+    setTokenRefreshCallback(onRefresh);
+    fetchMock.mockResolvedValue(mockResponse(401));
+
+    const res = await fetchWithTokenRefresh('http://api/test');
+
+    // リフレッシュは一度きり・fetch は最大2回
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.status).toBe(401);
+  });
+
+  it('トークンが期限切れ間近なら fetch 前に先行リフレッシュする', async () => {
+    const onRefresh = jest.fn().mockResolvedValue(true);
+    setTokenRefreshCallback(onRefresh);
+    // 有効期限を「今から1分後」に設定（5分閾値の期限間近に該当）
+    setTokenExpiresAt(Math.floor(Date.now() / 1000) + 60);
+    fetchMock.mockResolvedValue(mockResponse(200));
+
+    const res = await fetchWithTokenRefresh('http://api/test');
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -135,6 +135,45 @@ async function refreshTokenIfNeeded(): Promise<boolean> {
   return refreshPromise;
 }
 
+/**
+ * 直 fetch（blob 取得等で apiRequest を使えない呼び出し）にトークンリフレッシュを
+ * 共有するラッパー（#256）。apiRequest と同じく、
+ *  1. リクエスト前: トークンが期限切れ間近なら先行リフレッシュ
+ *  2. 401 受領時: 一度だけリフレッシュして再 fetch（無限ループ防止）
+ * を行う。レスポンスの解釈（blob/json）は呼び出し側の責務。
+ *
+ * 新規の API 呼び出しは原則 apiRequest/apiGet 経由とし、blob 等で直 fetch が
+ * 必要な場合のみこれを使うこと（横断機能のバイパスを作らない）。
+ */
+export async function fetchWithTokenRefresh(
+  url: string,
+  init: RequestInit = {}
+): Promise<Response> {
+  if (isTokenExpiringSoon()) {
+    debugLog('Token is expiring soon, attempting refresh (raw fetch)');
+    await refreshTokenIfNeeded();
+  }
+
+  const doFetch = () =>
+    fetch(url, {
+      credentials: 'include', // HttpOnly Cookie を送信するために必須
+      ...init,
+    });
+
+  const response = await doFetch();
+
+  if (response.status === 401) {
+    debugLog('Received 401 (raw fetch), attempting token refresh');
+    const refreshed = await refreshTokenIfNeeded();
+    if (refreshed) {
+      debugLog('Token refreshed, retrying raw fetch');
+      return doFetch();
+    }
+  }
+
+  return response;
+}
+
 // デバッグログ
 function debugLog(message: string, data?: unknown): void {
   if (API_CONFIG.debug) {

--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -4,7 +4,15 @@
 
 import { DOCUMENT_TEMPLATE_TYPES } from '@komine/types/api';
 import { ApiResponse } from './types';
-import { apiGet, apiPost, apiPut, apiDelete, shouldUseMockData, API_CONFIG } from './client';
+import {
+  apiGet,
+  apiPost,
+  apiPut,
+  apiDelete,
+  shouldUseMockData,
+  API_CONFIG,
+  fetchWithTokenRefresh,
+} from './client';
 
 // =============================================================================
 // 型定義
@@ -863,10 +871,10 @@ export async function uploadDocumentFile(
   const url = `${API_CONFIG.baseUrl}/documents/${id}/upload`;
 
   try {
-    const response = await fetch(url, {
+    // FormData のため apiPost は使えないが、トークンリフレッシュは共有する（#256）
+    const response = await fetchWithTokenRefresh(url, {
       method: 'POST',
       body: formData,
-      credentials: 'include',
     });
 
     const data = await response.json();
@@ -918,6 +926,10 @@ export interface DocumentFileResponse {
  * backend `GET /documents/:id/file` は認証付きでファイル実体を返す（res.download）。
  * Authorization は HttpOnly Cookie で行うため `credentials: 'include'` で取得し、
  * 取得した Blob をそのままダウンロードに使う（再生成PDFとは別経路）。
+ *
+ * blob 応答のため apiGet は使えないが、トークンリフレッシュ（期限間近の先行
+ * リフレッシュ・401 時の一度きり再試行）は fetchWithTokenRefresh で
+ * 共有クライアントと同じ挙動にする（#256）。
  */
 export async function getDocumentFile(
   id: string
@@ -929,9 +941,8 @@ export async function getDocumentFile(
   const url = `${API_CONFIG.baseUrl}/documents/${id}/file`;
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithTokenRefresh(url, {
       method: 'GET',
-      credentials: 'include',
     });
 
     if (!response.ok) {

--- a/src/lib/api/yucho.ts
+++ b/src/lib/api/yucho.ts
@@ -5,7 +5,7 @@
  * 管理料・合祀料金の請求対象データの取得とCSV出力を提供する。
  */
 
-import { apiGet, API_CONFIG } from './client';
+import { apiGet, API_CONFIG, fetchWithTokenRefresh } from './client';
 import { ApiResponse } from './types';
 
 // ============================================================
@@ -103,6 +103,7 @@ export async function getYuchoBilling(
  * GET /api/v1/yucho/export → text/csv (全銀協固定長)
  *
  * apiRequest() は JSON 前提なので、CSV は直接 fetch でダウンロードする。
+ * トークンリフレッシュは fetchWithTokenRefresh で共有クライアントと同じ挙動にする（#256）。
  */
 export async function exportYuchoCsv(params: YuchoExportParams): Promise<Blob> {
   const searchParams = new URLSearchParams();
@@ -112,10 +113,10 @@ export async function exportYuchoCsv(params: YuchoExportParams): Promise<Blob> {
     }
   });
 
-  const response = await fetch(`${API_CONFIG.baseUrl}/yucho/export?${searchParams.toString()}`, {
-    method: 'GET',
-    credentials: 'include',
-  });
+  const response = await fetchWithTokenRefresh(
+    `${API_CONFIG.baseUrl}/yucho/export?${searchParams.toString()}`,
+    { method: 'GET' }
+  );
 
   if (!response.ok) {
     let message = `CSV出力に失敗しました (HTTP ${response.status})`;


### PR DESCRIPTION
## 概要

PR#254 で新設した `getDocumentFile` が共有 `apiRequest` を迂回して素の `fetch` を呼んでいたため、共有クライアントが持つ (1) `isTokenExpiringSoon()` の先行リフレッシュ (2) 401 受領時の `refreshTokenIfNeeded()` → 再試行 のどちらも効かず、書類詳細画面を開いたまま約55分以上経過してから「ファイルをダウンロード」すると HTTP_401 で失敗していた。

Closes #256

## 変更内容

- `src/lib/api/client.ts`: **`fetchWithTokenRefresh`** を新設
  - fetch 前: 期限間近なら先行リフレッシュ
  - 401 受領時: 一度だけリフレッシュ → 再 fetch（無限ループなし）
  - `credentials: 'include'` 既定。レスポンス解釈（blob/json）は呼び出し側の責務
- 直 fetch バイパスを総ざらいして置換（同一クラスの横展開）:
  - `documents.ts getDocumentFile`（本issue）
  - `documents.ts uploadDocumentFile`（FormData アップロード — 同じ55分問題あり）
  - `yucho.ts exportYuchoCsv`（CSV blob — 同上）
  - `auth.ts` の `/auth/refresh` 直 fetch はリフレッシュ自体のため**対象外**（ラップするとループ）

## テスト

- `fetch-with-token-refresh.test.ts` 新規5件: 200素通し / 401→リフレッシュ→再試行 / リフレッシュ失敗時は再試行なし / 再試行後401でもループしない / 期限間近の先行リフレッシュ
- `npm test` 全482件 pass / `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)