### PR TITLE
chore: TYPES_REF を a516e99 に bump（types#40 修正反映）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=6cabaf4a878db97988dca80910b60613e13bae4c
+ARG TYPES_REF=a516e99d096810ea8e783075ef6468533d3399d3
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \


### PR DESCRIPTION
## 概要

zaitsu82/komine-types#41（constructionInfoSchema の zod max を DB VarChar 長に整合、Closes types#40）のマージに伴う TYPES_REF bump。

- `6cabaf4` → `a516e99d096810ea8e783075ef6468533d3399d3`

ConstructionInfoTab の入力は共有 zod スキーマで検証されるため、この bump で client 側バリデーションにも DB VarChar 長との整合（constructionType≤50 / workItem1・2≤100）が反映される。

backend 側の同 bump: zaitsu82/komine-crm-backend#315

Refs zaitsu82/komine-types#40

🤖 Generated with [Claude Code](https://claude.com/claude-code)