### PR TITLE
chore: TYPES_REF を 6cabaf4 へ bump（types#39 .max() 追加）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=9814403ca64187af1ff3b657b18c6031bd69c532
+ARG TYPES_REF=6cabaf4a878db97988dca80910b60613e13bae4c
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \


### PR DESCRIPTION
## 概要

@komine/types PR#39（zaitsu82/komine-types#38 — VarChar 超過で P2000 になるフィールドへの `.max()` 追加）のマージに伴う `TYPES_REF` bump。backend 側 PR: zaitsu82/komine-crm-backend#308

| | SHA |
|---|---|
| 旧 | `9814403ca64187af1ff3b657b18c6031bd69c532` |
| 新 | `6cabaf4a878db97988dca80910b60613e13bae4c`（types#39 squash merge） |

共有スキーマのバリデーション強化のみで frontend のコード変更は不要。受付番号/許可書番号（50文字）、料金種別（50文字）、担当者（100文字）の超過がフォーム送信時に弾かれるようになる（従来は backend で P2000 → フィールド特定不能の汎用400）。

> frontend Dockerfile は Scan gate が無く bump 漏れが潜伏しやすいため、backend と同時に対応（CLAUDE.md 運用ルール）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)