### PR TITLE
fix: 碑文・区画位置詳細の空クリアをbackendに届ける (#304)

### DIFF
--- a/src/__tests__/lib/validations/plot-form.test.ts
+++ b/src/__tests__/lib/validations/plot-form.test.ts
@@ -922,6 +922,38 @@ describe('plotFormDataToUpdateRequest', () => {
     expect(request.contractPlot!.locationDescription).toBe('右半分');
   });
 
+  // issue #304: 碑文・区画位置詳細を空にして保存したとき、backend に「クリア」と
+  // 解釈させるため空文字を null で送る（`|| undefined` だと backend の
+  // `!== undefined` ガードで握りつぶされ、一度登録した値を UI から消せなくなる）。
+  it('locationDescription / inscription が空文字のとき null を送る（クリア）', () => {
+    const formData: PlotUpdateFormData = {
+      contractPlot: { contractAreaSqm: 3.6, locationDescription: '', inscription: '' },
+    };
+    const request = plotFormDataToUpdateRequest(formData);
+
+    expect(request.contractPlot!.locationDescription).toBeNull();
+    expect(request.contractPlot!.inscription).toBeNull();
+  });
+
+  it('locationDescription / inscription が空白のみのとき null を送る（クリア）', () => {
+    const formData: PlotUpdateFormData = {
+      contractPlot: { contractAreaSqm: 3.6, locationDescription: '   ', inscription: '\t ' },
+    };
+    const request = plotFormDataToUpdateRequest(formData);
+
+    expect(request.contractPlot!.locationDescription).toBeNull();
+    expect(request.contractPlot!.inscription).toBeNull();
+  });
+
+  it('inscription に値があるときはそのまま送る', () => {
+    const formData: PlotUpdateFormData = {
+      contractPlot: { contractAreaSqm: 3.6, inscription: '南無阿弥陀仏' },
+    };
+    const request = plotFormDataToUpdateRequest(formData);
+
+    expect(request.contractPlot!.inscription).toBe('南無阿弥陀仏');
+  });
+
   it('optionalセクションを直接パスする', () => {
     const workInfo = {
       companyName: '株式会社テスト',

--- a/src/lib/validations/plot-form.ts
+++ b/src/lib/validations/plot-form.ts
@@ -379,8 +379,15 @@ export function plotFormDataToUpdateRequest(formData: PlotUpdateFormData): Updat
   if (formData.contractPlot) {
     request.contractPlot = {
       contractAreaSqm: formData.contractPlot.contractAreaSqm,
-      locationDescription: formData.contractPlot.locationDescription || undefined,
-      inscription: formData.contractPlot.inscription || undefined,
+      // 空文字は明示 null で送り、backend に「クリア」と解釈させる（#304）。
+      // `|| undefined` だと backend の `!== undefined` ガードで「変更なし」扱いになり、
+      // 一度登録した値を UI から空にできなくなる。
+      locationDescription: formData.contractPlot.locationDescription?.trim()
+        ? formData.contractPlot.locationDescription
+        : null,
+      inscription: formData.contractPlot.inscription?.trim()
+        ? formData.contractPlot.inscription
+        : null,
     };
   }
 


### PR DESCRIPTION
## 概要

区画詳細フォームで「碑文」(`inscription`) と「区画位置詳細」(`locationDescription`) を空にして保存しても、値がクリアされず以前の値が残る問題を修正。

## 根本原因

`src/lib/validations/plot-form.ts` の `plotFormDataToUpdateRequest` が空文字を `|| undefined` で `undefined` に潰しており、backend `updatePlot` の `!== undefined` ガード（PR#329）で「変更なし」扱いになっていた。

## 変更内容

- `locationDescription` / `inscription` を「trim後に値あり→その文字列／空・空白のみ→`null`」へ変更（issue提案どおり）
- `UpdatePlotRequest.contractPlot` は型上 `string | null` を受理することを確認済み
- 回帰テスト3件追加

## 検証

- `npm test` → 118 passed
- `npm run lint` → clean
- backend改修不要（フロント単独で完結）

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)