### PR TITLE
feat(plots): 全画面の区画番号を displayNumber 優先表示にする (#283)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=df9802a74bd519b75768209d7a94f0730a09ee9b
+ARG TYPES_REF=7836c67e228a246c70cc3a541db6b93edd286bcf
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \

--- a/src/__tests__/components/billing-list-table.test.tsx
+++ b/src/__tests__/components/billing-list-table.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { BillingListTable } from '@/components/billing/billing-list-table';
+import type { Billing } from '@komine/types';
+import { LEGACY_VALUE_NOTE } from '@/lib/legacy-plot-display';
 
 /**
  * #171: 請求一覧の空状態テスト
@@ -41,5 +43,36 @@ describe('BillingListTable empty state', () => {
     );
     expect(screen.getByText('読み込み中...')).toBeInTheDocument();
     expect(screen.queryByText('発行済みの請求はありません')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * #283: 請求一覧の区画番号も displayNumber 優先・legacy-* はミュート表示。
+ */
+describe('BillingListTable の区画番号表示 (#283)', () => {
+  const makeBilling = (overrides: Partial<Billing>): Billing =>
+    ({
+      id: 'b1',
+      amount: 5000,
+      paidAmount: 0,
+      plotNumber: 'legacy-0',
+      displayNumber: null,
+      areaName: '第1期',
+      customer: null,
+      ...overrides,
+    } as unknown as Billing);
+
+  it('displayNumber があれば業務番号を表示し、生の legacy 値は出さない', () => {
+    render(<BillingListTable items={[makeBilling({ displayNumber: 'A-1', plotNumber: 'legacy-101' })]} />);
+    const el = screen.getByText('A-1');
+    expect(el).not.toHaveAttribute('title', LEGACY_VALUE_NOTE);
+    expect(screen.queryByText('legacy-101')).not.toBeInTheDocument();
+  });
+
+  it('displayNumber 未設定の legacy 区画は「整備中」ミュート表示にする', () => {
+    render(<BillingListTable items={[makeBilling({ displayNumber: null, plotNumber: 'legacy-3' })]} />);
+    const el = screen.getByText('legacy-3');
+    expect(el).toHaveAttribute('title', LEGACY_VALUE_NOTE);
+    expect(el.className).toContain('italic');
   });
 });

--- a/src/components/billing/billing-detail-dialog.tsx
+++ b/src/components/billing/billing-detail-dialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { BillingDetailResponse } from '@komine/types';
 import { getBillingById, BILLING_CATEGORY_LABELS, BILLING_RECORD_STATUS_LABELS } from '@/lib/api/billings';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 
 const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
 
@@ -105,7 +106,19 @@ function BillingDetailBody({ billing }: { billing: BillingDetailResponse }) {
               </span>
             }
           />
-          <Row label="区画" value={billing.plotNumber ? `${billing.plotNumber} (${billing.areaName ?? ''})` : '-'} />
+          {/* Row.value は React.ReactNode のため LegacyAwareValue を使用。displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+          <Row
+            label="区画"
+            value={
+              billing.displayNumber || billing.plotNumber ? (
+                <>
+                  <LegacyAwareValue value={billing.displayNumber || billing.plotNumber} kind="plotNumber" /> ({billing.areaName ?? ''})
+                </>
+              ) : (
+                '-'
+              )
+            }
+          />
           <Row label="顧客" value={billing.customer?.name ?? '-'} />
           <Row label="金額" value={<span className="tabular-nums">¥{billing.amount.toLocaleString('ja-JP')}</span>} />
           <Row label="入金済" value={<span className="tabular-nums">¥{billing.paidAmount.toLocaleString('ja-JP')}</span>} />

--- a/src/components/billing/billing-list-table.tsx
+++ b/src/components/billing/billing-list-table.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 import { Billing } from '@komine/types';
 import { BILLING_CATEGORY_LABELS, BILLING_RECORD_STATUS_LABELS } from '@/lib/api/billings';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 
 const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
 
@@ -114,7 +115,8 @@ export function BillingListTable({
               </td>
               {!hidePlotColumns && (
                 <td className="px-2 md:px-4 py-3 text-sm text-sumi hidden md:table-cell">
-                  {b.plotNumber ?? '-'}
+                  {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                  <LegacyAwareValue value={b.displayNumber || b.plotNumber} kind="plotNumber" emptyText="-" />
                   {b.areaName && (
                     <span className="text-xs text-hai ml-1">({b.areaName})</span>
                   )}

--- a/src/components/collective-burial/DetailView.tsx
+++ b/src/components/collective-burial/DetailView.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 import {
   CollectiveBurialDetail,
   BillingStatus,
@@ -98,7 +99,8 @@ export default function CollectiveBurialDetailView({
             <div>
               <h2 className="font-mincho text-xl font-semibold text-sumi tracking-wide">合祀詳細</h2>
               <p className="text-sm text-hai mt-0.5">
-                区画: {data.plotNumber} / {data.areaName}
+                {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                区画: <LegacyAwareValue value={data.displayNumber || data.plotNumber} kind="plotNumber" /> / {data.areaName}
               </p>
             </div>
             <span className={`px-4 py-1.5 rounded-full text-sm font-medium ${BILLING_STATUS_COLORS[data.billingStatus as BillingStatus]}`}>
@@ -145,7 +147,10 @@ export default function CollectiveBurialDetailView({
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 md:gap-6">
                   <div>
                     <Label className="text-sm text-hai">区画番号</Label>
-                    <p className="font-semibold text-sumi mt-1">{data.plotNumber}</p>
+                    {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                    <p className="font-semibold text-sumi mt-1">
+                      <LegacyAwareValue value={data.displayNumber || data.plotNumber} kind="plotNumber" />
+                    </p>
                   </div>
                   <div>
                     <Label className="text-sm text-hai">区域</Label>

--- a/src/components/collective-burial/ListView.tsx
+++ b/src/components/collective-burial/ListView.tsx
@@ -27,6 +27,7 @@ import {
   calculateScheduledCollectiveBurialDate,
 } from '@/lib/collective-burial-rules';
 import PageHeader from '@/components/page-header';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 
 interface CollectiveBurialListViewProps {
   onBack?: () => void;
@@ -592,7 +593,8 @@ export default function CollectiveBurialListView({
                                     className="font-semibold text-matsu hover:text-matsu-700 hover:underline underline-offset-2"
                                     title="台帳詳細を開く"
                                   >
-                                    {record.plotNumber}
+                                    {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                                    <LegacyAwareValue value={record.displayNumber || record.plotNumber} kind="plotNumber" />
                                   </Link>
                                 </td>
                                 <td className="px-2 md:px-4 py-3 text-center text-sm text-sumi hidden md:table-cell">

--- a/src/components/document-detail-view.tsx
+++ b/src/components/document-detail-view.tsx
@@ -5,6 +5,7 @@
  */
 
 import { Button } from '@/components/ui/button';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 import {
   useDocumentDetail,
   canRegenerateDocument,
@@ -279,7 +280,8 @@ export function DocumentDetailView({
                   区画
                 </dt>
                 <dd className="text-sumi">
-                  {data.contractPlot.physicalPlot.areaName} - {data.contractPlot.physicalPlot.plotNumber}
+                  {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                  {data.contractPlot.physicalPlot.areaName} - <LegacyAwareValue value={data.contractPlot.physicalPlot.displayNumber || data.contractPlot.physicalPlot.plotNumber} kind="plotNumber" />
                 </dd>
               </div>
             ) : (

--- a/src/components/document-form.tsx
+++ b/src/components/document-form.tsx
@@ -168,7 +168,7 @@ function buildAutoFillData(
       base.contractNumber = `CON-${new Date().getFullYear()}-${String(Date.now()).slice(-4)}`;
       base.contractDate = plotDetail.contractDate || today;
       base.contractorName = customerName;
-      base.plotNumber = `${plot.areaName} ${plot.plotNumber}`;
+      base.plotNumber = `${plot.areaName} ${plot.displayNumber || plot.plotNumber}`;
       base.terms = '';
       break;
     }
@@ -176,7 +176,7 @@ function buildAutoFillData(
       const now = new Date();
       base.permitNumber = plotDetail.permitNumber || '';
       base.permitType = '普通墓地';
-      base.plotNumber = `${plot.areaName} ${plot.plotNumber}`;
+      base.plotNumber = `${plot.areaName} ${plot.displayNumber || plot.plotNumber}`;
       if (plot.areaSqm) base.area = String(plot.areaSqm);
       base.issueYear = String(now.getFullYear());
       base.issueMonth = String(now.getMonth() + 1);
@@ -334,7 +334,7 @@ export function DocumentForm({
       ? getPrimaryCustomer(plotDetail)?.name || ''
       : '';
     const plotNumber = plotDetail
-      ? `${plotDetail.physicalPlot.areaName} ${plotDetail.physicalPlot.plotNumber}`
+      ? `${plotDetail.physicalPlot.areaName} ${plotDetail.physicalPlot.displayNumber || plotDetail.physicalPlot.plotNumber}`
       : '';
     const nameSuffix = customerName
       ? `_${customerName}_${plotNumber}`

--- a/src/components/payment/payment-list-table.tsx
+++ b/src/components/payment/payment-list-table.tsx
@@ -2,6 +2,7 @@
 
 import { Payment } from '@komine/types';
 import { BILLING_CATEGORY_LABELS } from '@/lib/api/billings';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 
 const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
 
@@ -99,7 +100,8 @@ export function PaymentListTable({
               </td>
               {!hidePlotColumns && (
                 <td className="px-2 md:px-4 py-3 text-sm text-sumi hidden lg:table-cell">
-                  {p.plotNumber ?? '-'}
+                  {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                  <LegacyAwareValue value={p.displayNumber || p.plotNumber} kind="plotNumber" emptyText="-" />
                 </td>
               )}
               <td className="px-2 md:px-4 py-3 text-sm text-sumi hidden sm:table-cell">

--- a/src/components/yucho/YuchoManagement.tsx
+++ b/src/components/yucho/YuchoManagement.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { EmptyState } from '@/components/ui/empty-state';
 import { StatCard } from '@/components/ui/stat-card';
 import { BaseDialog } from '@/components/shared/dialogs/BaseDialog';
+import { LegacyAwareValue } from '@/components/legacy-aware-value';
 import { showSuccess, showError } from '@/lib/toast';
 import { useAsyncData } from '@/hooks/useAsyncData';
 import {
@@ -388,7 +389,10 @@ function ManagementTable({ items, year }: { items: YuchoBillingItem[]; year: num
             <tbody>
               {items.map((item) => (
                 <tr key={item.sourceId} className="border-t border-gin hover:bg-kinari/50">
-                  <td className="px-4 py-3 font-mono text-sumi">{item.plotNumber}</td>
+                  <td className="px-4 py-3 font-mono text-sumi">
+                    {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                    <LegacyAwareValue value={item.displayNumber || item.plotNumber} kind="plotNumber" />
+                  </td>
                   <td className="px-4 py-3 text-sumi">{item.areaName}</td>
                   <td className="px-4 py-3 text-sumi">
                     <div>{item.customerName ?? '—'}</div>
@@ -414,7 +418,10 @@ function ManagementTable({ items, year }: { items: YuchoBillingItem[]; year: num
           >
             <div className="flex items-start justify-between gap-2 mb-2">
               <div className="min-w-0">
-                <p className="font-mono text-xs text-hai">{item.plotNumber}</p>
+                {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                <p className="font-mono text-xs text-hai">
+                  <LegacyAwareValue value={item.displayNumber || item.plotNumber} kind="plotNumber" />
+                </p>
                 <p className="text-sm text-sumi truncate">{item.customerName ?? '—'}</p>
                 <p className="text-[10px] text-hai truncate">{item.customerNameKana ?? ''}</p>
               </div>
@@ -471,7 +478,10 @@ function CollectiveTable({ items, year }: { items: YuchoBillingItem[]; year: num
             <tbody>
               {items.map((item) => (
                 <tr key={item.sourceId} className="border-t border-gin hover:bg-kinari/50">
-                  <td className="px-4 py-3 font-mono text-sumi">{item.plotNumber}</td>
+                  <td className="px-4 py-3 font-mono text-sumi">
+                    {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                    <LegacyAwareValue value={item.displayNumber || item.plotNumber} kind="plotNumber" />
+                  </td>
                   <td className="px-4 py-3 text-sumi">
                     <div>{item.customerName ?? '—'}</div>
                     <div className="text-xs text-hai">{item.customerNameKana ?? ''}</div>
@@ -496,7 +506,10 @@ function CollectiveTable({ items, year }: { items: YuchoBillingItem[]; year: num
           >
             <div className="flex items-start justify-between gap-2 mb-2">
               <div className="min-w-0">
-                <p className="font-mono text-xs text-hai">{item.plotNumber}</p>
+                {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
+                <p className="font-mono text-xs text-hai">
+                  <LegacyAwareValue value={item.displayNumber || item.plotNumber} kind="plotNumber" />
+                </p>
                 <p className="text-sm text-sumi truncate">{item.customerName ?? '—'}</p>
                 <p className="text-[10px] text-hai truncate">{item.customerNameKana ?? ''}</p>
               </div>

--- a/src/lib/api/collective-burials.ts
+++ b/src/lib/api/collective-burials.ts
@@ -48,6 +48,7 @@ export interface CollectiveBurialListItem {
   id: string;
   contractPlotId: string;
   plotNumber: string;
+  displayNumber?: string | null;
   areaName: string;
   contractDate: string;
   applicantName: string | null;

--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -53,6 +53,7 @@ export interface DocumentListItem {
   contractPlot: {
     id: string;
     plotNumber: string;
+    displayNumber?: string | null;
     areaName: string;
   } | null;
   customer: {
@@ -90,6 +91,7 @@ export interface DocumentDetail {
     physicalPlot: {
       id: string;
       plotNumber: string;
+      displayNumber?: string | null;
       areaName: string;
     };
   } | null;

--- a/src/lib/api/yucho.ts
+++ b/src/lib/api/yucho.ts
@@ -28,6 +28,7 @@ export interface YuchoBillingItem {
   sourceId: string;
   contractPlotId: string;
   plotNumber: string;
+  displayNumber?: string | null;
   areaName: string;
   contractDate: string;
   customerId: string | null;


### PR DESCRIPTION
## 概要

#283（全画面で legacy-* 区画番号表示を消す）の **frontend 縦串（最終）**。台帳以外の画面（合祀/請求/入金/ゆうちょ/書類）も `legacy-{grave_cd}` の `plotNumber` でなく表示用区画番号 `displayNumber`（#158）を優先表示し、未正規化の legacy 値は `LegacyAwareValue` で「整備中」ミュート表示に統一する。

依存: types#47（merged）+ backend#353（DTOに displayNumber を返す）。frontend は `displayNumber || plotNumber` で表示するため、displayNumber 未配備でも従来どおり plotNumber にフォールバックする（非破壊）。

## 変更

**表示サイト（LegacyAwareValue）**
- 合祀: `DetailView`（ヘッダー＋区画番号フィールド）/ `ListView`（一覧リンク）
- 請求: `billing-list-table` / `billing-detail-dialog`（Row.value は ReactNode なので LegacyAwareValue）
- 入金: `payment-list-table`
- ゆうちょ: `YuchoManagement`（管理料・合祀の PC表×2 + モバイルカード×2）
- 書類: `document-detail-view`

**文字列文脈（displayNumber || plotNumber）**
- `document-form`: 契約書・許可証テンプレートの区画番号、ダウンロードファイル名 suffix（印字される番号なので legacy 抑制効果大）

**型・設定**
- ローカル型 `collective-burials.ts` / `yucho.ts` / `documents.ts` に `displayNumber?: string | null`
- Dockerfile `TYPES_REF` を types#47 (`7836c67`) へ bump

## テスト
- 請求一覧の displayNumber 優先 / legacy ミュートの回帰テストを追加
- `tsc` clean / `eslint` clean / collective・billing・payment・yucho・document 系テスト green

## これで #283 完了
台帳（#164 で対応済み）に加え、全機能画面で legacy-* 区画番号が主表示から排除される。

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)