### PR TITLE
feat(plots): 区画詳細に「期」を表示・一覧エリア列をLegacyAware化・残数検索文言を是正 (#285 #166 #182 #173)

### DIFF
--- a/src/__tests__/components/plot-registry/plot-list-legacy-number.test.tsx
+++ b/src/__tests__/components/plot-registry/plot-list-legacy-number.test.tsx
@@ -49,4 +49,19 @@ describe('区画一覧の区画No表示 (#164)', () => {
     expect(el).toHaveAttribute('title', LEGACY_VALUE_NOTE);
     expect(el.className).toContain('italic');
   });
+
+  // #166: エリア（区画名）列も legacy 値を「整備中」ミュート表示にする
+  it('エリアが正規化済みの区画名ならそのまま表示する', () => {
+    renderList([makePlot({ id: 'c', displayNumber: 'A-1', areaName: '凛A' })]);
+    const el = screen.getByText('凛A');
+    expect(el).toBeInTheDocument();
+    expect(el).not.toHaveAttribute('title', LEGACY_VALUE_NOTE);
+  });
+
+  it('エリアが legacy 内部コード（"1-29"）なら「整備中」ミュート表示にする', () => {
+    renderList([makePlot({ id: 'd', displayNumber: 'A-1', areaName: '1-29' })]);
+    const el = screen.getByText('1-29');
+    expect(el).toHaveAttribute('title', LEGACY_VALUE_NOTE);
+    expect(el.className).toContain('italic');
+  });
 });

--- a/src/__tests__/lib/section-period.test.ts
+++ b/src/__tests__/lib/section-period.test.ts
@@ -1,0 +1,78 @@
+import {
+  resolvePeriodFromAreaName,
+  buildSectionPeriodMap,
+  PERIOD_NAMES,
+} from '@/lib/section-period';
+import type { SectionNameMasterItem } from '@/lib/api/masters';
+
+function sn(name: string, period: string, overrides: Partial<SectionNameMasterItem> = {}): SectionNameMasterItem {
+  return {
+    id: 1,
+    code: name,
+    name,
+    description: null,
+    sortOrder: null,
+    isActive: true,
+    period,
+    ...overrides,
+  };
+}
+
+describe('resolvePeriodFromAreaName', () => {
+  const master: SectionNameMasterItem[] = [
+    sn('凛A', '第4期'),
+    sn('つながり', '第4期'),
+    sn('樹木葬', '第3期樹林部'),
+    sn('吉相C', '第1期'),
+  ];
+
+  it('area_name 自体が期名ならそのまま返す（手動作成区画など）', () => {
+    for (const p of PERIOD_NAMES) {
+      expect(resolvePeriodFromAreaName(p, master)).toBe(p);
+    }
+  });
+
+  it('区画名マスタに登録があればその期を返す', () => {
+    expect(resolvePeriodFromAreaName('凛A', master)).toBe('第4期');
+    expect(resolvePeriodFromAreaName('樹木葬', master)).toBe('第3期樹林部');
+    expect(resolvePeriodFromAreaName('吉相C', master)).toBe('第1期');
+  });
+
+  it('前後の空白を無視して解決する', () => {
+    expect(resolvePeriodFromAreaName('  凛A  ', master)).toBe('第4期');
+    expect(resolvePeriodFromAreaName(' 第2期 ', master)).toBe('第2期');
+  });
+
+  it('レガシー未正規化値（"1-29" 等）やマスタ未登録は null', () => {
+    expect(resolvePeriodFromAreaName('1-29', master)).toBeNull();
+    expect(resolvePeriodFromAreaName('legacy-101', master)).toBeNull();
+    expect(resolvePeriodFromAreaName('存在しない区画', master)).toBeNull();
+  });
+
+  it('空値・マスタ未取得時は null', () => {
+    expect(resolvePeriodFromAreaName(null, master)).toBeNull();
+    expect(resolvePeriodFromAreaName(undefined, master)).toBeNull();
+    expect(resolvePeriodFromAreaName('', master)).toBeNull();
+    expect(resolvePeriodFromAreaName('凛A', null)).toBeNull();
+    expect(resolvePeriodFromAreaName('凛A', [])).toBeNull();
+  });
+});
+
+describe('buildSectionPeriodMap', () => {
+  it('name → period のマップを作る', () => {
+    const map = buildSectionPeriodMap([sn('凛A', '第4期'), sn('吉相C', '第1期')]);
+    expect(map.get('凛A')).toBe('第4期');
+    expect(map.get('吉相C')).toBe('第1期');
+  });
+
+  it('period が空のエントリは除外する', () => {
+    const map = buildSectionPeriodMap([sn('凛A', '第4期'), sn('壊れ', '')]);
+    expect(map.has('壊れ')).toBe(false);
+    expect(map.size).toBe(1);
+  });
+
+  it('null/undefined は空マップ', () => {
+    expect(buildSectionPeriodMap(null).size).toBe(0);
+    expect(buildSectionPeriodMap(undefined).size).toBe(0);
+  });
+});

--- a/src/components/plot-availability-management.tsx
+++ b/src/components/plot-availability-management.tsx
@@ -447,7 +447,7 @@ export default function PlotAvailabilityManagement() {
               <Input
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder={displayMode === 'section' ? "区画名・コードで検索…（期マスタ整備中）" : "面積・タイプ・コードで検索…（期マスタ整備中）"}
+                placeholder={displayMode === 'section' ? "区画名・期で検索…" : "面積・タイプで検索…"}
                 className="flex-1 sm:max-w-md"
               />
               <Button

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -22,8 +22,9 @@ import {
 } from '@komine/types';
 import { usePlotDetail } from '@/hooks/usePlots';
 import { useMasters } from '@/hooks/useMasters';
-import type { MasterItem, TaxTypeMasterItem } from '@/lib/api/masters';
+import type { MasterItem, TaxTypeMasterItem, SectionNameMasterItem } from '@/lib/api/masters';
 import { resolveMasterName, LEGACY_FEE_CODE_MAP } from '@/lib/master-resolve';
+import { resolvePeriodFromAreaName } from '@/lib/section-period';
 import { getPlotSizeLabel } from '@/types/plot-constants';
 import { calculateScheduledCollectiveBurialDate } from '@/lib/collective-burial-rules';
 import { isEmptyDisplayValue, EMPTY_LABELS, type EmptyKind } from '@/lib/empty-display';
@@ -312,7 +313,16 @@ function CustomerInfoSection({
   );
 }
 
-function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
+function BasicInfoTab({
+  plot,
+  sectionNames,
+}: {
+  plot: PlotDetailResponse;
+  sectionNames: SectionNameMasterItem[];
+}) {
+  // 期は area_name から区画名マスタ経由で導出する（DBに独立カラムが無い設計 #166/#285）
+  const period = resolvePeriodFromAreaName(plot.physicalPlot.areaName, sectionNames);
+  const areaIsLegacy = isLegacyAreaName(plot.physicalPlot.areaName);
   const contractorRole = plot.roles.find(r => r.role === ContractRole.Contractor);
   const applicantRole = plot.roles.find(r => r.role === ContractRole.Applicant);
   const primaryRole = contractorRole ?? plot.roles[0];
@@ -344,9 +354,25 @@ function BasicInfoTab({ plot }: { plot: PlotDetailResponse }) {
           }
         />
         <InfoField
-          label="エリア"
+          label="期"
+          // 期は区画名マスタ（SectionNameMaster.period）から導出（#285）
+          value={period ?? undefined}
+          hint={
+            period
+              ? undefined
+              : areaIsLegacy
+                ? '整備中（レガシー移行値・要確認）'
+                : '区画名マスタから期を判定できません（要確認）'
+          }
+        />
+        <InfoField
+          label="区画名（エリア）"
           value={plot.physicalPlot.areaName}
-          hint={isLegacyAreaName(plot.physicalPlot.areaName) ? '整備中（レガシー移行値・要確認）' : undefined}
+          hint={
+            areaIsLegacy
+              ? '整備中（レガシー移行値・要確認）'
+              : '霊園の区画名（例: 凛A）。上の「期」はこの区画名から判定'
+          }
         />
         <InfoField
           label="物理区画面積 (㎡)"
@@ -854,7 +880,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
   const { plot, isLoading, error, refresh } = usePlotDetail(plotId);
   // 名称解決は無効化済みマスタを含む全件で行う（#238: 無効化しても既存データの表示を維持）
   const { allMasters } = useMasters();
-  const { calcTypes, taxTypes, billingTypes, paymentMethods, contractors, directions, positions } =
+  const { calcTypes, taxTypes, billingTypes, paymentMethods, contractors, directions, positions, sectionNames } =
     allMasters;
   const feeMasters: FeeMasters = { calcTypes, taxTypes, billingTypes, paymentMethods };
 
@@ -1179,7 +1205,7 @@ export default function PlotDetailView({ plotId, onEdit, onBack, onDelete, onRes
         </TabsList>
 
         <TabsContent value="basic" className="mt-4 md:mt-6">
-          <BasicInfoTab plot={plot} />
+          <BasicInfoTab plot={plot} sectionNames={sectionNames} />
         </TabsContent>
 
         <TabsContent value="fee" className="mt-4 md:mt-6">

--- a/src/components/plot-registry/PlotCardList.tsx
+++ b/src/components/plot-registry/PlotCardList.tsx
@@ -71,7 +71,10 @@ export function PlotCardList({
                         <LegacyAwareValue value={plot.displayNumber || plot.plotNumber} kind="plotNumber" />
                       </span>
                       {plot.areaName && (
-                        <span className="text-xs text-hai truncate">{plot.areaName}</span>
+                        // エリア（区画名）。legacy-* / "1-29" 等の未正規化値は「整備中」ミュート表示 #166
+                        <span className="text-xs truncate">
+                          <LegacyAwareValue value={plot.areaName} kind="areaName" className="text-hai" />
+                        </span>
                       )}
                     </div>
                     <div className="flex items-center gap-1 shrink-0">

--- a/src/components/plot-registry/PlotTable.tsx
+++ b/src/components/plot-registry/PlotTable.tsx
@@ -272,8 +272,9 @@ export function PlotTable({
                     <td className={cellWrapClass('plotNumber', 'px-2 py-2 font-mono text-matsu font-medium text-xs underline-offset-2 group-hover:underline')} title={plot.displayNumber || plot.plotNumber}>
                       <LegacyAwareValue value={plot.displayNumber || plot.plotNumber} kind="plotNumber" />
                     </td>
+                    {/* エリア（区画名）。legacy-* / "1-29" 等の未正規化値は「整備中」ミュート表示にする #166 */}
                     <td className={cellWrapClass('areaName', 'px-2 py-2 text-xs text-hai')} title={plot.areaName || undefined}>
-                      {plot.areaName || '-'}
+                      <LegacyAwareValue value={plot.areaName} kind="areaName" />
                     </td>
                     <td className="px-2 py-2 align-top">
                       <div className={isColumnExpanded(columnWidths, 'customerName') ? '' : 'truncate'}>

--- a/src/lib/section-period.ts
+++ b/src/lib/section-period.ts
@@ -1,0 +1,58 @@
+/**
+ * 区画名（area_name）から期（第N期）を導出する。
+ *
+ * 期はDBに独立カラムを持たず、区画名マスタ（SectionNameMaster.period）から導出する設計（#166）。
+ * バックエンドの inventoryService.resolvePeriod と同じ規則をフロントでも再利用し、
+ * 区画詳細・一覧で「期」を表示できるようにする（#285 / #166）。
+ *
+ * 解決規則（backend resolvePeriod と一致）:
+ *   1. area_name 自体が期名（"第1期" 等。手動作成区画など）ならそのまま採用。
+ *   2. 区画名マスタに登録があればその period。
+ *   3. いずれにも該当しなければ未分類（このフロント関数では null を返す）。
+ *
+ * バックエンドが area_name を正規化（実区画名へ backfill）済みなら、
+ * 区画名マスタ経由で正しい期が解決される。未正規化のレガシー値（"1-29" 等）は
+ * マスタに無いため null となり、呼び出し側で「整備中／未分類」表示にできる。
+ */
+
+import type { SectionNameMasterItem } from '@/lib/api/masters';
+
+/** 期の正式名称（backend inventoryService.PERIODS と一致）。表示順の正本も兼ねる。 */
+export const PERIOD_NAMES = ['第1期', '第2期', '第3期', '第3期樹林部', '第4期'] as const;
+
+/** 未分類バケットのラベル（backend UNCLASSIFIED_PERIOD と一致）。 */
+export const UNCLASSIFIED_PERIOD = 'その他';
+
+const PERIOD_NAME_SET: ReadonlySet<string> = new Set(PERIOD_NAMES);
+
+/**
+ * 区画名マスタ（name → period）の解決用マップを作る。
+ * is_active のフィルタは呼び出し側（useMasters の active 系）で済んでいる前提だが、
+ * allMasters を渡しても害は無い（同名の最新 period で上書き）。
+ */
+export function buildSectionPeriodMap(
+  sectionNames: SectionNameMasterItem[] | null | undefined,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const s of sectionNames ?? []) {
+    if (s.name && s.period) map.set(s.name, s.period);
+  }
+  return map;
+}
+
+/**
+ * 区画名から期を解決する。導出できない場合（レガシー未正規化値・マスタ未登録）は null。
+ *
+ * @param areaName  PhysicalPlot.areaName（実区画名 例 "凛A"、またはレガシー "1-29"）
+ * @param sectionNames 区画名マスタ（useMasters().sectionNames など）
+ * @returns 期名（"第4期" 等）、解決不能なら null
+ */
+export function resolvePeriodFromAreaName(
+  areaName: string | null | undefined,
+  sectionNames: SectionNameMasterItem[] | null | undefined,
+): string | null {
+  if (!areaName) return null;
+  const name = areaName.trim();
+  if (PERIOD_NAME_SET.has(name)) return name;
+  return buildSectionPeriodMap(sectionNames).get(name) ?? null;
+}


### PR DESCRIPTION
## 概要

区画の「期（第N期）」表示と、台帳一覧のエリア（区画名）legacy 表示を整備する。期は DB に独立カラムを持たず区画名マスタ（`SectionNameMaster.period`）から導出する設計（#166）のため、backend `inventoryService.resolvePeriod` と同じ規則をフロントでも再利用する共通ロジック `src/lib/section-period.ts` を追加した。

## 変更内容

### #285 区画詳細に「期」を表示
- 「区画情報」に `期` 項目を追加。`area_name` → 区画名マスタ経由で第N期を導出して表示。
- 「エリア」ラベルを「区画名（エリア）」に明確化し、期との関係を hint で補足。
- 導出不能時（レガシー未正規化値 / マスタ未登録）は hint で「整備中・要確認」を明示。

### #166 台帳一覧の関係性
- 一覧（`PlotTable` / `PlotCardList`）のエリア列を `LegacyAwareValue` 化し、`legacy-*` / `"1-29"` 等の未正規化値を「整備中」ミュート表示で業務値と区別。
- 詳細タイトル・パンくずは既に displayNumber 優先（#283/#164）。期の独立表示は本 PR の詳細表示で担保。

### #182 / #173 区画残数管理
- 検索プレースホルダから古い「（期マスタ整備中）」を除去（`区画名・期で検索…` / `面積・タイプで検索…`）。
- 本番 `backfill:area-name` 適用 + backend #166/PR#352 で期別集計が「その他」バケット込みで上部総数と整合済み。期別カードは backend の整合済みサマリーをそのまま描画するため、フロント側の追加修正は不要（文言のみ是正）。

## テスト
- `section-period.test.ts` 8件（期解決・マップ構築）
- 一覧エリア legacy 表示 2件追加
- lib/registry/types スイート **350 件 green**、lint clean、tsc（変更ファイル）clean

Closes #285
Closes #166
Closes #182
Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
