### PR TITLE
chore: TYPES_REF を types#48 (node_modules 追跡解除済) へ bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=7836c67e228a246c70cc3a541db6b93edd286bcf
+ARG TYPES_REF=38f5623d2b0b1f3e49f7f74fca0ed6abe03891c1
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \


### PR DESCRIPTION
## 概要

types#48 で、誤コミットされていた `node_modules` シンボリックリンクを追跡解除した。本番 Docker ビルドが汚染のない types を clone するよう、frontend Dockerfile の `TYPES_REF` を types#48 (`38f5623`) へ bump する。

型内容は #47 と同一（symlink 除去のみ）。frontend は Docker gate が無いため潜伏しやすく、明示的に追従しておく。

🤖 Generated with [Claude Code](https://claude.com/claude-code)