### PR TITLE
fix(plots): レガシーintのUI露出を解消（墓石形状/基地タイプ非表示・入金料金種別・工事業者未設定） (#334)

### DIFF
--- a/src/__tests__/lib/legacy-sentinels.test.ts
+++ b/src/__tests__/lib/legacy-sentinels.test.ts
@@ -1,0 +1,33 @@
+import { formatFeeType, isUnsetContractor, UNSET_CONTRACTOR_CODE } from '@/lib/legacy-sentinels';
+
+describe('formatFeeType (#334)', () => {
+  it('legacy センチネルを使用料/管理料へ変換する', () => {
+    expect(formatFeeType('legacy-fee-20230001')).toBe('使用料');
+    expect(formatFeeType('legacy-fee-20230002')).toBe('管理料');
+  });
+
+  it('未設定は "-" を返す', () => {
+    expect(formatFeeType(null)).toBe('-');
+    expect(formatFeeType(undefined)).toBe('-');
+    expect(formatFeeType('')).toBe('-');
+  });
+
+  it('既知センチネル以外（手入力値等）は素通しする', () => {
+    expect(formatFeeType('使用料')).toBe('使用料');
+    expect(formatFeeType('legacy-fee-99999999')).toBe('legacy-fee-99999999');
+  });
+});
+
+describe('isUnsetContractor (#334)', () => {
+  it('legacy-gyousha-0（未設定センチネル）のみ true', () => {
+    expect(isUnsetContractor(UNSET_CONTRACTOR_CODE)).toBe(true);
+    expect(isUnsetContractor('legacy-gyousha-0')).toBe(true);
+  });
+
+  it('実在業者コード・未設定値は false', () => {
+    expect(isUnsetContractor('legacy-gyousha-12')).toBe(false);
+    expect(isUnsetContractor('財津工務店')).toBe(false);
+    expect(isUnsetContractor(null)).toBe(false);
+    expect(isUnsetContractor(undefined)).toBe(false);
+  });
+});

--- a/src/components/billing/billing-detail-dialog.tsx
+++ b/src/components/billing/billing-detail-dialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { BillingDetailResponse } from '@komine/types';
 import { getBillingById, BILLING_CATEGORY_LABELS, BILLING_RECORD_STATUS_LABELS } from '@/lib/api/billings';
 import { LegacyAwareValue } from '@/components/legacy-aware-value';
+import { formatFeeType } from '@/lib/legacy-sentinels';
 
 const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
 
@@ -165,7 +166,7 @@ function BillingDetailBody({ billing }: { billing: BillingDetailResponse }) {
                     <td className="px-3 py-2 text-sm text-sumi tabular-nums">{p.paymentDate ?? p.scheduledDate ?? '-'}</td>
                     <td className="px-3 py-2 text-sm text-right text-sumi tabular-nums">{formatYen(p.paymentAmount)}</td>
                     <td className="px-3 py-2 text-sm text-hai hidden sm:table-cell">{p.staffInCharge ?? '-'}</td>
-                    <td className="px-3 py-2 text-sm text-hai hidden md:table-cell">{p.feeType ?? '-'}</td>
+                    <td className="px-3 py-2 text-sm text-hai hidden md:table-cell">{formatFeeType(p.feeType)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/components/payment/payment-list-table.tsx
+++ b/src/components/payment/payment-list-table.tsx
@@ -3,6 +3,7 @@
 import { Payment } from '@komine/types';
 import { BILLING_CATEGORY_LABELS } from '@/lib/api/billings';
 import { LegacyAwareValue } from '@/components/legacy-aware-value';
+import { formatFeeType } from '@/lib/legacy-sentinels';
 
 const formatYen = (n: number): string => `¥${n.toLocaleString('ja-JP')}`;
 
@@ -108,7 +109,7 @@ export function PaymentListTable({
                 {p.customer?.name ?? '-'}
               </td>
               <td className="px-2 md:px-4 py-3 text-sm text-hai hidden lg:table-cell">
-                {p.feeType ?? '-'}
+                {formatFeeType(p.feeType)}
               </td>
               <td className="px-2 md:px-4 py-3 text-sm text-hai hidden lg:table-cell">
                 {p.staffInCharge ?? '-'}

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -30,6 +30,7 @@ import { calculateScheduledCollectiveBurialDate } from '@/lib/collective-burial-
 import { isEmptyDisplayValue, EMPTY_LABELS, type EmptyKind } from '@/lib/empty-display';
 import { LegacyAwareValue, LegacyValueNote } from '@/components/legacy-aware-value';
 import { isLegacyPlotNumber, isLegacyAreaName } from '@/lib/legacy-plot-display';
+import { isUnsetContractor } from '@/lib/legacy-sentinels';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -754,10 +755,10 @@ function BurialInfoTab({
       )}
 
       {/* 墓石情報 */}
-      {(plot.gravestoneInfo || plot.graveKind != null || plot.graveKubun != null) && (
+      {/* 墓石形状(graveKind)・基地タイプ(graveKubun) はマスタ未設計でレガシーintの意味が
+          未確定のため非表示（#334）。業務側で意味が確定したらマスタ化して再表示する。 */}
+      {plot.gravestoneInfo && (
         <Section title="墓石情報">
-          <InfoField label="墓石形状" value={plot.graveKind?.toString()} />
-          <InfoField label="基地タイプ" value={plot.graveKubun?.toString()} />
           <InfoField label="墓石基礎" value={plot.gravestoneInfo?.gravestoneBase} />
           <InfoField label="外柵位置" value={plot.gravestoneInfo?.enclosurePosition} />
           <InfoField label="石材店" value={plot.gravestoneInfo?.gravestoneDealer} />
@@ -788,7 +789,8 @@ function ConstructionInfoTab({
   contractors: MasterItem[];
 }) {
   const resolveContractor = (value: string | null | undefined): string | null => {
-    if (!value) return null;
+    // legacy-gyousha-0 は「業者ID未設定」のセンチネル。実在業者でないため未登録扱い（#334）。
+    if (!value || isUnsetContractor(value)) return null;
     const master = contractors.find((c) => c.code === value);
     return master ? master.name : value;
   };

--- a/src/components/plot-form/previewHelper.ts
+++ b/src/components/plot-form/previewHelper.ts
@@ -1,6 +1,7 @@
 import type { PlotFormData } from '@/lib/validations/plot-form';
 import type { PreviewSection, PreviewDiffSection, PreviewDiffItem } from '@/components/shared/dialogs';
 import type { MasterItem } from '@/lib/api';
+import { isUnsetContractor } from '@/lib/legacy-sentinels';
 
 export interface PreviewMasterContext {
   contractors?: MasterItem[];
@@ -10,7 +11,8 @@ function resolveContractorLabel(
   value: string | null | undefined,
   contractors: MasterItem[] | undefined,
 ): string {
-  if (!value) return '';
+  // legacy-gyousha-0 は「業者ID未設定」のセンチネル。書類にも実在業者として印字しない（#334）。
+  if (!value || isUnsetContractor(value)) return '';
   if (!contractors || contractors.length === 0) return value;
   const master = contractors.find((c) => c.code === value);
   return master ? master.name : value;

--- a/src/lib/legacy-sentinels.ts
+++ b/src/lib/legacy-sentinels.ts
@@ -1,0 +1,40 @@
+/**
+ * レガシー移行で付与されたセンチネル値の表示変換（#334）
+ *
+ * 旧システムからの移行時、意味の確定していないコードを `legacy-*` 形式の
+ * センチネル値で保存している。UI にそのまま出すと利用者に意味不明な文字列が
+ * 見えるため、業務確認で意味が確定したものをここで表示用ラベルへ変換する。
+ */
+
+/**
+ * 入金の料金種別センチネル → 表示ラベル。
+ * 業務確認（2026-06-09）で確定:
+ *   legacy-fee-20230001 = 使用料 / legacy-fee-20230002 = 管理料
+ * （請求側 billing_type 20280001=使用料 / 20280002=管理料 と同系列）
+ */
+const LEGACY_FEE_TYPE_LABELS: Record<string, string> = {
+  'legacy-fee-20230001': '使用料',
+  'legacy-fee-20230002': '管理料',
+};
+
+/**
+ * 入金の料金種別を表示用ラベルへ変換する。
+ * legacy センチネルは日本語ラベルへ、未設定は '-'、それ以外（手入力値等）は素通し。
+ */
+export function formatFeeType(feeType: string | null | undefined): string {
+  if (!feeType) return '-';
+  return LEGACY_FEE_TYPE_LABELS[feeType] ?? feeType;
+}
+
+/**
+ * 工事業者「未設定」を表すレガシーセンチネル（ContractorMaster の code）。
+ * 移行スクリプトが業者ID未設定の工事記録に `legacy-gyousha-0` を付与し、
+ * マスタ名が「業者ID:0」になってしまっている。これは実在の業者ではないため
+ * UI では「未登録」扱い（値なし）として表示する。
+ */
+export const UNSET_CONTRACTOR_CODE = 'legacy-gyousha-0';
+
+/** 工事業者コードが「未設定」センチネルかどうか。 */
+export function isUnsetContractor(code: string | null | undefined): boolean {
+  return code === UNSET_CONTRACTOR_CODE;
+}


### PR DESCRIPTION
## 概要
マスタ未設計でレガシー値（intセンチネル）がそのままUIに露出していた3点を、業務確認（2026-06-09）の結果に基づき修正。

## 変更
### ① 墓石形状 / 基地タイプ → 非表示
`grave_kind`(0/1/2/3) / `grave_kubun`(0/1) はマスタ未設計で各コードの意味が未確定。利用者には「1」「2」等の意味不明な数字が見えていたため、区画詳細「墓石情報」から非表示にした（業務側で意味が確定したらマスタ化して再表示）。

### ② 入金の料金種別 → 日本語ラベル
`payments.fee_type` が `legacy-fee-20230001`(9,687件) / `legacy-fee-20230002`(2,818件) のセンチネルのまま入金明細に出ていた。業務確認で **20230001=使用料 / 20230002=管理料**（請求側 billing_type 20280001/20280002 と同系列）と確定したため、表示用ヘルパ `formatFeeType` を新設し、請求明細ダイアログ・入金一覧の2画面で変換。

### ③ 工事業者「業者ID:0」→ 未登録
`construction_infos.contractor` の `legacy-gyousha-0`(233件) は「業者ID未設定」のセンチネルだが、ContractorMaster 名「業者ID:0」として表示・書類印字されていた。`isUnsetContractor` で未設定判定し、区画詳細・書類プレビューとも実在業者として出さない（未登録扱い）。

## テスト
- `legacy-sentinels.test.ts` 新規（formatFeeType / isUnsetContractor）
- 既存 preview-helper / plot-form / plots-helpers 全green
- lint クリーン

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)