### PR TITLE
fix: ゆうちょプレビューを記号番号優先にしCSVと揃える (#305)

### DIFF
--- a/src/__tests__/components/yucho-account-format.test.ts
+++ b/src/__tests__/components/yucho-account-format.test.ts
@@ -1,0 +1,80 @@
+import { formatYuchoAccount } from '@/components/yucho/YuchoManagement';
+import type { YuchoBillingItem, YuchoBillingInfo } from '@/lib/api/yucho';
+
+// #305: ゆうちょプレビューの「記号・番号」表示が CSV 出力と乖離しないことの回帰テスト。
+// backend#367 で CSV は記号番号(yuchoSymbol/yuchoNumber)を正準ソース化したため、
+// プレビューも記号番号を優先し、無いときだけ従来の支店名推定にフォールバックする。
+
+function makeItem(info: Partial<YuchoBillingInfo> | null): YuchoBillingItem {
+  return {
+    category: 'management',
+    sourceId: 'src-1',
+    contractPlotId: 'cp-1',
+    plotNumber: 'A-001',
+    displayNumber: null,
+    areaName: '第1期',
+    contractDate: '2024-01-15',
+    customerId: 'cust-1',
+    customerName: '田中太郎',
+    customerNameKana: 'タナカタロウ',
+    billingAmount: 5000,
+    billingStatus: 'unpaid',
+    scheduledDate: null,
+    billingMonth: 3,
+    billingInfo:
+      info === null
+        ? null
+        : {
+            bankName: null,
+            branchName: null,
+            accountType: null,
+            accountNumber: null,
+            accountHolder: null,
+            yuchoSymbol: null,
+            yuchoNumber: null,
+            ...info,
+          },
+  };
+}
+
+describe('formatYuchoAccount (#305)', () => {
+  it('記号番号があれば「記号-番号」を優先表示する（CSVと同一ソース）', () => {
+    const item = makeItem({ yuchoSymbol: '11280', yuchoNumber: '1234567' });
+    expect(formatYuchoAccount(item)).toBe('11280-1234567');
+  });
+
+  it('記号番号があれば、口座(branch/account)未登録でも表示する（#170運用: 記号番号のみ登録）', () => {
+    const item = makeItem({
+      yuchoSymbol: '10180',
+      yuchoNumber: '9876543',
+      branchName: null,
+      accountNumber: null,
+    });
+    // 従来は「—」になり口座未登録に見えていた行が、記号番号で正しく表示される
+    expect(formatYuchoAccount(item)).toBe('10180-9876543');
+  });
+
+  it('記号番号が漢数字混じり等の非数字を含んでも数字のみ抽出して表示する', () => {
+    const item = makeItem({ yuchoSymbol: '〇一八店 11280', yuchoNumber: '1234567' });
+    expect(formatYuchoAccount(item)).toBe('11280-1234567');
+  });
+
+  it('記号番号が無い場合は従来の支店名推定にフォールバックする', () => {
+    const item = makeItem({ branchName: '128', accountNumber: '1234567' });
+    expect(formatYuchoAccount(item)).toBe('11280-1234567');
+  });
+
+  it('記号のみ・番号欠落のときはフォールバックする（片方欠けは記号番号扱いにしない）', () => {
+    const item = makeItem({ yuchoSymbol: '11280', yuchoNumber: null, branchName: '128' });
+    // 番号が無いので記号番号は使えず、支店名推定で記号のみ表示
+    expect(formatYuchoAccount(item)).toBe('11280');
+  });
+
+  it('billingInfo が null のときは「—」', () => {
+    expect(formatYuchoAccount(makeItem(null))).toBe('—');
+  });
+
+  it('記号番号も口座情報も無いときは「—」', () => {
+    expect(formatYuchoAccount(makeItem({}))).toBe('—');
+  });
+});

--- a/src/components/yucho/YuchoManagement.tsx
+++ b/src/components/yucho/YuchoManagement.tsx
@@ -34,12 +34,32 @@ function formatYen(amount: number) {
 }
 
 /**
- * BillingInfo の口座番号からゆうちょ風の表示「記号-番号」を組み立てる。
- * 方式A前提: branch_name の3桁数字を支店コードとして「1{支店コード}0」を記号、account_number を番号として表示。
+ * 記号番号があれば「記号-番号」を組み立てる（backend yuchoAccount.formatSymbolNumber と同ロジック）。
+ * どちらか欠ければ null を返し、呼び出し側で従来の支店名推定にフォールバックさせる。
  */
-function formatYuchoAccount(item: YuchoBillingItem): string {
+function formatSymbolNumber(
+  symbol: string | null | undefined,
+  num: string | null | undefined,
+): string | null {
+  const s = symbol?.replace(/[^\d]/g, '') ?? '';
+  const n = num?.replace(/[^\d]/g, '') ?? '';
+  if (!s || !n) return null;
+  return `${s}-${n}`;
+}
+
+/**
+ * ゆうちょ風の表示「記号-番号」を組み立てる。
+ * #305: CSV出力（backend）は記号番号(yuchoSymbol/yuchoNumber)を正準ソースにするため、
+ * プレビュー表示も記号番号があればそれを優先し、CSVと乖離しないようにする。
+ * 記号番号が無い場合のみ、従来の支店名(branch_name)の3桁数字から「1{支店コード}0」を推定。
+ */
+export function formatYuchoAccount(item: YuchoBillingItem): string {
   const info = item.billingInfo;
   if (!info) return '—';
+  // 記号番号があれば最優先（CSVと同一ソース）
+  const fromSymbolNumber = formatSymbolNumber(info.yuchoSymbol, info.yuchoNumber);
+  if (fromSymbolNumber) return fromSymbolNumber;
+  // フォールバック: 支店名の3桁から記号を推定（旧データ向け）
   const branch = (info.branchName ?? '').match(/\d{3}/)?.[0];
   const symbol = branch ? `1${branch}0` : info.branchName ?? '';
   const number = info.accountNumber ?? '';

--- a/src/lib/api/yucho.ts
+++ b/src/lib/api/yucho.ts
@@ -21,6 +21,10 @@ export interface YuchoBillingInfo {
   accountType: string | null;
   accountNumber: string | null;
   accountHolder: string | null;
+  /** ゆうちょ記号（5桁・"1"+店番3桁+預金種目1桁）。CSVと同じ正準ソース（backend#367） */
+  yuchoSymbol: string | null;
+  /** ゆうちょ番号（口座番号）。CSVと同じ正準ソース（backend#367） */
+  yuchoNumber: string | null;
 }
 
 export interface YuchoBillingItem {


### PR DESCRIPTION
## 概要

ゆうちょ連携画面のプレビュー表示が顧客の記号番号（`yuchoSymbol`/`yuchoNumber`）を無視して branchName からの推定表示を行っており、実際に出力されるCSV（backend#367 で記号番号を正準ソース化済）と乖離していた問題を修正。

## 根本原因

`YuchoManagement.tsx` の `formatYuchoAccount` が依然 branchName の `\d{3}` 推定のままで、`YuchoBillingItem.billingInfo` 型に記号番号欄が無かった。backend は #367 で CSV と `/yucho/billing` の両方で `yuchoSymbol`/`yuchoNumber` を正準化済み（`yuchoAccount.ts`/`yuchoCsv.ts`）。

## 変更内容

- `YuchoBillingInfo` 型に `yuchoSymbol` / `yuchoNumber` を追加
- `formatYuchoAccount` を「記号番号があれば数字抽出して `記号-番号` を優先、無ければ従来推定にフォールバック」へ変更（backend `formatSymbolNumber` と同じ優先順位）
- テスト用に関数を named export 化し、回帰テスト7件追加

## 検証

- `npm test` → 7 passed（該当spec）
- `npm run lint` → clean
- backend改修不要（#367 で対応済み）

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)