### PR TITLE
feat: 変更保存時の変更理由入力（プリセット＋自由入力） (#261)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=a516e99d096810ea8e783075ef6468533d3399d3
+ARG TYPES_REF=e3d4d374b812a32fccb59bb5cd47ba7627f546e0
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/__tests__/components/plot-form/plot-form.test.tsx
+++ b/src/__tests__/components/plot-form/plot-form.test.tsx
@@ -653,6 +653,63 @@ describe('PlotForm', () => {
     expect(onSave.mock.calls[0][0].physicalPlot.plotNumber).toBe('A-002');
   });
 
+  it('プレビューの変更理由入力（プリセットdatalist付き）の値が onSave の第2引数に渡る（#261）', async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn();
+    const detail = makePlotDetail();
+    render(<PlotForm plotDetail={detail} onSave={onSave} onCancel={jest.fn()} />);
+
+    const plotNumberInput = screen.getByDisplayValue('A-001');
+    await user.clear(plotNumberInput);
+    await user.type(plotNumberInput, 'A-002');
+    await user.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('変更理由（任意）')).toBeInTheDocument();
+    });
+
+    // プリセットの datalist が描画されている
+    const reasonInput = screen.getByLabelText('変更理由（任意）') as HTMLInputElement;
+    expect(reasonInput).toHaveAttribute('list', 'change-reason-presets');
+    const datalist = document.getElementById('change-reason-presets');
+    expect(datalist).not.toBeNull();
+    const options = Array.from(datalist!.querySelectorAll('option')).map((o) => o.value);
+    expect(options).toEqual(
+      expect.arrayContaining(['名義変更', '住所変更', '解約', '合祀', '修理', '字彫', '備品購入'])
+    );
+
+    // 自由入力（プリセット外）も可
+    await user.type(reasonInput, '名義変更');
+    await user.click(screen.getByRole('button', { name: '確認して更新' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+    expect(onSave.mock.calls[0][1]).toBe('名義変更');
+  });
+
+  it('変更理由が未入力なら onSave の第2引数は undefined（#261）', async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn();
+    const detail = makePlotDetail();
+    render(<PlotForm plotDetail={detail} onSave={onSave} onCancel={jest.fn()} />);
+
+    const plotNumberInput = screen.getByDisplayValue('A-001');
+    await user.clear(plotNumberInput);
+    await user.type(plotNumberInput, 'A-002');
+    await user.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '確認して更新' })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: '確認して更新' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+    expect(onSave.mock.calls[0][1]).toBeUndefined();
+  });
+
   it('プレビューで「戻る」をクリックするとダイアログが閉じて onSave は呼ばれない', async () => {
     const user = userEvent.setup();
     const onSave = jest.fn();

--- a/src/app/(main)/plots/[id]/edit/page.tsx
+++ b/src/app/(main)/plots/[id]/edit/page.tsx
@@ -20,10 +20,14 @@ export default function EditPlotPage() {
 
   const { plot: plotDetail, isLoading: isPlotDetailLoading } = usePlotDetail(plotId);
 
-  const handleSave = async (data: PlotFormData) => {
+  const handleSave = async (data: PlotFormData, changeReason?: string) => {
     setIsLoading(true);
     try {
       const request = plotFormDataToUpdateRequest(data);
+      // 変更理由（#261）。指定があれば本更新で記録される履歴の変更事由に反映される
+      if (changeReason) {
+        request.changeReason = changeReason;
+      }
       const response = await updatePlot(plotId, request);
       if (response.success) {
         showApiSuccess('更新', '区画情報');

--- a/src/components/plot-form/index.tsx
+++ b/src/components/plot-form/index.tsx
@@ -11,7 +11,10 @@ import {
 import type { PlotFormData } from '@/lib/validations/plot-form';
 import { PreviewDialog } from '@/components/shared/dialogs';
 import { buildPlotPreviewSections, buildPlotDiffSections } from './previewHelper';
+import { CHANGE_REASON_PRESETS, CHANGE_REASON_MAX_LENGTH } from '@/lib/change-reasons';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useMasters } from '@/hooks';
 import { showWarning } from '@/lib/toast';
@@ -94,6 +97,8 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
   const [expandedContactId, setExpandedContactId] = useState<string | null>(null);
   const [previewData, setPreviewData] = useState<PlotFormData | null>(null);
   const [showPreview, setShowPreview] = useState(false);
+  // 変更理由（#261）。編集時の確認ダイアログでプリセット＋自由入力を受け付ける
+  const [changeReason, setChangeReason] = useState('');
 
   const initialFormData = plotDetail ? plotDetailToFormData(plotDetail) : null;
 
@@ -105,7 +110,7 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
   const handleConfirmSubmit = () => {
     if (previewData) {
       setShowPreview(false);
-      onSave(previewData);
+      onSave(previewData, isEditing ? changeReason.trim() || undefined : undefined);
     }
   };
 
@@ -457,7 +462,33 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
           confirmText={isEditing ? '確認して更新' : '確認して登録'}
           isLoading={isLoading}
           size="xl"
-        />
+        >
+          {/* 変更理由（#261）。プリセット＋自由入力（datalist）。履歴に記録される */}
+          {isEditing && (
+            <div>
+              <Label htmlFor="plot-change-reason" className="text-sm font-medium text-sumi">
+                変更理由（任意）
+              </Label>
+              <Input
+                id="plot-change-reason"
+                list="change-reason-presets"
+                value={changeReason}
+                maxLength={CHANGE_REASON_MAX_LENGTH}
+                placeholder="例: 名義変更（選択または自由入力）"
+                onChange={(e) => setChangeReason(e.target.value)}
+                className="mt-1"
+              />
+              <datalist id="change-reason-presets">
+                {CHANGE_REASON_PRESETS.map((preset) => (
+                  <option key={preset} value={preset} />
+                ))}
+              </datalist>
+              <p className="text-xs text-hai mt-1">
+                入力した理由は変更履歴（変更事由）に記録されます
+              </p>
+            </div>
+          )}
+        </PreviewDialog>
       )}
     </form>
   );

--- a/src/components/plot-form/types.ts
+++ b/src/components/plot-form/types.ts
@@ -20,7 +20,11 @@ export interface MasterData {
 
 export interface PlotFormProps {
   plotDetail?: PlotDetailResponse;
-  onSave: (data: PlotFormData) => void;
+  /**
+   * 保存コールバック。編集時は確認ダイアログで入力された変更理由（#261）が
+   * 第2引数で渡る（未入力時は undefined、新規登録時は常に undefined）。
+   */
+  onSave: (data: PlotFormData, changeReason?: string) => void;
   onCancel: () => void;
   isLoading?: boolean;
 }

--- a/src/components/shared/dialogs/PreviewDialog.tsx
+++ b/src/components/shared/dialogs/PreviewDialog.tsx
@@ -52,6 +52,8 @@ interface PreviewDialogProps {
   isLoading?: boolean;
   /** ダイアログサイズ */
   size?: 'sm' | 'md' | 'lg' | 'xl' | 'full';
+  /** プレビュー本文の下（フッターの上）に表示する追加コンテンツ（例: 変更理由入力 #261） */
+  children?: ReactNode;
 }
 
 function formatValue(value: ReactNode): ReactNode {
@@ -132,6 +134,7 @@ export function PreviewDialog({
   cancelText = '戻る',
   isLoading = false,
   size = 'lg',
+  children,
 }: PreviewDialogProps) {
   const hasDiff = diffSections && diffSections.some((s) => s.items.some((item) => {
     const beforeStr = String(item.before ?? '');
@@ -198,6 +201,8 @@ export function PreviewDialog({
           <p className="text-sm text-hai text-center py-4">変更された項目はありません</p>
         )}
       </div>
+
+      {children && <div className="mt-4 pt-4 border-t border-gin">{children}</div>}
     </BaseDialog>
   );
 }

--- a/src/lib/change-reasons.ts
+++ b/src/lib/change-reasons.ts
@@ -1,0 +1,23 @@
+/**
+ * 変更理由プリセット（#261、業務確認シート回答 2026-06-07 Q16）
+ *
+ * 区画情報の更新時に選択できる定型の変更理由。datalist で提示し、
+ * 自由入力（その他の理由）も許容する。値はそのまま History.change_reason
+ * （VarChar(200)）に記録されるフリーテキスト互換。
+ *
+ * 将来マスタ化（backend #46 系）する場合は、この配列を masters API からの
+ * 取得に置き換えるだけで済む構成にしておく。
+ */
+export const CHANGE_REASON_PRESETS: readonly string[] = [
+  '名義変更',
+  '住所変更',
+  '電話番号変更',
+  '解約',
+  '合祀',
+  '修理',
+  '字彫',
+  '備品購入',
+];
+
+/** History.change_reason の DB 上限（VarChar(200)） */
+export const CHANGE_REASON_MAX_LENGTH = 200;


### PR DESCRIPTION
## 概要

業務確認シート回答（2026-06-07 Q16「全部いる」＋「修理・字彫・備品購入なども」）の反映。縦串の frontend 部分。

Closes #261

関連: types zaitsu82/komine-types#42（マージ済み）/ backend zaitsu82/komine-crm-backend#322

## 変更内容

- **更新確認ダイアログに「変更理由（任意）」入力を追加**（編集モードのみ）
  - プリセット: 名義変更 / 住所変更 / 電話番号変更 / 解約 / 合祀 / 修理 / 字彫 / 備品購入
  - `datalist` でプリセット提示＋自由入力も可（フリーテキスト互換、maxLength 200 = History.change_reason VarChar 長）
  - 入力値は `UpdatePlotRequest.changeReason` として送信され、backend が本更新の履歴（変更事由）に記録
- `src/lib/change-reasons.ts` にプリセット配列を一元化 — 将来マスタ化（backend #46 系）する場合は masters API 取得に置き換えるだけの構成
- `PreviewDialog` に `children` prop を追加（本文下・フッター上に描画、他用途にも再利用可）
- HistoryTab の表示は変更なし（フリーテキスト互換のまま）
- `TYPES_REF` を e3d4d37（types#42）へ bump
- 解約・復活フローの reason 記録は実装済みのため対象外（プリセット「解約」は通常更新時の理由用）

## 検証

- `npx tsc --noEmit` ✅ / `npm run lint` ✅ / `npm test` **490/490** ✅
  - 新規2件: プリセット datalist 描画＋入力値が onSave 第2引数に渡る / 未入力時は undefined
- 編集画面は DesktopOnlyGate 対象（768px未満はガード）のため md 以上での表示が前提。ダイアログ内は既存 BaseDialog のレスポンシブ挙動に準拠

## 備考

- backend #322 マージ前にこの PR が先に本番に出ても、changeReason は backend の zod に剥がされるだけで無害（後方互換）
- 完全動作には backend #322 のマージ＋デプロイが必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)