### PR TITLE
fix(plots): 台帳一覧・編集パンくずの区画No を LegacyAwareValue 化 (#164)

### DIFF
--- a/src/__tests__/components/plot-registry/plot-list-legacy-number.test.tsx
+++ b/src/__tests__/components/plot-registry/plot-list-legacy-number.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { PlotCardList } from '@/components/plot-registry/PlotCardList';
+import { LEGACY_VALUE_NOTE } from '@/lib/legacy-plot-display';
+import type { PlotListItem } from '@komine/types';
+
+/**
+ * #164: 台帳一覧の「区画No」に legacy-* 等の内部IDが生表示されない（主表示から排除）。
+ * displayNumber があれば業務番号を、無ければ legacy 値を「整備中」ミュート表示する。
+ */
+function makePlot(overrides: Partial<PlotListItem>): PlotListItem {
+  return {
+    id: overrides.id ?? 'p1',
+    plotNumber: 'legacy-0',
+    displayNumber: null,
+    areaName: '第1期',
+    paymentStatus: 'paid',
+    contractDate: null,
+    roles: [],
+    ...overrides,
+  } as unknown as PlotListItem;
+}
+
+describe('区画一覧の区画No表示 (#164)', () => {
+  const renderList = (plots: PlotListItem[]) =>
+    render(
+      <PlotCardList
+        plots={plots}
+        isLoading={false}
+        startIndex={0}
+        onPlotSelect={() => {}}
+        emptyState={<div>empty</div>}
+      />
+    );
+
+  it('displayNumber があれば業務番号をそのまま表示する', () => {
+    renderList([makePlot({ id: 'a', displayNumber: 'A-1', plotNumber: 'legacy-101' })]);
+    const el = screen.getByText('A-1');
+    expect(el).toBeInTheDocument();
+    // legacy 扱いされず（整備中ツールチップが付かない）
+    expect(el).not.toHaveAttribute('title', LEGACY_VALUE_NOTE);
+    // 生の legacy 値は主表示に出ない
+    expect(screen.queryByText('legacy-101')).not.toBeInTheDocument();
+  });
+
+  it('displayNumber 未設定の legacy 区画は「整備中」ミュート表示にする', () => {
+    renderList([makePlot({ id: 'b', displayNumber: null, plotNumber: 'legacy-3' })]);
+    const el = screen.getByText('legacy-3');
+    // 淡色・斜体 + 整備中ツールチップで業務番号と誤認させない
+    expect(el).toHaveAttribute('title', LEGACY_VALUE_NOTE);
+    expect(el.className).toContain('italic');
+  });
+});

--- a/src/app/(main)/plots/[id]/edit/page.tsx
+++ b/src/app/(main)/plots/[id]/edit/page.tsx
@@ -10,6 +10,7 @@ import { showError, showApiSuccess, showApiError } from '@/lib/toast';
 import PlotForm from '@/components/plot-form';
 import PageHeader from '@/components/page-header';
 import { DesktopOnlyGate } from '@/components/desktop-only-gate';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 import { usePlotDetail } from '@/hooks/usePlots';
 
 export default function EditPlotPage() {
@@ -67,7 +68,15 @@ export default function EditPlotPage() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
           <Link href={`/plots/${plotId}`} className="hover:text-matsu transition-colors truncate">
-            {plotDetail?.physicalPlot?.plotNumber || '区画詳細'}
+            {/* 表示用区画番号を優先・legacy-* は「整備中」ミュート表示 #158/#164 */}
+            {plotDetail?.physicalPlot ? (
+              <LegacyAwareValue
+                value={plotDetail.physicalPlot.displayNumber || plotDetail.physicalPlot.plotNumber}
+                kind="plotNumber"
+              />
+            ) : (
+              '区画詳細'
+            )}
           </Link>
           <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />

--- a/src/components/plot-registry/PlotCardList.tsx
+++ b/src/components/plot-registry/PlotCardList.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { StatusBadge } from '@/components/ui/status-badge';
 import { PAYMENT_STATUS_LABELS, PAYMENT_STATUS_VARIANTS } from './constants';
 import { formatContractDate, getRowBgColor, getSearchHitReason } from './utils';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 
 interface PlotCardListProps {
   plots: PlotListItem[];
@@ -66,7 +67,8 @@ export function PlotCardList({
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2 min-w-0">
                       <span className="font-mono text-matsu font-semibold text-sm truncate">
-                        {plot.displayNumber || plot.plotNumber}
+                        {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #158/#164 */}
+                        <LegacyAwareValue value={plot.displayNumber || plot.plotNumber} kind="plotNumber" />
                       </span>
                       {plot.areaName && (
                         <span className="text-xs text-hai truncate">{plot.areaName}</span>

--- a/src/components/plot-registry/PlotTable.tsx
+++ b/src/components/plot-registry/PlotTable.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/plots-column-widths';
 import { PAYMENT_STATUS_LABELS, PAYMENT_STATUS_VARIANTS } from './constants';
 import { formatPhoneNumber, formatDate } from '@/lib/format';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 import { formatContractDate, formatMoneyString, getRowBgColor, getSearchHitReason } from './utils';
 import { ColumnResizer } from './ColumnResizer';
 import { SortIndicator } from './SortIndicator';
@@ -266,9 +267,10 @@ export function PlotTable({
                     }}
                     aria-label={`${plot.displayNumber || plot.plotNumber} の詳細を開く`}
                   >
-                    {/* 表示用区画番号（grave_name_cd 由来）を優先。未設定時は plotNumber にフォールバック #158 */}
+                    {/* 表示用区画番号（grave_name_cd 由来）を優先。未設定時は plotNumber に
+                        フォールバックし、legacy-* 等の未正規化値は「整備中」ミュート表示にする #158/#164 */}
                     <td className={cellWrapClass('plotNumber', 'px-2 py-2 font-mono text-matsu font-medium text-xs underline-offset-2 group-hover:underline')} title={plot.displayNumber || plot.plotNumber}>
-                      {plot.displayNumber || plot.plotNumber}
+                      <LegacyAwareValue value={plot.displayNumber || plot.plotNumber} kind="plotNumber" />
                     </td>
                     <td className={cellWrapClass('areaName', 'px-2 py-2 text-xs text-hai')} title={plot.areaName || undefined}>
                       {plot.areaName || '-'}


### PR DESCRIPTION
## 概要

#164（台帳の区画Noに `legacy-101` 等の内部IDが出る）の**最後の残り**を解消し、台帳問い合わせ範囲で受け入れ条件を満たす。

これまで一覧（PlotTable/PlotCardList）・編集パンくずは `displayNumber || plotNumber` で **displayNumber 優先**だったが、`displayNumber` 未設定の legacy 区画では生の `plot_number`（`legacy-3` 等）をそのまま表示していた。

### 実DB調査
- physical_plots: **6255件**、うち `plot_number LIKE 'legacy-%'` = **6250件**（plot_number は移行設計上 legacy 維持・表示は display_number で行う #158）
- `display_number` 設定済み = **6249件**
- **legacy かつ display_number 無し = 1件**（`legacy-3` / area `1-99999999` の edge レコード）→ 一覧で生 `legacy-3` が出ていた

## 変更

詳細・パンくず・各ダイアログ（PR #279）と同じく `LegacyAwareValue` でラップし、未正規化値は「整備中（要確認）」のミュート表示に統一。backfill の網羅状態に依存せず、台帳のユーザー向け**主表示から `legacy-*` を排除**する（将来の移行にも強い）。

- `PlotTable` / `PlotCardList`: 区画No を `LegacyAwareValue` に
- 区画編集ページのパンくず: `displayNumber` 優先 + `LegacyAwareValue`
- 一覧の legacy 表示回帰テストを追加（`plot-list-legacy-number.test.tsx`）

## 受け入れ条件（#164）

- [x] 一覧・詳細の区画番号が業務番号（displayNumber）で表示される、または未整備が「整備中」で明示される
- [x] `legacy-*` 形式が台帳のユーザー向け主表示（一覧/詳細/パンくず/ダイアログ/編集）から排除される

## スコープ注記 → #283

`area_name`（エリア/期、`1-29` 等）の正式名称化は #166 のマッピング確定待ちで対象外（引き続き「整備中」表示）。
また**台帳以外の画面**（合祀/請求/入金/ゆうちょ/書類）は各 DTO に `displayNumber` が無く生 `plotNumber` を表示しており legacy-* がほぼ全件出る。これは backend の DTO 追加が必要な別スコープのため **#283** に分離起票した。

## テスト
- 新規 `plot-list-legacy-number.test.tsx` 2 passed / `tsc` clean / `eslint` clean

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)