### PR TITLE
feat(history): 変更理由プリセットに「その他」を追加 (Closes #273)

### DIFF
--- a/src/lib/change-reasons.ts
+++ b/src/lib/change-reasons.ts
@@ -17,6 +17,7 @@ export const CHANGE_REASON_PRESETS: readonly string[] = [
   '修理',
   '字彫',
   '備品購入',
+  'その他',
 ];
 
 /** History.change_reason の DB 上限（VarChar(200)） */


### PR DESCRIPTION
## 概要
komine-docs#10 項目7（変更履歴の種別）のコード突き合わせで判明した軽微対応。
要望9種別（名義変更/住所変更/電話番号変更/解約/合祀/修理/字彫/備品購入/その他）のうち、**「その他」だけ `CHANGE_REASON_PRESETS` に未登録**だった。datalist なので自由入力自体は可能だが、選択肢として明示する。

## 変更
- `src/lib/change-reasons.ts` の `CHANGE_REASON_PRESETS` 末尾に `'その他'` を catch-all として1行追加

## 検証
- `plot-form.test.tsx` 46件 green（変更理由datalistのテストは `arrayContaining` の部分一致のため非破壊）
- `eslint src/lib/change-reasons.ts` クリーン

Closes #273
Refs komine-docs#10

🤖 Generated with [Claude Code](https://claude.com/claude-code)