### PR TITLE
feat(plot-form): 電話/郵便番号の入力をハイフン除去で正規化 + TYPES_REF bump (#280)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=437b56845adf9c9f3689c22acb878431a8665dc1
+ARG TYPES_REF=df9802a74bd519b75768209d7a94f0730a09ee9b
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/__tests__/lib/format.test.ts
+++ b/src/__tests__/lib/format.test.ts
@@ -6,7 +6,12 @@ import {
   formatBillingMonth,
   formatDate,
   formatYearMonth,
+  digitsOnly,
 } from '@/lib/format';
+import {
+  customerSchema,
+  workInfoSchema,
+} from '@komine/types/validations';
 
 describe('formatCurrency', () => {
   it('数値をカンマ区切り + 円で表示する', () => {
@@ -151,5 +156,64 @@ describe('formatYearMonth', () => {
   it('null / 不正値は fallback を返す', () => {
     expect(formatYearMonth(null)).toBe('-');
     expect(formatYearMonth('bad')).toBe('-');
+  });
+});
+
+describe('digitsOnly (#280 入力正規化)', () => {
+  it('ハイフン・空白・括弧等の非数字を除去する', () => {
+    expect(digitsOnly('090-1234-5678')).toBe('09012345678');
+    expect(digitsOnly('807-0842')).toBe('8070842');
+    expect(digitsOnly('03 (1234) 5678')).toBe('0312345678');
+    expect(digitsOnly('１２３')).toBe(''); // 全角数字は半角数字でないため除去
+  });
+
+  it('null / undefined / 空は空文字を返す', () => {
+    expect(digitsOnly(null)).toBe('');
+    expect(digitsOnly(undefined)).toBe('');
+    expect(digitsOnly('')).toBe('');
+    expect(digitsOnly('---')).toBe('');
+  });
+
+  it('既に数字のみの値はそのまま返す', () => {
+    expect(digitsOnly('09012345678')).toBe('09012345678');
+    expect(digitsOnly('8070842')).toBe('8070842');
+  });
+
+  // 正規化後の値が共有 zod（@komine/types）の max / regex を通ることを保証する。
+  // これが #280 の主目的（ハイフン付き入力での P2000・バリデーションエラー防止）。
+  it('正規化後の電話/郵便が customerSchema を通る', () => {
+    const parsed = customerSchema.safeParse({
+      name: '田中太郎',
+      nameKana: 'タナカタロウ',
+      address: '東京都新宿区西新宿1-1-1',
+      postalCode: digitsOnly('807-0842'), // 7桁数字 → regex /^\d{7}$/
+      phoneNumber: digitsOnly('090-1234-5678'), // 0始まり11桁 → phoneSchema
+      faxNumber: digitsOnly('03-1234-5678'), // 0始まり10桁 → phoneSchema
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('正規化前のハイフン付き郵便は customerSchema で弾かれる（正規化の必要性）', () => {
+    const parsed = customerSchema.safeParse({
+      name: '田中太郎',
+      nameKana: 'タナカタロウ',
+      address: '東京都新宿区西新宿1-1-1',
+      postalCode: '807-0842', // ハイフン付き → regex /^\d{7}$/ 不一致
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('正規化後の workPhoneNumber が workInfoSchema の数字のみ regex を通る', () => {
+    const ok = workInfoSchema.safeParse({
+      companyName: '株式会社サンプル',
+      workPhoneNumber: digitsOnly('090-1234-5678'), // 0始まり11桁
+    });
+    expect(ok.success).toBe(true);
+
+    const ng = workInfoSchema.safeParse({
+      companyName: '株式会社サンプル',
+      workPhoneNumber: '090-1234-5678', // ハイフン付き → regex 不一致
+    });
+    expect(ng.success).toBe(false);
   });
 });

--- a/src/components/plot-form/BasicInfoTab.tsx
+++ b/src/components/plot-form/BasicInfoTab.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Gender, PaymentStatus } from '@komine/types';
 import { defaultApplicant } from '@/lib/validations/plot-form';
+import { digitsOnly } from '@/lib/format';
 
 export function BasicInfoTab({
   register,
@@ -328,7 +329,7 @@ export function BasicInfoTab({
             label="郵便番号"
             viewMode={viewMode}
             required
-            register={register('customer.postalCode')}
+            register={register('customer.postalCode', { setValueAs: digitsOnly })}
             error={errors.customer?.postalCode?.message}
             placeholder="1234567（ハイフンなし7桁）"
           />
@@ -357,7 +358,7 @@ export function BasicInfoTab({
           <ViewModeField
             label="本籍郵便番号"
             viewMode={viewMode}
-            register={register('customer.registeredPostalCode')}
+            register={register('customer.registeredPostalCode', { setValueAs: digitsOnly })}
             error={errors.customer?.registeredPostalCode?.message}
             placeholder="1234567（ハイフンなし7桁）"
           />
@@ -375,7 +376,7 @@ export function BasicInfoTab({
           <ViewModeField
             label="電話番号"
             viewMode={viewMode}
-            register={register('customer.phoneNumber')}
+            register={register('customer.phoneNumber', { setValueAs: digitsOnly })}
             error={errors.customer?.phoneNumber?.message}
             placeholder="09012345678（ハイフンなし10-11桁）"
           />
@@ -383,7 +384,7 @@ export function BasicInfoTab({
           <ViewModeField
             label="FAX"
             viewMode={viewMode}
-            register={register('customer.faxNumber')}
+            register={register('customer.faxNumber', { setValueAs: digitsOnly })}
             error={errors.customer?.faxNumber?.message}
             placeholder="0312345678"
           />
@@ -504,7 +505,7 @@ function ApplicantSection({
           <ViewModeField
             label="郵便番号"
             viewMode={viewMode}
-            register={register('applicant.postalCode')}
+            register={register('applicant.postalCode', { setValueAs: digitsOnly })}
             error={errors.applicant?.postalCode?.message}
             placeholder="1234567（ハイフンなし7桁）"
           />
@@ -532,7 +533,7 @@ function ApplicantSection({
           <ViewModeField
             label="本籍郵便番号"
             viewMode={viewMode}
-            register={register('applicant.registeredPostalCode')}
+            register={register('applicant.registeredPostalCode', { setValueAs: digitsOnly })}
             error={errors.applicant?.registeredPostalCode?.message}
             placeholder="1234567（ハイフンなし7桁）"
           />
@@ -550,7 +551,7 @@ function ApplicantSection({
           <ViewModeField
             label="電話番号"
             viewMode={viewMode}
-            register={register('applicant.phoneNumber')}
+            register={register('applicant.phoneNumber', { setValueAs: digitsOnly })}
             error={errors.applicant?.phoneNumber?.message}
             placeholder="09012345678"
           />
@@ -558,7 +559,7 @@ function ApplicantSection({
           <ViewModeField
             label="FAX"
             viewMode={viewMode}
-            register={register('applicant.faxNumber')}
+            register={register('applicant.faxNumber', { setValueAs: digitsOnly })}
             error={errors.applicant?.faxNumber?.message}
             placeholder="0312345678"
           />

--- a/src/components/plot-form/ContactsTab.tsx
+++ b/src/components/plot-form/ContactsTab.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { SelectItem } from '@/components/ui/select';
 import { AddressType } from '@komine/types';
+import { digitsOnly } from '@/lib/format';
 import { ChevronDown, ChevronUp, Trash2, Plus } from 'lucide-react';
 
 export function ContactsTab({
@@ -198,7 +199,7 @@ export function ContactsTab({
                   <Label htmlFor={`familyContacts.${index}.postalCode`}>郵便番号</Label>
                   <Input
                     id={`familyContacts.${index}.postalCode`}
-                    {...register(`familyContacts.${index}.postalCode`)}
+                    {...register(`familyContacts.${index}.postalCode`, { setValueAs: digitsOnly })}
                     placeholder="123-4567"
                     className={
                       errors.familyContacts?.[index]?.postalCode ? 'border-beni' : ''
@@ -231,7 +232,7 @@ export function ContactsTab({
                   <Label htmlFor={`familyContacts.${index}.phoneNumber`}>電話番号</Label>
                   <Input
                     id={`familyContacts.${index}.phoneNumber`}
-                    {...register(`familyContacts.${index}.phoneNumber`)}
+                    {...register(`familyContacts.${index}.phoneNumber`, { setValueAs: digitsOnly })}
                     className={
                       errors.familyContacts?.[index]?.phoneNumber ? 'border-beni' : ''
                     }
@@ -248,7 +249,7 @@ export function ContactsTab({
                   <Label htmlFor={`familyContacts.${index}.phoneNumber2`}>電話番号2</Label>
                   <Input
                     id={`familyContacts.${index}.phoneNumber2`}
-                    {...register(`familyContacts.${index}.phoneNumber2`)}
+                    {...register(`familyContacts.${index}.phoneNumber2`, { setValueAs: digitsOnly })}
                     className={
                       errors.familyContacts?.[index]?.phoneNumber2 ? 'border-beni' : ''
                     }
@@ -265,7 +266,7 @@ export function ContactsTab({
                   <Label htmlFor={`familyContacts.${index}.faxNumber`}>FAX</Label>
                   <Input
                     id={`familyContacts.${index}.faxNumber`}
-                    {...register(`familyContacts.${index}.faxNumber`)}
+                    {...register(`familyContacts.${index}.faxNumber`, { setValueAs: digitsOnly })}
                     className={errors.familyContacts?.[index]?.faxNumber ? 'border-beni' : ''}
                   />
                   {errors.familyContacts?.[index]?.faxNumber && (

--- a/src/components/plot-form/WorkBillingTab.tsx
+++ b/src/components/plot-form/WorkBillingTab.tsx
@@ -6,6 +6,7 @@ import { SelectItem } from '@/components/ui/select'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { DmSetting, AddressType } from '@komine/types'
+import { digitsOnly } from '@/lib/format'
 
 export function WorkBillingTab({
   register,
@@ -60,13 +61,13 @@ export function WorkBillingTab({
               />
               <ViewModeField
                 label="勤務先郵便番号"
-                register={register('workInfo.workPostalCode')}
+                register={register('workInfo.workPostalCode', { setValueAs: digitsOnly })}
                 error={errors.workInfo?.workPostalCode?.message}
                 placeholder="123-4567"
               />
               <ViewModeField
                 label="勤務先電話番号"
-                register={register('workInfo.workPhoneNumber')}
+                register={register('workInfo.workPhoneNumber', { setValueAs: digitsOnly })}
                 error={errors.workInfo?.workPhoneNumber?.message}
                 placeholder="03-1234-5678"
               />

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -82,6 +82,20 @@ export function formatPostalCode(value: string | null | undefined): string {
 }
 
 /**
+ * 入力値を数字のみに正規化する（保存用）。電話・郵便・FAX の入力欄で
+ * ハイフン等の非数字を除去してから保存・検証する（#280）。
+ *
+ * 共有 zod（@komine/types）が電話=max11/15・郵便=max7・workPhone=0始まり数字のみ
+ * regex を課しているため、ハイフン付き入力（"807-0842" 等）はそのままだと
+ * バリデーションエラー / P2000 になる。react-hook-form の `setValueAs` に渡し、
+ * フォーム state には数字のみを格納する（表示は formatPhoneNumber 等で別途整形）。
+ */
+export function digitsOnly(value: string | null | undefined): string {
+  if (!value) return '';
+  return value.replace(/[^\d]/g, '');
+}
+
+/**
  * 終納請求年月などの年月文字列を「YYYY年M月」に正規化する。
  * - null / undefined / 空 / "0" / 全ゼロ → fallback（既定 "未設定"）
  * - "YYYY年M月" / "YYYY年MM月" → 前ゼロを除いて返す


### PR DESCRIPTION
## 概要

「電話/郵便番号は数字のみで保存」を業務確認（2026-06-08）。types#46 で共有 zod の max を VarChar 幅へ縮小済み（郵便7 / 電話11 / 電話2=15、勤務先電話は `^0\d{9,10}$` の数字のみ regex）。frontend 側でハイフン付き入力を正規化し、バリデーションエラー / P2000 を防ぐ。Closes #280。

## 変更

### 1. 入力の正規化
- `format.ts` に `digitsOnly()` を追加（非数字を除去）。
- 区画フォームの電話/郵便/FAX **全14フィールド**に react-hook-form の `setValueAs: digitsOnly` を付与:
  - **顧客 / 申込者**（BasicInfoTab）: postalCode / registeredPostalCode / phoneNumber / faxNumber
  - **連絡先**（ContactsTab）: postalCode / phoneNumber / phoneNumber2 / faxNumber
  - **勤務先**（WorkBillingTab）: workPostalCode / workPhoneNumber
- `setValueAs` はフォーム state（＝検証・保存対象）を数字のみに正規化する。DOM 表示は入力のまま、詳細・帳票では従来どおり `formatPhoneNumber` / `formatPostalCode` でハイフン整形する既存規約に沿う。zodResolver は送信前に走るため、入力境界での正規化が必須（送信時整形では検証で弾かれてしまう）。

### 2. TYPES_REF bump
- frontend Dockerfile の `TYPES_REF` を types#46 マージコミット `df9802a` へ更新（types 更新は両 repo bump 必須。frontend は CI gate が無いため潜伏注意）。backend は #338 で対応済み。

## テスト

- `digitsOnly` 単体 + **正規化後の値が共有 zod（customerSchema / workInfoSchema）を通る / ハイフン付きは弾かれる**ことを検証（format.test.ts、32 passed）。
- plot-form 系 227 tests green、`tsc --noEmit` / `eslint` clean。

## ⚠️ 別件メモ（types repo の node_modules 汚染）

bump 先の types#46 (`df9802a`) も、ルートに `node_modules`（symlink, mode 120000）がコミットされたまま（#45 から未解消）。これは**本番 Docker ビルド（komine-local）の types ステージ `npm ci` を壊す潜在バグ**で、現行 pin (437b568) でも同じ。本 PR の範囲外（types repo 側で `git rm --cached node_modules` + .gitignore が必要・issue 未起票）だが、TYPES_REF を触ったため申し送り。

🤖 Generated with [Claude Code](https://claude.com/claude-code)