### PR TITLE
合祀年数の標準選択肢を backend マスタ参照に置換 (#289)

### DIFF
--- a/src/__tests__/components/plot-form/burial-info-tab.test.tsx
+++ b/src/__tests__/components/plot-form/burial-info-tab.test.tsx
@@ -174,6 +174,20 @@ describe('BurialInfoTab', () => {
     expect(screen.getByText(/自動判定: 33年（通常区画 → 33年）/)).toBeInTheDocument();
   });
 
+  it('合祀年数の標準チップ（マスタ由来・24年含む）で有効期間を設定できる（#289）', async () => {
+    const user = userEvent.setup();
+    render(<BurialInfoTabHost />);
+
+    await user.click(screen.getByLabelText('合祀対象区画'));
+
+    const input = screen.getByLabelText(/有効期間/) as HTMLInputElement;
+    expect(input.value).toBe('33');
+
+    // マスタ未取得時は標準値（13/15/24/33）がフォールバックでチップに並ぶ
+    await user.click(screen.getByRole('button', { name: '24年' }));
+    expect(input.value).toBe('24');
+  });
+
   it('「墓石情報を追加」で墓石情報セクションが展開される', async () => {
     const user = userEvent.setup();
     render(<BurialInfoTabHost />);

--- a/src/__tests__/components/plot-form/test-helpers.tsx
+++ b/src/__tests__/components/plot-form/test-helpers.tsx
@@ -16,6 +16,7 @@ export const emptyMasterData: MasterData = {
   sectionNames: [],
   relationships: [],
   contractors: [],
+  validityPeriods: [],
   isLoading: false,
 };
 

--- a/src/__tests__/hooks/use-masters-inactive.test.ts
+++ b/src/__tests__/hooks/use-masters-inactive.test.ts
@@ -25,6 +25,7 @@ jest.mock('@/lib/api', () => ({
   getConstructionTypes: jest.fn(),
   getSectionNames: jest.fn(),
   getContractors: jest.fn(),
+  getValidityPeriods: jest.fn(),
 }));
 
 const mastersData: AllMastersData = {
@@ -43,6 +44,7 @@ const mastersData: AllMastersData = {
   contractor: [],
   direction: [],
   position: [],
+  validityPeriod: [],
 };
 
 describe('useMasters 2系統アクセサ (#238)', () => {

--- a/src/__tests__/lib/collective-burial-rules.test.ts
+++ b/src/__tests__/lib/collective-burial-rules.test.ts
@@ -7,6 +7,8 @@ import {
   calculateScheduledCollectiveBurialDate,
   JURIN_RULE_TRANSITION_DATE,
   VALIDITY_RULE_TABLE,
+  STANDARD_VALIDITY_YEARS,
+  getValidityYearOptions,
 } from '@/lib/collective-burial-rules';
 
 describe('collective-burial-rules', () => {
@@ -61,6 +63,43 @@ describe('collective-burial-rules', () => {
         years: 33,
         yearsBeforeTransition: 33,
       });
+    });
+  });
+
+  describe('getValidityYearOptions（#289 合祀年数マスタ参照）', () => {
+    it('マスタの code から年数を昇順・重複排除で返す', () => {
+      const master = [
+        { code: '33', name: '33年' },
+        { code: '13', name: '13年' },
+        { code: '24', name: '24年' },
+        { code: '15', name: '15年' },
+        { code: '13', name: '13年（重複）' },
+      ];
+      expect(getValidityYearOptions(master)).toEqual([13, 15, 24, 33]);
+    });
+
+    it('code が非数値でも name から年数を拾う', () => {
+      const master = [
+        { code: 'VP_13', name: '13年' },
+        { code: null, name: '24年' },
+      ];
+      expect(getValidityYearOptions(master)).toEqual([13, 24]);
+    });
+
+    it('マスタが空 / undefined / null は標準値にフォールバックする', () => {
+      expect(getValidityYearOptions([])).toEqual(STANDARD_VALIDITY_YEARS);
+      expect(getValidityYearOptions(undefined)).toEqual(STANDARD_VALIDITY_YEARS);
+      expect(getValidityYearOptions(null)).toEqual(STANDARD_VALIDITY_YEARS);
+    });
+
+    it('年数を一切取り出せない場合も標準値にフォールバックする', () => {
+      const master = [{ code: 'x', name: '不明' }];
+      expect(getValidityYearOptions(master)).toEqual(STANDARD_VALIDITY_YEARS);
+    });
+
+    it('標準値フォールバックには 24 年が含まれる（旧ハードコードに無かった値）', () => {
+      expect(STANDARD_VALIDITY_YEARS).toContain(24);
+      expect(getValidityYearOptions([])).toContain(24);
     });
   });
 

--- a/src/components/masters-management.tsx
+++ b/src/components/masters-management.tsx
@@ -55,6 +55,7 @@ const MASTER_TYPES: MasterTypeConfig[] = [
   { key: 'recipient-type', label: '受取人タイプ', dataKey: 'recipientType' },
   { key: 'construction-type', label: '工事タイプ', dataKey: 'constructionType' },
   { key: 'section-name', label: '区画名', dataKey: 'sectionName' },
+  { key: 'validity-period', label: '合祀年数', dataKey: 'validityPeriod' },
 ];
 
 export default function MastersManagement() {

--- a/src/components/plot-form/BurialInfoTab.tsx
+++ b/src/components/plot-form/BurialInfoTab.tsx
@@ -14,8 +14,58 @@ import {
   inferValidityPeriodYears,
   summarizeValidityRule,
   calculateScheduledCollectiveBurialDate,
+  getValidityYearOptions,
 } from '@/lib/collective-burial-rules';
 import { formatDate } from '@/lib/format';
+
+/**
+ * 合祀年数の標準値（マスタ由来）をワンタップで選べるクイック選択チップ（#289）。
+ * 自由入力（例外指定 Q17）は維持しつつ、標準年数の語彙をマスタから供給する。
+ */
+function ValidityYearChips({
+  options,
+  value,
+  onPick,
+  onClear,
+}: {
+  options: number[];
+  value: number | null | undefined;
+  onPick: (year: number) => void;
+  onClear?: () => void;
+}) {
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+      <span className="text-xs text-hai">標準（マスタ）:</span>
+      {options.map((year) => {
+        const active = value === year;
+        return (
+          <button
+            key={year}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onPick(year)}
+            className={`px-2 py-0.5 rounded-full border text-xs transition-colors ${
+              active
+                ? 'bg-matsu text-white border-matsu'
+                : 'bg-white text-sumi border-gin hover:bg-matsu-50'
+            }`}
+          >
+            {year}年
+          </button>
+        );
+      })}
+      {onClear && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="px-2 py-0.5 rounded-full border border-gin text-xs text-hai bg-white hover:bg-kinari"
+        >
+          区画既定
+        </button>
+      )}
+    </div>
+  );
+}
 
 export function BurialInfoTab({
   register,
@@ -28,6 +78,8 @@ export function BurialInfoTab({
   masterData,
 }: BurialInfoTabProps) {
   const relationships = masterData?.relationships ?? [];
+  // 合祀年数の標準選択肢は backend マスタから供給（#289）。未取得時は標準値にフォールバック
+  const validityYearOptions = getValidityYearOptions(masterData?.validityPeriods);
   const [expandedBurialId, setExpandedBurialId] = useState<string | null>(null);
 
   const collectiveBurial = watch('collectiveBurial');
@@ -403,6 +455,25 @@ export function BurialInfoTab({
                               区画既定: {plotYears}年（空欄でこの方も同じ）
                             </p>
                           )}
+                          {/* 個別指定の標準年数もマスタから供給。「区画既定」で継承に戻す（#289） */}
+                          <ValidityYearChips
+                            options={validityYearOptions}
+                            value={hasOverride ? overrideRaw : null}
+                            onPick={(year) =>
+                              setValue(
+                                `buriedPersons.${index}.validityPeriodYearsOverride`,
+                                year,
+                                { shouldDirty: true },
+                              )
+                            }
+                            onClear={() =>
+                              setValue(
+                                `buriedPersons.${index}.validityPeriodYearsOverride`,
+                                null,
+                                { shouldDirty: true },
+                              )
+                            }
+                          />
                           {errors.buriedPersons?.[index]?.validityPeriodYearsOverride && (
                             <p className="text-sm text-beni mt-1">
                               {errors.buriedPersons[index]?.validityPeriodYearsOverride?.message}
@@ -510,6 +581,14 @@ export function BurialInfoTab({
               ) : (
                 <p className="text-xs text-hai mt-1">自動判定: {inferredValidityYears}年（{validityRuleSummary}）</p>
               )}
+              {/* 標準年数（13/15/24/33 等）をマスタから供給。クリックで設定（#289） */}
+              <ValidityYearChips
+                options={validityYearOptions}
+                value={currentValidityYears}
+                onPick={(year) =>
+                  setValue('collectiveBurial.validityPeriodYears', year, { shouldDirty: true })
+                }
+              />
               {errors.collectiveBurial?.validityPeriodYears && (
                 <p className="text-sm text-beni mt-1">
                   {errors.collectiveBurial.validityPeriodYears.message}

--- a/src/components/plot-form/index.tsx
+++ b/src/components/plot-form/index.tsx
@@ -37,6 +37,7 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     sectionNames,
     relationships,
     contractors,
+    validityPeriods,
     allMasters,
     isLoading: isMasterLoading,
   } = useMasters();
@@ -49,6 +50,7 @@ export default function PlotForm({ plotDetail, onSave, isLoading }: PlotFormProp
     sectionNames,
     relationships,
     contractors,
+    validityPeriods,
     // 無効を含む全件。既存値のフォールバック表示に使用（#238）
     all: allMasters,
     isLoading: isMasterLoading,

--- a/src/components/plot-form/types.ts
+++ b/src/components/plot-form/types.ts
@@ -13,6 +13,8 @@ export interface MasterData {
   sectionNames: SectionNameMasterItem[];
   relationships: MasterItem[];
   contractors: MasterItem[];
+  /** 合祀年数マスタ（#289）。合祀設定の有効期間・個別合祀年数の標準選択肢に使う */
+  validityPeriods: MasterItem[];
   /** 名称解決・無効値フォールバック用: 無効を含む全件（#238） */
   all?: MasterLists;
   isLoading: boolean;

--- a/src/hooks/useMasters.ts
+++ b/src/hooks/useMasters.ts
@@ -12,6 +12,7 @@ import {
   getConstructionTypes,
   getSectionNames,
   getContractors,
+  getValidityPeriods,
   MasterItem,
   TaxTypeMasterItem,
   SectionNameMasterItem,
@@ -32,6 +33,7 @@ export interface MasterLists {
   contractors: MasterItem[];
   directions: MasterItem[];
   positions: MasterItem[];
+  validityPeriods: MasterItem[];
 }
 
 // マスタデータの状態型
@@ -176,6 +178,7 @@ export function useMasters(options?: { skipCache?: boolean }) {
       contractors: state.data?.contractor || [],
       directions: state.data?.direction || [],
       positions: state.data?.position || [],
+      validityPeriods: state.data?.validityPeriod || [],
     };
     const active: MasterLists = {
       cemeteryTypes: all.cemeteryTypes.filter((m) => m.isActive),
@@ -190,6 +193,7 @@ export function useMasters(options?: { skipCache?: boolean }) {
       contractors: all.contractors.filter((m) => m.isActive),
       directions: all.directions.filter((m) => m.isActive),
       positions: all.positions.filter((m) => m.isActive),
+      validityPeriods: all.validityPeriods.filter((m) => m.isActive),
     };
     return { allMasters: all, activeMasters: active };
   }, [state.data]);
@@ -214,6 +218,7 @@ export function useMasters(options?: { skipCache?: boolean }) {
     contractors: activeMasters.contractors,
     directions: activeMasters.directions,
     positions: activeMasters.positions,
+    validityPeriods: activeMasters.validityPeriods,
 
     // 名称解決用: 無効化済みを含む全件（#238）
     allMasters,
@@ -272,6 +277,7 @@ export const useRecipientTypes = () => useMasterData<MasterItem>(getRecipientTyp
 export const useConstructionTypes = () => useMasterData<MasterItem>(getConstructionTypes);
 export const useSectionNames = () => useMasterData<SectionNameMasterItem>(getSectionNames);
 export const useContractors = () => useMasterData<MasterItem>(getContractors);
+export const useValidityPeriods = () => useMasterData<MasterItem>(getValidityPeriods);
 
 /**
  * マスタデータからコードで値を検索するユーティリティ

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -67,6 +67,7 @@ export {
   getContractors,
   getDirections,
   getPositions,
+  getValidityPeriods,
   createMasterItem,
   updateMasterItem,
   deleteMasterItem,

--- a/src/lib/api/masters.ts
+++ b/src/lib/api/masters.ts
@@ -40,6 +40,10 @@ export interface AllMastersData {
   contractor: MasterItem[];
   direction: MasterItem[];
   position: MasterItem[];
+  // 合祀年数マスタ（#289）。code/name に年数（13/15/24/33 等）を持つフラットな一覧。
+  // タイプ×年数の対応（どの区域が何年か）は持たないため、自動判定ルールは
+  // collective-burial-rules.ts の VALIDITY_RULE_TABLE が引き続き担う（Q34/#281）。
+  validityPeriod: MasterItem[];
 }
 
 // モックデータ
@@ -130,6 +134,13 @@ const mockMasterData: AllMastersData = {
     { id: 1, code: '1', name: '角', description: null, sortOrder: 1, isActive: true },
     { id: 2, code: '2', name: '端', description: null, sortOrder: 2, isActive: true },
     { id: 3, code: '3', name: '中', description: null, sortOrder: 3, isActive: true },
+  ],
+  // 合祀年数: backend seedMasters.ts の validity-period（13/15/24/33）と一致。code=年数。
+  validityPeriod: [
+    { id: 1, code: '13', name: '13年', description: null, sortOrder: 13, isActive: true },
+    { id: 2, code: '15', name: '15年', description: null, sortOrder: 15, isActive: true },
+    { id: 3, code: '24', name: '24年', description: null, sortOrder: 24, isActive: true },
+    { id: 4, code: '33', name: '33年', description: null, sortOrder: 33, isActive: true },
   ],
 };
 
@@ -284,6 +295,16 @@ export async function getPositions(): Promise<ApiResponse<MasterItem[]>> {
   return apiGet<MasterItem[]>('/masters/position');
 }
 
+/**
+ * 合祀年数マスタ取得（#289）
+ */
+export async function getValidityPeriods(): Promise<ApiResponse<MasterItem[]>> {
+  if (shouldUseMockData()) {
+    return { success: true, data: mockMasterData.validityPeriod };
+  }
+  return apiGet<MasterItem[]>('/masters/validity-period');
+}
+
 // CRUD用の型定義
 export type MasterType =
   | 'cemetery-type'
@@ -297,7 +318,8 @@ export type MasterType =
   | 'relationship'
   | 'contractor'
   | 'direction'
-  | 'position';
+  | 'position'
+  | 'validity-period';
 
 export interface CreateMasterRequest {
   code?: string;

--- a/src/lib/collective-burial-rules.ts
+++ b/src/lib/collective-burial-rules.ts
@@ -54,6 +54,44 @@ export const VALIDITY_RULE_TABLE: Record<GraveType, ValidityRule> = {
   general: { label: '通常区画', years: 33, yearsBeforeTransition: 33 },
 };
 
+/**
+ * 合祀年数マスタ（backend `validity-period`）が未取得/空のときに使う標準年数のフォールバック（#289）。
+ * backend seedMasters.ts の validity-period（13/15/24/33）と一致させる。
+ */
+export const STANDARD_VALIDITY_YEARS: number[] = [13, 15, 24, 33];
+
+/**
+ * 合祀年数の選択肢（標準年数）を backend の合祀年数マスタから導出する（#289）。
+ *
+ * マスタは code/name に年数を持つフラットな一覧（13/15/24/33 等）。ここから
+ * 年数(number)を昇順・重複排除で返す。マスタが空/未取得なら
+ * {@link STANDARD_VALIDITY_YEARS} にフォールバックする。
+ *
+ * 注意: どの区域が何年か（タイプ×年数の対応）はマスタには含まれないため、
+ * 自動判定の既定値は引き続き {@link VALIDITY_RULE_TABLE} が算出する。
+ * 本関数はあくまで「入力時に選べる標準年数の語彙」を提供する。
+ *
+ * @param master 合祀年数マスタ（active のみ想定。code or name に年数を含む）
+ */
+export function getValidityYearOptions(
+  master?: ReadonlyArray<{ code?: string | null; name?: string | null }> | null,
+): number[] {
+  const years = (master ?? [])
+    .map((m) => parseYear(m?.code) ?? parseYear(m?.name))
+    .filter((n): n is number => n !== null);
+  const unique = Array.from(new Set(years)).sort((a, b) => a - b);
+  return unique.length > 0 ? unique : [...STANDARD_VALIDITY_YEARS];
+}
+
+/** "13" / "13年" 等の文字列から先頭の正の整数を取り出す。取れなければ null。 */
+function parseYear(value: string | null | undefined): number | null {
+  if (value == null) return null;
+  const matched = String(value).match(/\d+/);
+  if (!matched) return null;
+  const n = Number(matched[0]);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
 /** 樹林墓部かどうかを区域名から判定 */
 export function isJurinArea(areaName: string | null | undefined): boolean {
   if (!areaName) return false;


### PR DESCRIPTION
## 概要

komine-docs#10 項目11（合祀年数のマスタ化）のフロント側対応。ハードコードしていた合祀年数の語彙（`VALIDITY_RULE_TABLE` に 13/15/33・**24年欠落**）を、backend の `validity-period` マスタ（13/15/24/33）から供給するように置き換えた。

`依存: backend（合祀年数マスタ + API）` は既に充足済み（`ValidityPeriodMaster` テーブル + `GET /masters/validity-period` + `/masters/all` が `validityPeriod` を返却済み・seed=13/15/24/33）。**backend 変更は不要、フロント単独の縦串**。

## 変更内容

- **マスタ配線**: `AllMastersData`/`useMasters`(`MasterLists`)/`MasterData` に `validityPeriod` を追加。`getValidityPeriods()` API・モック（13/15/24/33）・個別フック `useValidityPeriods` を追加し、既存の `useMasters` 取得パターンに合わせた。
- **語彙導出**: `collective-burial-rules.ts` に `getValidityYearOptions()` を追加。マスタの code/name から年数を**昇順・重複排除**で導出し、未取得/空のときは `STANDARD_VALIDITY_YEARS`(=13/15/24/33) にフォールバック。
- **入力UI**: 合祀設定の「有効期間」と埋葬者個別の「合祀年数（この方のみ）」に、マスタ由来の**標準年数クイック選択チップ**を追加。これで **24年が選択可能**になった。数値の**自由入力（例外指定 Q17）は維持**し、個別指定には「区画既定」に戻すチップも用意。
- **マスタ管理**: `/masters` に「合祀年数」タブを追加（マスタ化＝管理可能に）。

## スコープの注記（重要）

backend の `validity-period` マスタは**年数の値リスト（フラット）**で、「どの区域タイプが何年か」というタイプ×年数の対応も 2023-04 切替日も持たない。そのため**自動判定ルール `VALIDITY_RULE_TABLE` は完全には置換できず据え置き**（樹林13/15・通常33の推定はこれが担う）。タイプ別年数（24年がどのタイプか等）は **Q34 で業務回収中（#281）** で、確定後に自動判定へ反映する。

本PRが対応するのは「**入力時に選べる標準年数の語彙をマスタ駆動にし、24年を出す**」範囲。

## テスト

- `getValidityYearOptions` の単体テスト（昇順・重複排除・name フォールバック・空→標準値・24含む）を追加
- BurialInfoTab にチップ操作のテスト（24年チップで有効期間設定）を追加
- フロント全スイート green（40 suites / 526 tests）、`tsc --noEmit` 0、ESLint 0

Closes #289
Refs komine-docs#10, #281, #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)