### PR TITLE
fix(plots): モック区画詳細の履歴タブ空表示を解消 (#267)

### DIFF
--- a/src/__tests__/lib/api/plot-history-mock.test.ts
+++ b/src/__tests__/lib/api/plot-history-mock.test.ts
@@ -1,0 +1,50 @@
+jest.mock('@/lib/api/client', () => {
+  const actual = jest.requireActual('@/lib/api/client');
+  return { __esModule: true, ...actual, shouldUseMockData: () => true };
+});
+
+import { getPlotById } from '@/lib/api/plots';
+
+/**
+ * #267: モックモードで区画詳細の履歴タブが全区画で常に空になる回帰を防ぐ。
+ * mockGetPlotById が組み立てる PlotDetailResponse に妥当な histories が含まれ、
+ * HistoryTab が解釈できる shape（actionType/changedBy/changeReason/createdAt）に
+ * なっていることを保証する。
+ */
+describe('モック区画詳細の履歴 (#267)', () => {
+  const mockPlotIds = ['mock-plot-1', 'mock-plot-2'];
+
+  it.each(mockPlotIds)('%s は空でない履歴を返す', async (id) => {
+    const res = await getPlotById(id);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+
+    const histories = res.data.histories ?? [];
+    expect(histories.length).toBeGreaterThan(0);
+  });
+
+  it('各履歴エントリが HistoryTab の必須フィールドを持つ', async () => {
+    const res = await getPlotById('mock-plot-1');
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+
+    const histories = res.data.histories ?? [];
+    for (const h of histories) {
+      expect(typeof h.id).toBe('string');
+      expect(h.id.length).toBeGreaterThan(0);
+      expect(['CREATE', 'UPDATE', 'DELETE']).toContain(h.actionType);
+      expect('changedBy' in h).toBe(true);
+      expect('changeReason' in h).toBe(true);
+      expect(typeof h.createdAt).toBe('string');
+    }
+  });
+
+  it('レガシー移行を表す CREATE エントリを含む', async () => {
+    const res = await getPlotById('mock-plot-2');
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+
+    const histories = res.data.histories ?? [];
+    expect(histories.some((h) => h.actionType === 'CREATE')).toBe(true);
+  });
+});

--- a/src/lib/api/plots.ts
+++ b/src/lib/api/plots.ts
@@ -215,6 +215,82 @@ async function mockGetPlots(
 }
 
 /**
+ * モック: 区画の変更履歴を組み立てる（issue #267）
+ *
+ * 実環境（backend #51 の historyService）が返すリッチな履歴 shape に合わせて
+ * 区画作成（CREATE）と代表的な更新（UPDATE）を数件生成する。
+ * `@komine/types` の PlotDetailResponse.histories は簡易 shape のため、
+ * HistoryTab が解釈する拡張 shape を unknown 経由でキャストして返す。
+ */
+function buildMockHistories(plot: PlotListItem): PlotDetailResponse['histories'] {
+  const contractorName =
+    plot.roles.find((r) => r.role === ContractRole.Contractor)?.customer.name ??
+    plot.customerName ??
+    '';
+
+  const histories: Array<Record<string, unknown>> = [];
+
+  // 直近の更新（UPDATE）— 区画ごとに妥当な変更を1件
+  if (plot.paymentStatus === PaymentStatus.Paid) {
+    histories.push({
+      id: `${plot.id}-hist-update-1`,
+      entityType: 'SaleContract',
+      entityLabel: '販売契約',
+      actionType: 'UPDATE',
+      changedFields: {
+        paymentStatus: { before: '未入金', after: '入金済' },
+      },
+      fieldLabels: { paymentStatus: '入金状況' },
+      changedBy: '管理者',
+      changeReason: '管理料の口座振替を確認',
+      createdAt: plot.updatedAt,
+    });
+  } else if (plot.customerNotes) {
+    histories.push({
+      id: `${plot.id}-hist-update-1`,
+      entityType: 'Customer',
+      entityLabel: '顧客情報',
+      actionType: 'UPDATE',
+      changedFields: {
+        notes: { before: null, after: plot.customerNotes },
+      },
+      fieldLabels: { notes: '備考' },
+      changedBy: '担当者',
+      changeReason: '顧客からの連絡を反映',
+      createdAt: plot.updatedAt,
+    });
+  }
+
+  // 区画作成（CREATE）— レガシー移行時の初期登録
+  histories.push({
+    id: `${plot.id}-hist-create`,
+    entityType: 'ContractPlot',
+    entityLabel: '契約区画',
+    actionType: 'CREATE',
+    changedFields: null,
+    afterRecord: {
+      plotNumber: plot.plotNumber,
+      areaName: plot.areaName,
+      contractDate: plot.contractDate,
+      price: plot.price,
+      contractorName,
+    },
+    fieldLabels: {
+      plotNumber: '区画番号',
+      areaName: 'エリア',
+      contractDate: '契約日',
+      price: '契約金額',
+      contractorName: '契約者名',
+    },
+    changedBy: 'システム移行',
+    changeReason: 'レガシーデータ移行による初期登録',
+    createdAt: plot.createdAt,
+  });
+
+  return histories as unknown as PlotDetailResponse['histories'];
+}
+
+/**
  * モック: 区画詳細取得
  */
 async function mockGetPlotById(
@@ -379,6 +455,7 @@ async function mockGetPlotById(
         workInfo: null,
       },
     })),
+    histories: buildMockHistories(plot),
   };
 
   return {


### PR DESCRIPTION
## 概要

モックデータモード（`shouldUseMockData()` が true）で、区画詳細の「履歴」タブが**全区画で常に空**（「履歴データはありません」）になっていた不具合を修正。

## 原因

`mockGetPlotById`（`src/lib/api/plots.ts`）が組み立てる `PlotDetailResponse` に `histories` フィールドが一切含まれておらず、モック世界に履歴データが存在しなかった。実環境（レガシー移行データ）で履歴が空なのは仕様だが、これはモックモード限定の表示バグ（#176 と同族）。

## 変更

- `buildMockHistories(plot)` を追加。区画データから以下を生成し、全モック区画に履歴が表示されるようにした:
  - **CREATE**（レガシー移行による初期登録）— 区画番号・エリア・契約日・契約金額・契約者名を `afterRecord` に格納
  - **UPDATE**（入金状況の確認 / 顧客メモの反映）— `changedFields` の before/after 差分
- backend #51 の `historyService` が返すリッチ shape に合わせ、`HistoryTab` の差分テーブル表示・展開UIまで忠実に再現（`@komine/types` の簡易 shape は unknown 経由でキャスト）。
- 回帰テスト `plot-history-mock.test.ts` を追加（#176 のモック整合テストと同パターン）。

## テスト

- `npm test -- src/__tests__/lib/api/plot-history-mock.test.ts` → 4 passed
- `npm test -- src/__tests__/components/plot-form/plot-form.test.tsx`（HistoryTab描画）→ 46 passed
- `tsc --noEmit` clean / `eslint` clean

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)