### PR TITLE
fix(collective-burial): 合祀一覧の空表示を正しい登録導線へ修正 (#359)

### DIFF
--- a/src/components/collective-burial/ListView.tsx
+++ b/src/components/collective-burial/ListView.tsx
@@ -463,7 +463,7 @@ export default function CollectiveBurialListView({
               description={
                 (searchQuery || billingStatus !== 'all' || selectedYear !== 'all')
                   ? '検索語・請求状況・請求年の条件を緩めて再検索してください。'
-                  : 'まだ合祀者が登録されていません。新規登録ボタンから追加できます。'
+                  : 'まだ合祀者が登録されていません。台帳の区画編集→「埋葬情報」タブの「合祀対象区画」から登録できます。'
               }
               action={
                 (searchQuery || billingStatus !== 'all' || selectedYear !== 'all') ? (


### PR DESCRIPTION
## 概要
合祀管理画面（/collective-burials）の空表示が「新規登録ボタンから追加できます」と案内していたが、合祀には独立した新規登録ボタンが無く、登録は **台帳の区画編集 →「埋葬情報」タブ →「合祀対象区画」トグル** から行う設計。誤誘導になっていた文言を正しい導線へ修正した。

## 変更
- `collective-burial/ListView.tsx` の `EmptyState` description（フィルタ無し・0件時）を
  「まだ合祀者が登録されていません。台帳の区画編集→「埋葬情報」タブの「合祀対象区画」から登録できます。」に変更

## 背景
#359 の方針確認で「既存の共同区画(≈922区)は一括投入せず、運用の中で都度トグル登録していく」と確定。一括投入スクリプトは作らず、本PRの文言修正のみで #359 をクローズする。

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)