### PR TITLE
feat(plots): 区画No表示を displayNumber 優先に (#158)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=e3d4d374b812a32fccb59bb5cd47ba7627f546e0
+ARG TYPES_REF=437b56845adf9c9f3689c22acb878431a8665dc1
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -334,8 +334,13 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
       <Section title="区画情報">
         <InfoField
           label="区画番号"
-          value={plot.physicalPlot.plotNumber}
-          hint={isLegacyPlotNumber(plot.physicalPlot.plotNumber) ? '整備中（レガシー移行値・要確認）' : undefined}
+          // 表示用区画番号（grave_name_cd 由来）を優先。未設定時のみ legacy 値を表示し注記 #158
+          value={plot.physicalPlot.displayNumber || plot.physicalPlot.plotNumber}
+          hint={
+            !plot.physicalPlot.displayNumber && isLegacyPlotNumber(plot.physicalPlot.plotNumber)
+              ? '整備中（レガシー移行値・要確認）'
+              : undefined
+          }
         />
         <InfoField
           label="エリア"
@@ -916,9 +921,9 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-4 md:mb-6 bg-white border border-gin rounded-elegant-lg shadow-elegant-sm p-4 md:p-5">
         <div className="min-w-0">
           <h2 className="text-lg md:text-2xl font-bold text-sumi truncate">
-            <LegacyAwareValue value={plot.physicalPlot.plotNumber} kind="plotNumber" /> - <LegacyAwareValue value={plot.physicalPlot.areaName} kind="areaName" />
+            <LegacyAwareValue value={plot.physicalPlot.displayNumber || plot.physicalPlot.plotNumber} kind="plotNumber" /> - <LegacyAwareValue value={plot.physicalPlot.areaName} kind="areaName" />
           </h2>
-          {(isLegacyPlotNumber(plot.physicalPlot.plotNumber) || isLegacyAreaName(plot.physicalPlot.areaName)) && (
+          {((!plot.physicalPlot.displayNumber && isLegacyPlotNumber(plot.physicalPlot.plotNumber)) || isLegacyAreaName(plot.physicalPlot.areaName)) && (
             <LegacyValueNote className="mt-1" />
           )}
           {primaryCustomer && (

--- a/src/components/plot-registry/PlotCardList.tsx
+++ b/src/components/plot-registry/PlotCardList.tsx
@@ -65,7 +65,7 @@ export function PlotCardList({
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2 min-w-0">
                       <span className="font-mono text-matsu font-semibold text-sm truncate">
-                        {plot.plotNumber}
+                        {plot.displayNumber || plot.plotNumber}
                       </span>
                       {plot.areaName && (
                         <span className="text-xs text-hai truncate">{plot.areaName}</span>

--- a/src/components/plot-registry/PlotTable.tsx
+++ b/src/components/plot-registry/PlotTable.tsx
@@ -257,10 +257,11 @@ export function PlotTable({
                         onPlotSelect(plot);
                       }
                     }}
-                    aria-label={`${plot.plotNumber} の詳細を開く`}
+                    aria-label={`${plot.displayNumber || plot.plotNumber} の詳細を開く`}
                   >
-                    <td className={cellWrapClass('plotNumber', 'px-2 py-2 font-mono text-matsu font-medium text-xs underline-offset-2 group-hover:underline')} title={plot.plotNumber}>
-                      {plot.plotNumber}
+                    {/* 表示用区画番号（grave_name_cd 由来）を優先。未設定時は plotNumber にフォールバック #158 */}
+                    <td className={cellWrapClass('plotNumber', 'px-2 py-2 font-mono text-matsu font-medium text-xs underline-offset-2 group-hover:underline')} title={plot.displayNumber || plot.plotNumber}>
+                      {plot.displayNumber || plot.plotNumber}
                     </td>
                     <td className={cellWrapClass('areaName', 'px-2 py-2 text-xs text-hai')} title={plot.areaName || undefined}>
                       {plot.areaName || '-'}

--- a/src/components/plot-registry/utils.tsx
+++ b/src/components/plot-registry/utils.tsx
@@ -50,7 +50,7 @@ export function getSearchHitReason(
   const has = (v: string | null | undefined): boolean => !!v && v.toLowerCase().includes(q);
 
   if (has(plot.customerName) || has(plot.customerNameKana)) return null;
-  if (has(plot.plotNumber)) return '区画番号に一致';
+  if (has(plot.displayNumber) || has(plot.plotNumber)) return '区画番号に一致';
   if (has(plot.customerAddress)) return '住所に一致';
   if (has(plot.customerPhoneNumber)) return '電話番号に一致';
   if (plot.buriedPersonNames?.some((n) => has(n))) return '埋葬者名に一致';

--- a/src/lib/api/plots.ts
+++ b/src/lib/api/plots.ts
@@ -79,6 +79,7 @@ const mockPlots: PlotListItem[] = [
     contractAreaSqm: 3.6,
     locationDescription: null,
     plotNumber: 'A-001',
+    displayNumber: 'A-1',
     areaName: '第1期',
     physicalPlotAreaSqm: 3.6,
     physicalPlotStatus: PhysicalPlotStatus.SoldOut,
@@ -118,6 +119,7 @@ const mockPlots: PlotListItem[] = [
     contractAreaSqm: 1.8,
     locationDescription: '左半分',
     plotNumber: 'B-015',
+    displayNumber: 'B-15',
     areaName: '第2期',
     physicalPlotAreaSqm: 3.6,
     physicalPlotStatus: PhysicalPlotStatus.PartiallySold,
@@ -238,6 +240,7 @@ async function mockGetPlotById(
     physicalPlot: {
       id: `physical-${plot.id}`,
       plotNumber: plot.plotNumber,
+      displayNumber: plot.displayNumber,
       areaName: plot.areaName,
       areaSqm: plot.physicalPlotAreaSqm,
       status: plot.physicalPlotStatus,


### PR DESCRIPTION
## 概要

区画No が `legacy-{grave_cd}` のまま表示される問題（#158）の表示側対応。backend が返す `displayNumber`（レガシー grave_name_cd 由来、例 "A-100"）を優先表示し、未設定時のみ `plotNumber` にフォールバックする。

## 変更

- 区画一覧テーブル（PlotTable）/ モバイルカード（PlotCardList）/ 区画詳細（plot-detail-view）の区画番号を `displayNumber || plotNumber` に
- 詳細のレガシー注記（整備中…）は `displayNumber` 未設定時のみ表示
- フリーテキスト検索ヒントの「区画番号に一致」に displayNumber を追加
- モックデータに displayNumber を追加

## 検証

- 型チェック（types 新フィールド解決）clean / `eslint` clean / 関連 149 tests pass

## マージ順

types #45 を先にマージ → 本リポ Dockerfile `TYPES_REF` を types 新SHAに bump 後マージ。

Refs #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)