### PR TITLE
feat: 合祀年数の例外override対応（自動判定/手動指定の明示） (#259)

### DIFF
--- a/src/__tests__/components/plot-form/burial-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/burial-info-tab.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { BurialInfoTab } from '@/components/plot-form/BurialInfoTab';
+import { defaultPlotFormData } from '@/lib/validations/plot-form';
 import { TabHost, emptyMasterData } from './test-helpers';
 
 jest.mock('@/components/ui/select', () => ({
@@ -117,6 +118,60 @@ describe('BurialInfoTab', () => {
 
     expect(screen.getByLabelText(/埋葬上限数/)).toBeInTheDocument();
     expect(screen.getByLabelText(/有効期間/)).toBeInTheDocument();
+  });
+
+  it('トグルON時の有効期間は自動判定値が初期値になる（通常区画 → 33年）（#259）', async () => {
+    const user = userEvent.setup();
+    render(<BurialInfoTabHost />);
+
+    await user.click(screen.getByLabelText('合祀対象区画'));
+
+    const input = screen.getByLabelText(/有効期間/) as HTMLInputElement;
+    expect(input.value).toBe('33');
+    expect(screen.getByText(/自動判定: 33年（通常区画 → 33年）/)).toBeInTheDocument();
+  });
+
+  it('樹林墓部＋2023-04以降の契約日なら自動判定は13年（#259）', async () => {
+    const user = userEvent.setup();
+    render(
+      <BurialInfoTabHost
+        defaultValues={{
+          physicalPlot: {
+            ...defaultPlotFormData.physicalPlot,
+            areaName: '第3期樹林部',
+          },
+          saleContract: {
+            ...defaultPlotFormData.saleContract,
+            contractDate: '2023-05-01',
+          },
+        }}
+      />
+    );
+
+    await user.click(screen.getByLabelText('合祀対象区画'));
+
+    const input = screen.getByLabelText(/有効期間/) as HTMLInputElement;
+    expect(input.value).toBe('13');
+    expect(screen.getByText(/樹林墓部・契約日 2023-04-01 以降 → 13年/)).toBeInTheDocument();
+  });
+
+  it('自動判定と異なる値は手動指定（例外）として表示され、自動判定値に戻せる（#259）', async () => {
+    const user = userEvent.setup();
+    render(<BurialInfoTabHost />);
+
+    await user.click(screen.getByLabelText('合祀対象区画'));
+
+    const input = screen.getByLabelText(/有効期間/) as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, '24');
+
+    expect(screen.getByText(/手動指定: 24年（自動判定: 33年/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '自動判定値に戻す' }));
+
+    expect(input.value).toBe('33');
+    expect(screen.queryByText(/手動指定: 24年/)).not.toBeInTheDocument();
+    expect(screen.getByText(/自動判定: 33年（通常区画 → 33年）/)).toBeInTheDocument();
   });
 
   it('「墓石情報を追加」で墓石情報セクションが展開される', async () => {

--- a/src/__tests__/lib/collective-burial-rules.test.ts
+++ b/src/__tests__/lib/collective-burial-rules.test.ts
@@ -1,6 +1,7 @@
 import {
   isJurinArea,
   inferValidityPeriodYears,
+  summarizeValidityRule,
   calculateElapsedYears,
   calculateScheduledCollectiveBurialDate,
   JURIN_RULE_TRANSITION_DATE,
@@ -45,6 +46,25 @@ describe('collective-burial-rules', () => {
     it('areaName が null / undefined は 33 年', () => {
       expect(inferValidityPeriodYears(null)).toBe(33);
       expect(inferValidityPeriodYears(undefined)).toBe(33);
+    });
+  });
+
+  describe('summarizeValidityRule (#259)', () => {
+    it('樹林墓部 + 新ルール → 13年と根拠を返す', () => {
+      expect(summarizeValidityRule('第3期樹林部', '2023-04-01')).toBe(
+        '樹林墓部・契約日 2023-04-01 以降 → 13年'
+      );
+    });
+
+    it('樹林墓部 + 旧ルール → 15年と根拠を返す', () => {
+      expect(summarizeValidityRule('第3期樹林部', '2022-12-01')).toBe(
+        '樹林墓部・契約日 2023-04-01 より前 → 15年'
+      );
+    });
+
+    it('通常区画 → 33年と根拠を返す', () => {
+      expect(summarizeValidityRule('第1期A', '2024-01-01')).toBe('通常区画 → 33年');
+      expect(summarizeValidityRule(null)).toBe('通常区画 → 33年');
     });
   });
 

--- a/src/components/collective-burial/DetailView.tsx
+++ b/src/components/collective-burial/DetailView.tsx
@@ -81,7 +81,9 @@ export default function CollectiveBurialDetailView({
   const ruleBasis = isJurinArea(data.areaName)
     ? `${data.areaName} は樹林墓部のため、契約日が 2023-04-01 以降 → 13 年 / それ以前 → 15 年`
     : `${data.areaName} は通常区画のため 33 年`;
-  const ruleMismatch = data.validityPeriodYears !== inferredRule;
+  // 推定値と異なる登録値は手動の例外指定（#259, Q17「決まった年数より短くて良い人も出る」）。
+  // エラーではなく「手動指定」として情報表示する。
+  const isManualOverride = data.validityPeriodYears !== inferredRule;
 
   return (
     <div className="h-full flex flex-col bg-shiro">
@@ -241,6 +243,11 @@ export default function CollectiveBurialDetailView({
                   <div className="p-4 bg-kinari rounded-lg border border-gin">
                     <Label className="text-sm text-hai">有効期間</Label>
                     <p className="text-2xl font-bold text-sumi mt-1">{data.validityPeriodYears} 年</p>
+                    <p className="text-[11px] mt-1 leading-snug text-hai">
+                      {isManualOverride
+                        ? `手動指定（自動判定: ${inferredRule}年）`
+                        : '自動判定どおり'}
+                    </p>
                   </div>
                 </div>
 
@@ -286,10 +293,11 @@ export default function CollectiveBurialDetailView({
                   ) : (
                     <p className="text-sm text-hai">埋葬日が未設定のため算出できません</p>
                   )}
-                  <p className="text-xs text-hai mt-2">{ruleBasis}（推定 {inferredRule} 年）</p>
-                  {ruleMismatch && (
+                  <p className="text-xs text-hai mt-2">{ruleBasis}（自動判定 {inferredRule} 年）</p>
+                  {isManualOverride && (
                     <p className="text-xs text-kohaku-dark mt-1">
-                      ⚠ 登録値 {data.validityPeriodYears} 年 と業務ルール推定値 {inferredRule} 年 が一致しません。区域分類または契約日をご確認ください。
+                      この区画は手動指定 {data.validityPeriodYears} 年 / 自動判定 {inferredRule} 年 です。業務上の例外指定（短縮など）の場合はそのままで問題ありません。
+                      ※ お墓のタイプ別の年数（24年等）は業務確認中で、確定後に自動判定へ反映予定です。
                     </p>
                   )}
                 </div>

--- a/src/components/plot-form/BurialInfoTab.tsx
+++ b/src/components/plot-form/BurialInfoTab.tsx
@@ -10,6 +10,10 @@ import { SelectItem } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Gender } from '@komine/types';
 import { ChevronDown, ChevronUp, Trash2, Plus } from 'lucide-react';
+import {
+  inferValidityPeriodYears,
+  summarizeValidityRule,
+} from '@/lib/collective-burial-rules';
 
 export function BurialInfoTab({
   register,
@@ -27,6 +31,19 @@ export function BurialInfoTab({
   const collectiveBurial = watch('collectiveBurial');
   const [collectiveBurialEnabled, setCollectiveBurialEnabled] = useState(!!collectiveBurial);
 
+  // 合祀年数の自動判定（#259）。区域名＋契約日から業務ルールで推定する。
+  // タイプ×年数の確定対応表は業務確認 Q34 回答待ちのため、現行ルールを fallback とし、
+  // 推定値と異なる手動指定は例外指定として許容する（Q17「例外対応できるように」）。
+  const areaName = watch('physicalPlot.areaName');
+  const contractDate = watch('saleContract.contractDate');
+  const inferredValidityYears = inferValidityPeriodYears(areaName, contractDate || null);
+  const validityRuleSummary = summarizeValidityRule(areaName, contractDate || null);
+  const currentValidityYears = collectiveBurial?.validityPeriodYears;
+  const isValidityOverridden =
+    typeof currentValidityYears === 'number' &&
+    !Number.isNaN(currentValidityYears) &&
+    currentValidityYears !== inferredValidityYears;
+
   useEffect(() => {
     setCollectiveBurialEnabled(!!collectiveBurial);
   }, [collectiveBurial]);
@@ -36,7 +53,8 @@ export function BurialInfoTab({
     if (enabled) {
       setValue('collectiveBurial', {
         burialCapacity: 10,
-        validityPeriodYears: 33,
+        // 自動判定値を初期値にする（#259）。手動で変更すれば例外指定として保存される。
+        validityPeriodYears: inferredValidityYears,
         billingAmount: null,
         notes: null,
       });
@@ -403,11 +421,34 @@ export function BurialInfoTab({
                 type="number"
                 min={1}
                 max={100}
-                placeholder="例: 33"
+                placeholder={`例: ${inferredValidityYears}`}
                 {...register('collectiveBurial.validityPeriodYears', { valueAsNumber: true })}
                 className={errors.collectiveBurial?.validityPeriodYears ? 'border-beni' : ''}
               />
               <p className="text-xs text-hai mt-1">埋葬上限到達後の合祀管理期間</p>
+              {/* 自動判定 vs 手動指定の明示（#259）。例外指定は正当な運用として許容する */}
+              {isValidityOverridden ? (
+                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
+                  <p className="text-xs text-kohaku-dark">
+                    手動指定: {currentValidityYears}年（自動判定: {inferredValidityYears}年 / {validityRuleSummary}）。例外指定として保存されます。
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={() =>
+                      setValue('collectiveBurial.validityPeriodYears', inferredValidityYears, {
+                        shouldDirty: true,
+                      })
+                    }
+                  >
+                    自動判定値に戻す
+                  </Button>
+                </div>
+              ) : (
+                <p className="text-xs text-hai mt-1">自動判定: {inferredValidityYears}年（{validityRuleSummary}）</p>
+              )}
               {errors.collectiveBurial?.validityPeriodYears && (
                 <p className="text-sm text-beni mt-1">
                   {errors.collectiveBurial.validityPeriodYears.message}

--- a/src/lib/collective-burial-rules.ts
+++ b/src/lib/collective-burial-rules.ts
@@ -16,6 +16,11 @@
  *       - 業務ルールの根拠表示
  *       - 経過年数表示
  *       のために使う。
+ *
+ * ⚠ 業務確認（2026-06-07）で「24年も有る」「樹木葬や納骨堂など種類により年数違う」
+ *    との指摘あり（#259）。タイプ×年数の確定対応表は業務確認シート第3版 Q34 で回収中。
+ *    回答が確定するまで本モジュールの 13/15/33 推定は fallback として維持し、
+ *    推定値と異なる手動指定（例外指定）は正当な運用として許容する。
  */
 
 /** 業務ルール変更日（樹林墓部 15→13年） */
@@ -47,6 +52,26 @@ export function inferValidityPeriodYears(
     return 13;
   }
   return 15;
+}
+
+/**
+ * 自動判定の根拠を短文で返す（フォーム・詳細画面の hint 表示用）。
+ *
+ * @param areaName 区域名
+ * @param contractDate 契約日
+ * @returns 例: "樹林墓部・契約日 2023-04-01 以降 → 13年"
+ */
+export function summarizeValidityRule(
+  areaName: string | null | undefined,
+  contractDate?: Date | string | null,
+): string {
+  const years = inferValidityPeriodYears(areaName, contractDate);
+  if (!isJurinArea(areaName)) {
+    return `通常区画 → ${years}年`;
+  }
+  return years === 13
+    ? `樹林墓部・契約日 2023-04-01 以降 → ${years}年`
+    : `樹林墓部・契約日 2023-04-01 より前 → ${years}年`;
 }
 
 /**


### PR DESCRIPTION
## 概要

業務確認シート回答（2026-06-07 Q17「例外対応できるように」・確認済み欄「24年も有る／種類により年数違う」）反映のうち、**Q34回答前に着手可能な例外override部分**。

Refs #259（タイプ×年数の確定対応表は第3版シート Q34 回答待ちのためissueはオープン維持）

## 変更内容

### 区画フォーム（BurialInfoTab）
- 合祀トグルON時の有効期間初期値: ハードコード33年 → **自動判定値**（区域名＋契約日から `inferValidityPeriodYears`）
- 有効期間入力の直下に常時表示:
  - 自動判定と一致 →「自動判定: X年（根拠）」
  - 異なる →「手動指定: Y年（自動判定: X年 / 根拠）。例外指定として保存されます。」+「自動判定値に戻す」ボタン
- 手動入力は引き続き自由（例外指定を正当な運用として許容）

### 合祀詳細（DetailView）
- 推定値乖離の警告文を「⚠ 一致しません。ご確認ください」（エラー調）→「手動指定 Y年 / 自動判定 X年。例外指定の場合はそのままで問題ありません」（情報表示）に変更
- 有効期間カードに「自動判定どおり / 手動指定（自動判定: X年）」を明示
- タイプ別年数（24年等）が業務確認中である旨を注記

### lib
- `summarizeValidityRule()` を collective-burial-rules.ts に追加（根拠短文の一元化）
- モジュールdocに #259 の経緯（現行13/15/33はQ34確定までのfallback）を記載

## 検証

- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- `npm test` 488/488 ✅（新規6件: summarizeValidityRule 3件 + BurialInfoTab 自動判定/override/戻すボタン 3件）

## 残作業（Q34回答後・本PR対象外）

- タイプ×年数の対応表ベース判定への変更（24年・樹木葬/納骨堂等）
- 2023年4月切替の他タイプへの適用有無の反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)