### PR TITLE
feat(plots): 請求情報をゆうちょ自動払込向けに整備（入力ガイド＋クイックセット） (#170)

### DIFF
--- a/src/__tests__/components/plot-form/work-billing-tab.test.tsx
+++ b/src/__tests__/components/plot-form/work-billing-tab.test.tsx
@@ -89,4 +89,19 @@ describe('WorkBillingTab', () => {
   // 請求情報（BillingInfo）セクションは Phase 2 移行で廃止。
   // Phase 3 で Billing/Payment エンティティとして再設計予定。
   // Refs: zaitsu82/komine-crm-backend#106
+
+  it('「ゆうちょ自動払込をセット」で機関名称に「ゆうちょ銀行」が入る (#170)', async () => {
+    const user = userEvent.setup();
+    render(
+      <TabHost>
+        {(h) => <WorkBillingTab {...h} masterData={emptyMasterData} />}
+      </TabHost>
+    );
+
+    const bankInput = screen.getByPlaceholderText('○○銀行 / ゆうちょ銀行') as HTMLInputElement;
+    expect(bankInput.value).toBe('');
+
+    await user.click(screen.getByRole('button', { name: 'ゆうちょ自動払込をセット' }));
+    expect(bankInput.value).toBe('ゆうちょ銀行');
+  });
 });

--- a/src/components/plot-form/WorkBillingTab.tsx
+++ b/src/components/plot-form/WorkBillingTab.tsx
@@ -123,19 +123,44 @@ export function WorkBillingTab({
 
       {/* Section 2: 請求情報（契約者の振込先口座、ゆうちょ自動払込 CSV 用） */}
       <div className="border rounded-lg p-4">
-        <h3 className="text-sm font-semibold text-sumi mb-3">請求情報</h3>
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-sm font-semibold text-sumi">請求情報</h3>
+          {/* ゆうちょ自動払込のクイック入力（機関名称＝ゆうちょ銀行・口座科目＝普通） */}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => {
+              setValue('customer.bankName', 'ゆうちょ銀行')
+              if (!watch('customer.accountType')) {
+                setValue('customer.accountType', 'ordinary')
+              }
+            }}
+          >
+            ゆうちょ自動払込をセット
+          </Button>
+        </div>
+        {/* ゆうちょ自動払込（口座振替）の入力ガイド。受領した口座リストCSVの値をそのまま入力する（#170）。 */}
+        <p className="text-xs text-hai mb-3 leading-relaxed">
+          ゆうちょ自動払込（口座振替）の場合：
+          <span className="font-medium text-sumi">機関名称</span>＝「ゆうちょ銀行」／
+          <span className="font-medium text-sumi">支店名称</span>＝店番3桁（例: 747）／
+          <span className="font-medium text-sumi">口座科目</span>＝普通／
+          <span className="font-medium text-sumi">記号番号</span>＝口座番号 を、受領した口座リストCSVの値どおりに入力してください。
+        </p>
         <div className="grid grid-cols-2 gap-4">
           <ViewModeField
             label="機関名称"
             register={register('customer.bankName')}
             error={errors.customer?.bankName?.message}
-            placeholder="○○銀行"
+            placeholder="○○銀行 / ゆうちょ銀行"
           />
           <ViewModeField
-            label="支店名称"
+            label="支店名称 / ゆうちょ店番"
             register={register('customer.branchName')}
             error={errors.customer?.branchName?.message}
-            placeholder="本店 / 支店名"
+            placeholder="支店名 / ゆうちょは店番3桁（例: 747）"
           />
           <ViewModeSelect
             label="口座科目"
@@ -148,10 +173,10 @@ export function WorkBillingTab({
             <SelectItem value="savings">貯蓄</SelectItem>
           </ViewModeSelect>
           <ViewModeField
-            label="記号番号"
+            label="記号番号 / ゆうちょ口座番号"
             register={register('customer.accountNumber')}
             error={errors.customer?.accountNumber?.message}
-            placeholder="口座番号 / ゆうちょ記号番号"
+            placeholder="口座番号（ゆうちょは口座番号7桁）"
           />
           <div className="col-span-2">
             <ViewModeField


### PR DESCRIPTION
## 概要
ゆうちょ口座振替（自動払込）の対象顧客（数十件）を、事務所が**受領した口座リストCSVの値どおりに**登録できるよう、区画フォームの「請求情報」セクションをゆうちょ前提で整備した。

## 背景（#170 の再スコープ）
業務確認（2026-06-09）の結果、#170 は当初本文の大半が陳腐化していた：
- ゆうちょ自動払込CSVは **委託者ヘッダ無し**フォーマット → 委託者コード/引落日/収納口座は不要（コードでも確定済み）
- 受領CSVが記号番号を **店番(例:747)＋口座番号(例:1375269)＋種目** に変換済みで提供 → 逆算不要
- 口座振替対象は**数十件規模**・キーは名義カナのみ → 一括取込スクリプトは作らず**手入力**

→ 残りは「ゆうちょ口座の入力UI整備」のみ。本PRで対応。

## 変更（frontend 単独）
- **「ゆうちょ自動払込をセット」ボタン**：機関名称=「ゆうちょ銀行」・口座科目=普通 を一括設定
- **入力ガイド**：支店名称＝店番3桁 / 記号番号＝口座番号 を受領CSVどおり入力する旨を明示
- ラベル/プレースホルダをゆうちょ前提で補強（「支店名称 / ゆうちょ店番」等）

## なぜ既存フィールド経由か
ゆうちょCSV生成側（`yuchoCsv.ts`）は `bankName`→`extractBankCode`（9900）/ `branchName`→`extractBranchCode`（店番3桁）/ `accountNumber`（口座番号）/ `accountType`（預金種目）で振替ファイルを解決する。受領CSVの値をこれら既存フィールドに入れれば**byte一致の出力**になる。`yucho_symbol`/`yucho_number`（正規ソース）への保存は schema 拡張が要るため本PRでは見送り（生成は既存経路で正しく動作）。

## テスト
- `work-billing-tab.test.tsx` にクイックセットの動作テストを追加（全6件green）
- lint クリーン

## 確認方法
1. 区画編集 → 作業・請求タブ → 請求情報
2. 「ゆうちょ自動払込をセット」→ 機関名称=ゆうちょ銀行 / 口座科目=普通
3. 支店名称に店番(747)、記号番号に口座番号(1375269) を入力 → 保存
4. ゆうちょ連携(/yucho)でCSV出力 → 店番747・口座番号1375269 で出力されることを確認

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)