### PR TITLE
fix(plots): 台帳の埋葬者表示を修正（享年0=未登録・一覧ラベル折返し）

### DIFF
--- a/src/__tests__/components/plot-form/preview-helper.test.ts
+++ b/src/__tests__/components/plot-form/preview-helper.test.ts
@@ -5,7 +5,7 @@
  * 別レコード同士を比較して誤った差分を表示しない）を保証する。
  */
 
-import { buildPlotDiffSections } from '@/components/plot-form/previewHelper';
+import { buildPlotDiffSections, buildPlotPreviewSections } from '@/components/plot-form/previewHelper';
 import { defaultPlotFormData } from '@/lib/validations/plot-form';
 import type { PlotFormData } from '@/lib/validations/plot-form';
 
@@ -121,6 +121,25 @@ describe('buildPlotDiffSections 配列差分の id 突合 (#222)', () => {
       expect.arrayContaining([
         expect.objectContaining({ label: '氏名', before: '乙野二郎', after: '' }),
       ])
+    );
+  });
+});
+
+describe('buildPlotPreviewSections 享年0の扱い (#297)', () => {
+  it('享年0（旧システムで未記録）は書類プレビューに印字しない', () => {
+    const zero = makeBuriedPerson({ id: 'bp-0', name: '零野零', age: 0 } as Partial<BuriedPerson>);
+    const sections = buildPlotPreviewSections(makeFormData([zero]));
+    const buried = sections.find((s) => s.title === '埋葬者 1');
+    expect(buried).toBeDefined();
+    expect(buried?.items.some((i) => i.label === '享年')).toBe(false);
+  });
+
+  it('享年1以上は書類プレビューに印字する', () => {
+    const aged = makeBuriedPerson({ id: 'bp-a', name: '齢野有', age: 82 } as Partial<BuriedPerson>);
+    const sections = buildPlotPreviewSections(makeFormData([aged]));
+    const buried = sections.find((s) => s.title === '埋葬者 1');
+    expect(buried?.items).toEqual(
+      expect.arrayContaining([{ label: '享年', value: '82' }]),
     );
   });
 });

--- a/src/components/plot-detail-view.tsx
+++ b/src/components/plot-detail-view.tsx
@@ -706,7 +706,8 @@ function BurialInfoTab({
                   <InfoField label="性別" value={person.gender ? GENDER_LABELS[person.gender as Gender] : null} />
                   <InfoField label="生年月日" value={formatDate(person.birthDate)} />
                   <InfoField label="命日" value={formatDate(person.deathDate)} />
-                  <InfoField label="享年" value={person.age?.toString()} />
+                  {/* 享年は数え年(1始まり)。0=旧システムで未記録のため未登録扱い(#297) */}
+                  <InfoField label="享年" value={person.age ? person.age.toString() : null} />
                   <InfoField label="埋葬日" value={formatDate(person.burialDate)} />
                   <InfoField label="届出日" value={formatDate(person.reportDate)} />
                   <InfoField label="続柄" value={person.relationship} />

--- a/src/components/plot-form/previewHelper.ts
+++ b/src/components/plot-form/previewHelper.ts
@@ -220,7 +220,7 @@ export function buildPlotPreviewSections(
         { label: '氏名', value: p.name || '' },
         { label: '命日', value: p.deathDate || '' },
         { label: '埋葬日', value: p.burialDate || '' },
-        { label: '享年', value: p.age != null ? String(p.age) : '' },
+        { label: '享年', value: p.age ? String(p.age) : '' },
         { label: '性別', value: formatGender(p.gender) },
         {
           label: '合祀年数（この方のみ）',

--- a/src/components/plot-list-table.tsx
+++ b/src/components/plot-list-table.tsx
@@ -520,16 +520,19 @@ export default function PlotListTable({
                       )}
                       onClick={() => onPlotSelect?.(plot)}
                     >
-                      <td className="px-2 md:px-4 py-2 md:py-3 whitespace-nowrap">
+                      {/* td 自体の whitespace-nowrap は埋葬者divの折返しと行高がぶつかり
+                          ラベルと氏名が重なる原因になるため、nowrap は氏名・ふりがな行に限定し
+                          td は align-top にする (#299) */}
+                      <td className="px-2 md:px-4 py-2 md:py-3 align-top">
                         <div>
-                          <div className="text-sm font-semibold text-sumi">
+                          <div className="text-sm font-semibold text-sumi whitespace-nowrap">
                             {plot.customerName || '-'}
                           </div>
-                          <div className="text-xs md:text-sm text-hai">
+                          <div className="text-xs md:text-sm text-hai whitespace-nowrap">
                             {plot.customerNameKana || ''}
                           </div>
                           {showBuriedPersons && plot.buriedPersonNames.length > 0 && (
-                            <div className="mt-1 text-xs text-hai whitespace-normal max-w-[260px]">
+                            <div className="mt-1 text-xs text-hai whitespace-normal break-words leading-relaxed max-w-[260px]">
                               <span className="text-cha font-medium">埋葬者:</span>{' '}
                               {plot.buriedPersonNames.join('、')}
                             </div>


### PR DESCRIPTION
## 概要
台帳まわりの埋葬者表示に関するフロントエンドの軽微な表示修正2件。backend / types 変更なし。

## #297 享年「0」を未登録表示にする（Closes #297）
享年は数え年（1始まり）で 0 は事実上存在せず、`0 =` 旧システムで未記録のデータ。`?.toString()` は null/undefined しか拾わないため `0` が `"0"` としてそのまま表示され「0歳で埋葬」と誤読されていた。

- `plot-detail-view.tsx`：`value={person.age ? person.age.toString() : null}` → `InfoField` が「未登録」表示（`isEmptyDisplayValue(null)` 経由・#181 の空値規約に乗せる）
- `previewHelper.ts`（`buildPlotPreviewSections`）：享年を `p.age ? String(p.age) : ''` に。0 は空 → `items` から除外され書類に印字されない
- テスト追加：享年0非印字／1以上印字

編集フォームの享年入力（`BurialInfoTab.tsx`）は実値編集の妨げになるため据え置き（issue でも任意）。

### 受け入れ条件
- [x] 享年0の埋葬者が詳細で「未登録」表示
- [x] 享年1以上は数値表示
- [x] 書類プレビューで享年0が印字されない

## #299 一覧の埋葬者ラベル折返し（Refs #299）
氏名セルの `td` が `whitespace-nowrap` なのに埋葬者 div だけ `whitespace-normal` で折返しを許可しており、折返し時の行高がぶつかってラベルと氏名が重なる原因になっていた。`nowrap` を氏名・ふりがな行に限定し、`td` を `align-top`、埋葬者 div に `break-words` / `leading-relaxed` を付与。

### ⚠️ 調査メモ（要確認）
issue が指す `plot-list-table.tsx` は **リファクタ（#160 / #199）で `plot-registry` に置き換えられた旧コンポーネント**で、現在 `/plots` ルートからはレンダリングされていない（`BillingSummaryBadges` のユニットテストからのみ参照）。実 `/plots` は `plot-registry/PlotTable.tsx` が描画し、**埋葬者は独立カラム（`truncate` + tooltip）で構造上ラベルと内容は重ならない**。トグル文言も実体は既に「埋葬者を表示」で、システムテスト手順書 PLOTS-11 と一致している。

本 PR は issue 記載の該当ファイルのレイアウト欠陥を是正するもので、**実ユーザーが見る画面（plot-registry）は元から本症状の影響を受けていない**。そのため #299 は `Closes` ではなく `Refs` とし、issue 側にも調査結果をコメントした。クローズ可否・旧コンポーネント削除の要否は判断を仰ぎたい。

## 検証
- `npx eslint`（変更ファイル）: クリーン
- `npx jest preview-helper / billing-summary-badges`: 全 pass
