### PR TITLE
fix: 二次画面のareaNameをlegacy-aware表示 (#307)

### DIFF
--- a/src/__tests__/components/billing-list-table.test.tsx
+++ b/src/__tests__/components/billing-list-table.test.tsx
@@ -76,3 +76,34 @@ describe('BillingListTable の区画番号表示 (#283)', () => {
     expect(el.className).toContain('italic');
   });
 });
+
+/**
+ * #307: 二次画面の areaName も legacy-aware 表示にする。
+ * 正規化済みの期名はそのまま、レガシー移行値（1-29 等）は「整備中」ミュート表示。
+ */
+describe('BillingListTable の areaName 表示 (#307)', () => {
+  const makeBilling = (overrides: Partial<Billing>): Billing =>
+    ({
+      id: 'b1',
+      amount: 5000,
+      paidAmount: 0,
+      plotNumber: 'A-1',
+      displayNumber: 'A-1',
+      areaName: '第1期',
+      customer: null,
+      ...overrides,
+    } as unknown as Billing);
+
+  it('正規化済みの areaName はミュートせずそのまま表示する', () => {
+    render(<BillingListTable items={[makeBilling({ areaName: '第1期' })]} />);
+    const el = screen.getByText('第1期');
+    expect(el).not.toHaveAttribute('title', LEGACY_VALUE_NOTE);
+  });
+
+  it('legacy 移行値の areaName は「整備中」ミュート表示にする', () => {
+    render(<BillingListTable items={[makeBilling({ areaName: '1-29' })]} />);
+    const el = screen.getByText('1-29');
+    expect(el).toHaveAttribute('title', LEGACY_VALUE_NOTE);
+    expect(el.className).toContain('italic');
+  });
+});

--- a/src/components/billing/billing-detail-dialog.tsx
+++ b/src/components/billing/billing-detail-dialog.tsx
@@ -113,7 +113,7 @@ function BillingDetailBody({ billing }: { billing: BillingDetailResponse }) {
             value={
               billing.displayNumber || billing.plotNumber ? (
                 <>
-                  <LegacyAwareValue value={billing.displayNumber || billing.plotNumber} kind="plotNumber" /> ({billing.areaName ?? ''})
+                  <LegacyAwareValue value={billing.displayNumber || billing.plotNumber} kind="plotNumber" /> (<LegacyAwareValue value={billing.areaName} kind="areaName" emptyText="" />)
                 </>
               ) : (
                 '-'

--- a/src/components/billing/billing-list-table.tsx
+++ b/src/components/billing/billing-list-table.tsx
@@ -118,7 +118,9 @@ export function BillingListTable({
                   {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
                   <LegacyAwareValue value={b.displayNumber || b.plotNumber} kind="plotNumber" emptyText="-" />
                   {b.areaName && (
-                    <span className="text-xs text-hai ml-1">({b.areaName})</span>
+                    <span className="text-xs text-hai ml-1">
+                      (<LegacyAwareValue value={b.areaName} kind="areaName" />)
+                    </span>
                   )}
                 </td>
               )}

--- a/src/components/collective-burial/DetailView.tsx
+++ b/src/components/collective-burial/DetailView.tsx
@@ -100,7 +100,7 @@ export default function CollectiveBurialDetailView({
               <h2 className="font-mincho text-xl font-semibold text-sumi tracking-wide">合祀詳細</h2>
               <p className="text-sm text-hai mt-0.5">
                 {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
-                区画: <LegacyAwareValue value={data.displayNumber || data.plotNumber} kind="plotNumber" /> / {data.areaName}
+                区画: <LegacyAwareValue value={data.displayNumber || data.plotNumber} kind="plotNumber" /> / <LegacyAwareValue value={data.areaName} kind="areaName" />
               </p>
             </div>
             <span className={`px-4 py-1.5 rounded-full text-sm font-medium ${BILLING_STATUS_COLORS[data.billingStatus as BillingStatus]}`}>
@@ -154,7 +154,10 @@ export default function CollectiveBurialDetailView({
                   </div>
                   <div>
                     <Label className="text-sm text-hai">区域</Label>
-                    <p className="text-sumi mt-1">{data.areaName}</p>
+                    {/* legacy-* エリア値は「整備中」ミュート表示 #307 */}
+                    <p className="text-sumi mt-1">
+                      <LegacyAwareValue value={data.areaName} kind="areaName" />
+                    </p>
                   </div>
                   <div>
                     <Label className="text-sm text-hai">契約日</Label>

--- a/src/components/document-detail-view.tsx
+++ b/src/components/document-detail-view.tsx
@@ -281,7 +281,7 @@ export function DocumentDetailView({
                 </dt>
                 <dd className="text-sumi">
                   {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
-                  {data.contractPlot.physicalPlot.areaName} - <LegacyAwareValue value={data.contractPlot.physicalPlot.displayNumber || data.contractPlot.physicalPlot.plotNumber} kind="plotNumber" />
+                  <LegacyAwareValue value={data.contractPlot.physicalPlot.areaName} kind="areaName" /> - <LegacyAwareValue value={data.contractPlot.physicalPlot.displayNumber || data.contractPlot.physicalPlot.plotNumber} kind="plotNumber" />
                 </dd>
               </div>
             ) : (

--- a/src/components/yucho/YuchoManagement.tsx
+++ b/src/components/yucho/YuchoManagement.tsx
@@ -413,7 +413,10 @@ function ManagementTable({ items, year }: { items: YuchoBillingItem[]; year: num
                     {/* displayNumber 優先・legacy-* 等は「整備中」ミュート表示 #283 */}
                     <LegacyAwareValue value={item.displayNumber || item.plotNumber} kind="plotNumber" />
                   </td>
-                  <td className="px-4 py-3 text-sumi">{item.areaName}</td>
+                  <td className="px-4 py-3 text-sumi">
+                    {/* legacy-* エリア値は「整備中」ミュート表示 #307 */}
+                    <LegacyAwareValue value={item.areaName} kind="areaName" />
+                  </td>
                   <td className="px-4 py-3 text-sumi">
                     <div>{item.customerName ?? '—'}</div>
                     <div className="text-xs text-hai">{item.customerNameKana ?? ''}</div>


### PR DESCRIPTION
## 概要

二次画面（請求/入金/ゆうちょ/合祀/書類）の areaName がレガシー値を生表示していたのを、既存の `LegacyAwareValue`（`kind="areaName"`）パターンに統一。#283 で plotNumber のみ displayNumber 化されていた積み残し（#307）。

- billing-list-table.tsx（区画名列）/ billing-detail-dialog.tsx
- collective-burial/DetailView.tsx（2箇所）
- document-detail-view.tsx / yucho/YuchoManagement.tsx

backend 側は4エンドポイント（billing/yucho/document/collective）とも areaName・displayNumber 返却済み（#283既対応）を確認済みで、フロント単独で完結。

## テスト

billing-list-table.test.tsx に #307 の describe 追加。関連テスト 7/7 pass、lint clean。

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)