### PR TITLE
fix(nav): 区画コンテキスト書類画面でサイドバーの書類管理をアクティブにする

### DIFF
--- a/src/__tests__/components/global-sidebar-active.test.tsx
+++ b/src/__tests__/components/global-sidebar-active.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * GlobalSidebar アクティブ項目判定のテスト（#270）
+ *
+ * - 通常パスは前方一致で対応するナビ項目がアクティブになる
+ * - 区画コンテキストの書類画面（/plots/[id]/documents 配下）では
+ *   「台帳問い合わせ」ではなく「書類管理」がアクティブになる
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import GlobalSidebar from '@/components/layout/GlobalSidebar';
+
+let mockPathname = '/plots';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+jest.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'staff-1',
+      email: 'test@example.com',
+      name: 'テスト太郎',
+      role: 'admin',
+    },
+  }),
+}));
+
+function renderSidebar() {
+  return render(<GlobalSidebar collapsed={false} onToggleCollapse={() => {}} />);
+}
+
+/** ナビ項目リンクがアクティブ表示（bg-matsu-50）かどうか */
+function isLinkActive(label: string): boolean {
+  const link = screen.getByRole('link', { name: new RegExp(`^${label}`) });
+  return link.className.includes('bg-matsu-50');
+}
+
+describe('GlobalSidebar アクティブ項目判定', () => {
+  it('/plots では台帳問い合わせがアクティブ', () => {
+    mockPathname = '/plots';
+    renderSidebar();
+    expect(isLinkActive('台帳問い合わせ')).toBe(true);
+    expect(isLinkActive('書類管理')).toBe(false);
+  });
+
+  it('/plots/[id]（区画詳細）では台帳問い合わせがアクティブ', () => {
+    mockPathname = '/plots/123';
+    renderSidebar();
+    expect(isLinkActive('台帳問い合わせ')).toBe(true);
+    expect(isLinkActive('書類管理')).toBe(false);
+  });
+
+  it('/plots/[id]/edit では台帳問い合わせがアクティブのまま', () => {
+    mockPathname = '/plots/123/edit';
+    renderSidebar();
+    expect(isLinkActive('台帳問い合わせ')).toBe(true);
+    expect(isLinkActive('書類管理')).toBe(false);
+  });
+
+  it('/plots/[id]/documents（書類履歴）では書類管理がアクティブ（#270）', () => {
+    mockPathname = '/plots/123/documents';
+    renderSidebar();
+    expect(isLinkActive('書類管理')).toBe(true);
+    expect(isLinkActive('台帳問い合わせ')).toBe(false);
+  });
+
+  it('/plots/[id]/documents/create（書類作成）では書類管理がアクティブ（#270）', () => {
+    mockPathname = '/plots/123/documents/create';
+    renderSidebar();
+    expect(isLinkActive('書類管理')).toBe(true);
+    expect(isLinkActive('台帳問い合わせ')).toBe(false);
+  });
+
+  it('/documents（グローバル書類管理）では書類管理がアクティブ', () => {
+    mockPathname = '/documents';
+    renderSidebar();
+    expect(isLinkActive('書類管理')).toBe(true);
+    expect(isLinkActive('台帳問い合わせ')).toBe(false);
+  });
+
+  it('/collective-burials では合祀管理がアクティブ', () => {
+    mockPathname = '/collective-burials';
+    renderSidebar();
+    expect(isLinkActive('合祀管理')).toBe(true);
+    expect(isLinkActive('台帳問い合わせ')).toBe(false);
+  });
+});

--- a/src/components/layout/GlobalSidebar.tsx
+++ b/src/components/layout/GlobalSidebar.tsx
@@ -52,9 +52,16 @@ export default function GlobalSidebar({
     ),
   })).filter(group => group.items.length > 0);
 
+  // 区画コンテキストの書類画面（/plots/[id]/documents 配下）は
+  // 「台帳問い合わせ」ではなく「書類管理」をアクティブにする（#270）
+  const isPlotDocuments = /^\/plots\/[^/]+\/documents(\/|$)/.test(pathname);
+
   const isActive = (itemPath: string) => {
+    if (itemPath === '/documents') {
+      return pathname === itemPath || pathname.startsWith(itemPath + '/') || isPlotDocuments;
+    }
     if (itemPath === '/plots') {
-      return pathname === '/plots' || pathname.startsWith('/plots/');
+      return (pathname === '/plots' || pathname.startsWith('/plots/')) && !isPlotDocuments;
     }
     return pathname === itemPath || pathname.startsWith(itemPath + '/');
   };


### PR DESCRIPTION
## 概要

区画詳細（`/plots/[id]`）の「書類履歴」ボタンから `/plots/[id]/documents` に遷移すると、サイドバーのアクティブ表示が「台帳問い合わせ」のままになる問題を修正。

Closes #270

## 原因

`GlobalSidebar.tsx` の `isActive()` で「台帳問い合わせ」(`/plots`) が `startsWith('/plots/')` により `/plots/` 配下をすべてキャッチする一方、「書類管理」のナビ項目はグローバルパス `/documents` のみで判定しており、ネストパス `/plots/[id]/documents` にマッチしなかった。

## 変更内容

- `isActive()` に特別ルールを追加: `/plots/[id]/documents` 配下（書類履歴・書類作成）は「書類管理」をアクティブにし、「台帳問い合わせ」の判定からは除外
- ルート構造・遷移コードへの変更なし（判定ロジックのみ）

## テスト

- 新規: `global-sidebar-active.test.tsx`（7ケース — 通常パスの前方一致、`/plots/[id]/edit` は台帳のまま、`/plots/[id]/documents(/create)` は書類管理、グローバル `/documents`、合祀管理）
- `npm run lint` clean / Jest 全37スイート496テスト pass
- E2E `navigation.spec.ts` のアクティブ状態テスト（合祀管理クリック）には非干渉

🤖 Generated with [Claude Code](https://claude.com/claude-code)