### PR TITLE
fix(auth): パスワードリセット/招待リンクをimplicitフロー(ハッシュ)対応に (Closes #294)

### DIFF
--- a/src/__tests__/components/password-set-form.test.tsx
+++ b/src/__tests__/components/password-set-form.test.tsx
@@ -22,6 +22,7 @@ describe('PasswordSetForm', () => {
     pushMock.mockClear()
     resetPasswordMock.mockReset()
     mockSearchParams = new URLSearchParams()
+    window.location.hash = ''
   })
 
   describe('コードなしの場合', () => {
@@ -106,7 +107,11 @@ describe('PasswordSetForm', () => {
       await user.click(screen.getByRole('button', { name: 'パスワードを設定' }))
 
       await waitFor(() => {
-        expect(resetPasswordMock).toHaveBeenCalledWith('valid-code-123', 'Abcdef12', 'Abcdef12')
+        expect(resetPasswordMock).toHaveBeenCalledWith(
+          { accessToken: undefined, code: 'valid-code-123' },
+          'Abcdef12',
+          'Abcdef12'
+        )
       })
     })
 
@@ -158,6 +163,74 @@ describe('PasswordSetForm', () => {
           screen.getByRole('button', { name: 'パスワードリセットをやり直す' })
         ).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('ハッシュに access_token がある場合（implicit フロー）', () => {
+    beforeEach(() => {
+      window.location.hash =
+        '#access_token=hash-token-abc&refresh_token=r1&expires_in=3600&type=recovery'
+    })
+    afterEach(() => {
+      window.location.hash = ''
+    })
+
+    it('パスワード入力フォームが表示される', () => {
+      render(<PasswordSetForm mode="reset" />)
+      expect(screen.getByLabelText('新しいパスワード')).toBeInTheDocument()
+      expect(screen.getByLabelText('パスワード確認')).toBeInTheDocument()
+    })
+
+    it('access_token を credentials として resetPassword に渡す', async () => {
+      resetPasswordMock.mockResolvedValue({ success: true, data: {} })
+      const user = userEvent.setup()
+      render(<PasswordSetForm mode="reset" />)
+
+      await user.type(screen.getByLabelText('新しいパスワード'), 'Abcdef12')
+      await user.type(screen.getByLabelText('パスワード確認'), 'Abcdef12')
+      await user.click(screen.getByRole('button', { name: 'パスワードを再設定' }))
+
+      await waitFor(() => {
+        expect(resetPasswordMock).toHaveBeenCalledWith(
+          { accessToken: 'hash-token-abc', code: undefined },
+          'Abcdef12',
+          'Abcdef12'
+        )
+      })
+    })
+
+    it('読み込み後トークンをURLハッシュから除去する', async () => {
+      render(<PasswordSetForm mode="reset" />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('新しいパスワード')).toBeInTheDocument()
+      })
+      // access_token を履歴・アドレスバーに残さない
+      expect(window.location.hash).toBe('')
+    })
+  })
+
+  describe('期限切れ・無効リンク（ハッシュに #error=...）の場合', () => {
+    beforeEach(() => {
+      window.location.hash =
+        '#error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired'
+    })
+    afterEach(() => {
+      window.location.hash = ''
+    })
+
+    it('reset モード: フォームを出さず、期限切れヒントと「やり直す」CTAを表示する', () => {
+      render(<PasswordSetForm mode="reset" />)
+      expect(screen.queryByLabelText('新しいパスワード')).not.toBeInTheDocument()
+      expect(screen.getByText(/リセットリンクの有効期限が切れている/)).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'パスワードリセットをやり直す' })
+      ).toBeInTheDocument()
+    })
+
+    it('set モード: フォームを出さず、招待リンクの期限切れヒントを表示する', () => {
+      render(<PasswordSetForm mode="set" />)
+      expect(screen.queryByLabelText('新しいパスワード')).not.toBeInTheDocument()
+      expect(screen.getByText(/招待リンクの有効期限が切れている/)).toBeInTheDocument()
     })
   })
 })

--- a/src/components/password-set-form.tsx
+++ b/src/components/password-set-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -43,7 +43,11 @@ export function PasswordSetForm({ mode }: PasswordSetFormProps) {
   const searchParams = useSearchParams()
   const config = MODE_CONFIG[mode]
 
-  const code = searchParams.get('code')
+  // 認証情報: implicit フロー（メールリンクのハッシュ #access_token=...）が主経路。
+  // PKCE の ?code= は後方互換として併用する。
+  const [accessToken, setAccessToken] = useState<string | null>(null)
+  const [credentialCode, setCredentialCode] = useState<string | null>(null)
+  const [linkChecked, setLinkChecked] = useState(false)
 
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -51,6 +55,38 @@ export function PasswordSetForm({ mode }: PasswordSetFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSuccess, setIsSuccess] = useState(false)
   const [isExpired, setIsExpired] = useState(false)
+
+  useEffect(() => {
+    // Supabase の implicit フローでは、メールリンクは
+    //   /reset-password#access_token=...&refresh_token=...&type=recovery
+    // のように **ハッシュ** でトークンを返す。useSearchParams ではハッシュを
+    // 読めないため window.location.hash を直接パースする（これが主経路）。
+    const rawHash = window.location.hash.replace(/^#/, '')
+    const hashParams = new URLSearchParams(rawHash)
+    const tokenFromHash = hashParams.get('access_token')
+    const errorCode = hashParams.get('error_code') || hashParams.get('error')
+    const errorDescription = hashParams.get('error_description')
+    // PKCE フロー（後方互換）: ?code=
+    const codeFromQuery = searchParams.get('code')
+
+    if (tokenFromHash) {
+      setAccessToken(tokenFromHash)
+      // 短命トークンを履歴・アドレスバーに残さない
+      window.history.replaceState(null, '', window.location.pathname + window.location.search)
+    } else if (codeFromQuery) {
+      setCredentialCode(codeFromQuery)
+    } else if (errorCode) {
+      // 期限切れ・使用済みリンク等（#error=access_denied&error_code=otp_expired&error_description=...）
+      setIsExpired(true)
+      if (errorDescription) {
+        setError(decodeURIComponent(errorDescription.replace(/\+/g, ' ')))
+      }
+    }
+    setLinkChecked(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const hasCredential = Boolean(accessToken || credentialCode)
 
   const validatePassword = (): string | null => {
     if (newPassword.length < 8) {
@@ -75,7 +111,7 @@ export function PasswordSetForm({ mode }: PasswordSetFormProps) {
       return
     }
 
-    if (!code) {
+    if (!hasCredential) {
       setError(config.noCodeMessage)
       return
     }
@@ -83,7 +119,11 @@ export function PasswordSetForm({ mode }: PasswordSetFormProps) {
     setIsSubmitting(true)
 
     try {
-      const result = await resetPassword(code, newPassword, confirmPassword)
+      const result = await resetPassword(
+        { accessToken: accessToken ?? undefined, code: credentialCode ?? undefined },
+        newPassword,
+        confirmPassword
+      )
 
       if (result.success) {
         setIsSuccess(true)
@@ -168,17 +208,25 @@ export function PasswordSetForm({ mode }: PasswordSetFormProps) {
             <div className="w-12 h-px bg-gin mx-auto mt-4" />
           </div>
 
-          {!code ? (
-            <div className="text-center">
-              <div className="bg-beni-50 border border-beni-200 rounded-elegant px-4 py-3 mb-6">
-                <p className="text-beni text-sm">{config.noCodeMessage}</p>
+          {!linkChecked ? (
+            <div className="text-center text-hai text-sm py-4">読み込み中...</div>
+          ) : !hasCredential ? (
+            <div className="text-center space-y-4">
+              <div className="bg-beni-50 border border-beni-200 rounded-elegant px-4 py-3">
+                <p className="text-beni text-sm">{error || config.noCodeMessage}</p>
+                {isExpired && (
+                  <p className="text-beni/80 text-xs mt-2">{config.expiredHint}</p>
+                )}
               </div>
-              <Button
-                variant="outline"
-                onClick={() => router.push('/login')}
-              >
-                ログイン画面へ戻る
-              </Button>
+              {isExpired && config.retryCta ? (
+                <Button variant="outline" onClick={() => router.push(config.retryCta!.href)}>
+                  {config.retryCta.label}
+                </Button>
+              ) : (
+                <Button variant="outline" onClick={() => router.push('/login')}>
+                  ログイン画面へ戻る
+                </Button>
+              )}
             </div>
           ) : (
             <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -406,13 +406,14 @@ export async function forgotPassword(
  * 招待メールからの初回設定・パスワードリセット両方で使用
  */
 export async function resetPassword(
-  code: string,
+  credentials: { accessToken?: string; code?: string },
   newPassword: string,
   confirmPassword: string
 ): Promise<ApiResponse<{ message: string }>> {
   if (shouldUseMockData()) {
     await new Promise((resolve) => setTimeout(resolve, 500));
-    if (code.startsWith('invalid-')) {
+    const token = credentials.accessToken ?? credentials.code ?? '';
+    if (token.startsWith('invalid-')) {
       return {
         success: false,
         error: {
@@ -429,8 +430,11 @@ export async function resetPassword(
     };
   }
 
+  // implicit フローの access_token を主に送る。PKCE の code も後方互換で送る。
+  // undefined のキーは JSON.stringify で除外される。
   return apiPost<{ message: string }>('/auth/reset-password', {
-    code,
+    accessToken: credentials.accessToken,
+    code: credentials.code,
     newPassword,
     confirmPassword,
   });


### PR DESCRIPTION
## 背景
システムテスト AUTH-06/07 で、リセット/招待メールのリンクが必ず「無効」になる事象。実機URLで原因確定：

```
https://<frontend>/reset-password#access_token=eyJ...&type=recovery
```

Supabase は **implicit フロー**でトークンを **URLハッシュ**で返すが、`PasswordSetForm` は `?code=` クエリしか見ておらず（フロントに Supabase クライアントも無い）、`code` が無いため即「無効」表示になっていた。

## 変更
- `window.location.hash` をパースして `access_token` を取得 → backend へ `accessToken` として送る。
- PKCE の `?code=` も後方互換で併用（`resetPassword` を `{ accessToken?, code? }` 受け取りに変更）。
- 期限切れ/使用済みリンク（`#error=access_denied&error_code=otp_expired&...`）を検出して期限切れUI（ヒント＋やり直しCTA）に出し分け。
- 取得後はトークンを `history.replaceState` でアドレスバー/履歴から除去。
- 招待（`type=invite`, `/set-password`）も同一コンポーネントで同時解消。

## テスト
- `password-set-form.test.tsx`: 既存12 + 新規5（ハッシュaccess_token経路・トークン除去・期限切れ出し分け set/reset）= **16件 green**。
- `tsc --noEmit` 0 / `eslint` clean。

## デプロイ
backend **#373 / PR #374**（`accessToken` 受理）と対。backend は後方互換を保つため**順不同でデプロイ可**だが、本PRが効くのは backend デプロイ後。送達は #351（独自SMTP）の本番ドメイン設定が別途必要。

Closes #294
Refs #373, #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)