### PR TITLE
chore: Dockerfile TYPES_REF を types main HEAD へ bump (#303)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /packages/types
 # backend の Dockerfile と同方式（zaitsu82/komine-crm-backend#60 参照）。
 # セキュリティ: main 追従だとリポジトリ汚染が即本番到達するため、commit SHA で固定。
 # types 更新時はこの値を明示的に更新する。
-ARG TYPES_REF=38f5623d2b0b1f3e49f7f74fca0ed6abe03891c1
+ARG TYPES_REF=cc588917b2f2c12a3e301aa9ab1987219df0f8fe
 
 RUN git clone https://github.com/zaitsu82/komine-types.git . && \
     git checkout ${TYPES_REF} && \


### PR DESCRIPTION
## 概要
本番 Docker ビルド（komine-local の `docker compose up -d --build`）が、`@komine/types` の新 export 欠落により TS2305 で失敗していた問題を修正。

`document-form.tsx` が import している `splitPermitAddressAtChome` / `splitPostalCodeDigits` は types main HEAD (`cc58891`) の `src/api/documents.ts` に存在するが、Dockerfile の `TYPES_REF` が古い `38f5623` を指していたため、pin 先には未存在で `npm run build`（next build）が TS2305 で失敗していた。

## 変更内容
- `Dockerfile:15` の `TYPES_REF` を `38f5623…` → `cc588917b2f2c12a3e301aa9ab1987219df0f8fe`（types main HEAD）へ bump

## 検証
- `gh api repos/zaitsu82/komine-types/contents/src/api/documents.ts?ref=cc58891…` で `splitPostalCodeDigits`(:234) / `splitPermitAddressAtChome`(:377) が新 SHA に存在することを確認
- frontend にはローカル workspace の `@komine/types` を使用するため `npm run build` ローカル成功は別経路。Dockerfile は build-arg のみの変更

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)