### PR TITLE
refactor: 合祀年数判定をタイプ×年数対応表ベースに再構築（Q34回答の受け入れ準備） (#259)

### DIFF
--- a/src/__tests__/lib/collective-burial-rules.test.ts
+++ b/src/__tests__/lib/collective-burial-rules.test.ts
@@ -1,10 +1,12 @@
 import {
   isJurinArea,
+  classifyGraveType,
   inferValidityPeriodYears,
   summarizeValidityRule,
   calculateElapsedYears,
   calculateScheduledCollectiveBurialDate,
   JURIN_RULE_TRANSITION_DATE,
+  VALIDITY_RULE_TABLE,
 } from '@/lib/collective-burial-rules';
 
 describe('collective-burial-rules', () => {
@@ -19,6 +21,46 @@ describe('collective-burial-rules', () => {
       expect(isJurinArea('第2期')).toBe(false);
       expect(isJurinArea(null)).toBe(false);
       expect(isJurinArea('')).toBe(false);
+    });
+  });
+
+  describe('classifyGraveType（#259 対応表ベース判定）', () => {
+    it('「樹林」を含む区域名は jurin', () => {
+      expect(classifyGraveType('第3期樹林部')).toBe('jurin');
+      expect(classifyGraveType('樹林墓部')).toBe('jurin');
+    });
+
+    it('それ以外 / null は general', () => {
+      expect(classifyGraveType('第1期A')).toBe('general');
+      expect(classifyGraveType(null)).toBe('general');
+      expect(classifyGraveType(undefined)).toBe('general');
+    });
+  });
+
+  describe('VALIDITY_RULE_TABLE（#259 タイプ×年数対応表）', () => {
+    // Q34 回答後に行を追加した際の最低限の整合性ガード
+    it('全タイプの年数が正の整数で label を持つ', () => {
+      for (const [type, rule] of Object.entries(VALIDITY_RULE_TABLE)) {
+        expect(rule.label.length).toBeGreaterThan(0);
+        expect(Number.isInteger(rule.years)).toBe(true);
+        expect(rule.years).toBeGreaterThan(0);
+        expect(Number.isInteger(rule.yearsBeforeTransition)).toBe(true);
+        expect(rule.yearsBeforeTransition).toBeGreaterThan(0);
+        expect(type.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('現時点のエントリは旧帳票準拠（樹林13/15・通常33）', () => {
+      expect(VALIDITY_RULE_TABLE.jurin).toEqual({
+        label: '樹林墓部',
+        years: 13,
+        yearsBeforeTransition: 15,
+      });
+      expect(VALIDITY_RULE_TABLE.general).toEqual({
+        label: '通常区画',
+        years: 33,
+        yearsBeforeTransition: 33,
+      });
     });
   });
 

--- a/src/components/collective-burial/DetailView.tsx
+++ b/src/components/collective-burial/DetailView.tsx
@@ -22,7 +22,7 @@ import {
   calculateElapsedYears,
   calculateScheduledCollectiveBurialDate,
   inferValidityPeriodYears,
-  isJurinArea,
+  summarizeValidityRule,
 } from '@/lib/collective-burial-rules';
 
 interface CollectiveBurialDetailViewProps {
@@ -76,11 +76,10 @@ export default function CollectiveBurialDetailView({
     : scheduledDateFallback;
   const isFallbackScheduled = !data.billingScheduledDate && scheduledDateFallback !== null;
 
-  // 業務ルール基準 (区域名 + 契約日 から推定)
+  // 業務ルール基準 (区域名 + 契約日 から対応表で推定)。
+  // 根拠文言は対応表（VALIDITY_RULE_TABLE）から一元生成し、年数のハードコードを排除（#259）
   const inferredRule = inferValidityPeriodYears(data.areaName, data.contractDate);
-  const ruleBasis = isJurinArea(data.areaName)
-    ? `${data.areaName} は樹林墓部のため、契約日が 2023-04-01 以降 → 13 年 / それ以前 → 15 年`
-    : `${data.areaName} は通常区画のため 33 年`;
+  const ruleBasis = `${data.areaName}: ${summarizeValidityRule(data.areaName, data.contractDate)}`;
   // 推定値と異なる登録値は手動の例外指定（#259, Q17「決まった年数より短くて良い人も出る」）。
   // エラーではなく「手動指定」として情報表示する。
   const isManualOverride = data.validityPeriodYears !== inferredRule;
@@ -293,7 +292,7 @@ export default function CollectiveBurialDetailView({
                   ) : (
                     <p className="text-sm text-hai">埋葬日が未設定のため算出できません</p>
                   )}
-                  <p className="text-xs text-hai mt-2">{ruleBasis}（自動判定 {inferredRule} 年）</p>
+                  <p className="text-xs text-hai mt-2">自動判定: {ruleBasis}</p>
                   {isManualOverride && (
                     <p className="text-xs text-kohaku-dark mt-1">
                       この区画は手動指定 {data.validityPeriodYears} 年 / 自動判定 {inferredRule} 年 です。業務上の例外指定（短縮など）の場合はそのままで問題ありません。

--- a/src/lib/collective-burial-rules.ts
+++ b/src/lib/collective-burial-rules.ts
@@ -4,27 +4,55 @@
  * 旧 Excel 帳票 (`komine-docs/参考画面キャプチャ/09_合祀管理エクセル.JPG`) のヘッダー記載:
  *   「〜7期樹林墓部について13年(15年)経過後の合祀(2023年4月以降適用) 〜時33年経過」
  *
- * これを次のように解釈する:
- *   - 樹林墓部 (区域名に「樹林」を含む):
- *       - 契約日 >= 2023-04-01 → 13 年経過で合祀
- *       - 契約日 <  2023-04-01 → 15 年経過で合祀 (旧ルール)
- *   - その他の区画: 33 年経過で合祀
- *
  * 注意: CollectiveBurial レコードは `validityPeriodYears` を持っているため、
  *       UI 上は基本的にそれを優先する。本モジュールは
  *       - 未設定時のフォールバック推定
  *       - 業務ルールの根拠表示
  *       - 経過年数表示
  *       のために使う。
+ *       推定値と異なる手動指定（例外指定）は正当な運用として許容する（#259, Q17）。
  *
- * ⚠ 業務確認（2026-06-07）で「24年も有る」「樹木葬や納骨堂など種類により年数違う」
- *    との指摘あり（#259）。タイプ×年数の確定対応表は業務確認シート第3版 Q34 で回収中。
- *    回答が確定するまで本モジュールの 13/15/33 推定は fallback として維持し、
- *    推定値と異なる手動指定（例外指定）は正当な運用として許容する。
+ * ## タイプ×年数の対応表（#259）
+ *
+ * 業務確認（2026-06-07）で「24年も有る」「樹木葬や納骨堂など種類により年数違う」との
+ * 指摘を受け、判定を `VALIDITY_RULE_TABLE`（タイプ×年数の対応表）ベースに再構築した。
+ * 確定対応表は業務確認シート第3版 Q34 で回収中のため、現時点のエントリは
+ * 旧帳票から判明している 樹林墓部 13/15・通常 33 のみ（fallback）。
+ *
+ * ### Q34 回答後の反映手順（データ更新のみで済む想定）
+ * 1. `GraveType` にタイプを追加（例: 'nokotsudo'）
+ * 2. `VALIDITY_RULE_TABLE` に行を追加（例: { label: '納骨堂', years: 24, yearsBeforeTransition: 24 }）
+ *    - 2023年4月切替が無いタイプは years と yearsBeforeTransition を同値にする
+ * 3. `classifyGraveType` の判定を拡張（区域名→タイプの対応は Q33 回答で確定）
  */
 
-/** 業務ルール変更日（樹林墓部 15→13年） */
+/** 業務ルール変更日（樹林墓部 15→13年。他タイプへの適用有無は Q34 で確認中） */
 export const JURIN_RULE_TRANSITION_DATE = new Date(2023, 3, 1); // 2023-04-01
+
+/**
+ * お墓のタイプ（合祀年数の判定単位）。
+ * Q33/Q34 回答後に 樹木葬/バラ咲く樹木葬/納骨堂/花鳥風月 等を追加予定（#259）。
+ */
+export type GraveType = 'jurin' | 'general';
+
+/** タイプごとの合祀年数ルール */
+export interface ValidityRule {
+  /** 画面表示用のタイプ名 */
+  label: string;
+  /** 2023-04-01 以降の契約に適用する年数 */
+  years: number;
+  /** 2023-04-01 より前の契約に適用する年数（切替が無いタイプは years と同値） */
+  yearsBeforeTransition: number;
+}
+
+/**
+ * タイプ×年数の対応表（#259）。
+ * Q34 回答が確定したらここへ行を追加する（上記モジュールコメントの反映手順を参照）。
+ */
+export const VALIDITY_RULE_TABLE: Record<GraveType, ValidityRule> = {
+  jurin: { label: '樹林墓部', years: 13, yearsBeforeTransition: 15 },
+  general: { label: '通常区画', years: 33, yearsBeforeTransition: 33 },
+};
 
 /** 樹林墓部かどうかを区域名から判定 */
 export function isJurinArea(areaName: string | null | undefined): boolean {
@@ -33,25 +61,32 @@ export function isJurinArea(areaName: string | null | undefined): boolean {
 }
 
 /**
- * 区域名と契約日から、業務ルール上の有効年数 (13/15/33) を推定する。
+ * 区域名からお墓のタイプを判定する。
+ * 現状は区域名に「樹林」を含むか否かの2値のみ。
+ * 区域名→タイプの確定対応（タイプごとの所在期）は Q33 回答後に拡張する（#259）。
+ */
+export function classifyGraveType(areaName: string | null | undefined): GraveType {
+  return isJurinArea(areaName) ? 'jurin' : 'general';
+}
+
+/**
+ * 区域名と契約日から、業務ルール上の有効年数を対応表で推定する。
  *
  * @param areaName 区域名 (例: "第3期樹林部", "第1期A")
  * @param contractDate 契約日 (省略時は 2023-04-01 以降扱い = 新ルール適用)
- * @returns 13 | 15 | 33
+ * @returns 対応表の年数（現状 13 | 15 | 33）
  */
 export function inferValidityPeriodYears(
   areaName: string | null | undefined,
   contractDate?: Date | string | null,
-): 13 | 15 | 33 {
-  if (!isJurinArea(areaName)) {
-    return 33;
-  }
-  // 樹林墓部: 契約日が新ルール (2023-04-01) 以降か
+): number {
+  const rule = VALIDITY_RULE_TABLE[classifyGraveType(areaName)];
+  // 契約日が業務ルール変更日 (2023-04-01) 以降か
   const refDate = contractDate ? toDate(contractDate) : JURIN_RULE_TRANSITION_DATE;
   if (!refDate || refDate >= JURIN_RULE_TRANSITION_DATE) {
-    return 13;
+    return rule.years;
   }
-  return 15;
+  return rule.yearsBeforeTransition;
 }
 
 /**
@@ -59,19 +94,21 @@ export function inferValidityPeriodYears(
  *
  * @param areaName 区域名
  * @param contractDate 契約日
- * @returns 例: "樹林墓部・契約日 2023-04-01 以降 → 13年"
+ * @returns 例: "樹林墓部・契約日 2023-04-01 以降 → 13年" / "通常区画 → 33年"
  */
 export function summarizeValidityRule(
   areaName: string | null | undefined,
   contractDate?: Date | string | null,
 ): string {
+  const rule = VALIDITY_RULE_TABLE[classifyGraveType(areaName)];
   const years = inferValidityPeriodYears(areaName, contractDate);
-  if (!isJurinArea(areaName)) {
-    return `通常区画 → ${years}年`;
+  // 切替の無いタイプは日付条件を出さない
+  if (rule.years === rule.yearsBeforeTransition) {
+    return `${rule.label} → ${years}年`;
   }
-  return years === 13
-    ? `樹林墓部・契約日 2023-04-01 以降 → ${years}年`
-    : `樹林墓部・契約日 2023-04-01 より前 → ${years}年`;
+  return years === rule.years
+    ? `${rule.label}・契約日 2023-04-01 以降 → ${years}年`
+    : `${rule.label}・契約日 2023-04-01 より前 → ${years}年`;
 }
 
 /**


### PR DESCRIPTION
## 概要

#259 の残作業（タイプ×年数の確定対応表ベースへの変更）のうち、**Q34回答前に先行できる構造の再構築**。回答確定後は**対応表へのデータ追加のみ**で済む状態にする。

Refs #259（クローズしない: 確定値=Q34・区域名→タイプ対応=Q33 の回答待ち）

## 変更内容

- **`VALIDITY_RULE_TABLE`**（タイプ×年数対応表）を新設
  - `GraveType → { label, years, yearsBeforeTransition }`
  - 現エントリは旧帳票から判明している `樹林墓部 13/15`・`通常区画 33` のみ（fallback）
  - 2023年4月切替が無いタイプは `years === yearsBeforeTransition` で表現
- **`classifyGraveType`**（区域名→タイプ判定）を分離 — 現状は「樹林」含むか否かの2値。Q33回答（タイプごとの所在期）で拡張
- `inferValidityPeriodYears` / `summarizeValidityRule` を対応表参照に変更（**出力値・文言は完全に不変**、返り値型のみ `13|15|33` → `number` に一般化）
- 合祀詳細（DetailView）の根拠文言から年数ハードコードを排除し `summarizeValidityRule` に一元化（表示は「自動判定: 第1期A: 通常区画 → 33年」形式に統一）
- **Q34回答後の反映手順をモジュールコメントに明文化**（①GraveType追加 ②表に行追加 ③classifyGraveType拡張）

## 検証

- `npx tsc --noEmit` ✅ / `npm run lint` ✅
- `npm test` **489/489** ✅（新規4件: classifyGraveType 2件 + 対応表整合性ガード 2件。**既存の infer/summarize テストは無変更でpass = 挙動不変**）

🤖 Generated with [Claude Code](https://claude.com/claude-code)